### PR TITLE
feat: add interactive setup command and local state persistence

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -9,6 +9,7 @@ import { enableDebug } from './core/logger.js';
 import { getCLIVersion } from './core/utils.js';
 import { formatJsonSuccess, formatJsonError } from './formatters/json.js';
 import { resolveErrorCode } from './core/errors.js';
+import { hasLocalState, loadLocalState, saveLocalState } from './core/local-state.js';
 
 const program = new Command();
 
@@ -25,18 +26,47 @@ program.hook('preAction', (_thisCommand, _actionCommand) => {
 });
 
 program
+  .command('setup')
+  .description('Interactive first-run configuration')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const { runSetup } = await import('./commands/setup.js');
+      const prefs = await runSetup();
+      const state = loadLocalState();
+      state.preferences = prefs;
+      saveLocalState(state);
+      if (options.json) {
+        console.log(formatJsonSuccess(prefs));
+      }
+    } catch (err) {
+      if (options.json) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(formatJsonError(msg, resolveErrorCode(err)));
+      } else {
+        console.error('Error:', err instanceof Error ? err.message : String(err));
+      }
+      process.exit(1);
+    }
+  });
+
+program
   .command('search [count]')
   .description('Search for contributable issues using multi-strategy discovery')
   .option('--json', 'Output as JSON')
   .action(async (count: string | undefined, options: { json?: boolean }) => {
     try {
+      if (!hasLocalState()) {
+        console.log('💡 Run `oss-scout setup` to configure your preferences for personalized search results.\n');
+      }
       const { runSearch } = await import('./commands/search.js');
       const maxResults = count ? parseInt(count, 10) : 10;
       if (isNaN(maxResults) || maxResults < 1) {
         console.error('Error: count must be a positive integer');
         process.exit(1);
       }
-      const results = await runSearch({ maxResults });
+      const state = loadLocalState();
+      const results = await runSearch({ maxResults, state });
       if (options.json) {
         console.log(formatJsonSuccess(results));
       } else {
@@ -74,7 +104,8 @@ program
   .action(async (issueUrl: string, options: { json?: boolean }) => {
     try {
       const { runVet } = await import('./commands/vet.js');
-      const result = await runVet({ issueUrl });
+      const state = loadLocalState();
+      const result = await runVet({ issueUrl, state });
       if (options.json) {
         console.log(formatJsonSuccess(result));
       } else {

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -4,6 +4,7 @@
 
 import { createScout } from '../scout.js';
 import { requireGitHubToken } from '../core/utils.js';
+import type { ScoutState } from '../core/schemas.js';
 
 export interface SearchOutput {
   candidates: Array<{
@@ -35,11 +36,14 @@ export interface SearchOutput {
 
 interface SearchCommandOptions {
   maxResults: number;
+  state?: ScoutState;
 }
 
 export async function runSearch(options: SearchCommandOptions): Promise<SearchOutput> {
   const token = requireGitHubToken();
-  const scout = await createScout({ githubToken: token });
+  const scout = options.state
+    ? await createScout({ githubToken: token, persistence: 'provided', initialState: options.state })
+    : await createScout({ githubToken: token });
   const result = await scout.search({ maxResults: options.maxResults });
 
   return {

--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { runSetup } from './setup.js';
+import type { ScoutPreferences } from '../core/schemas.js';
+
+/**
+ * Creates a mock readline interface that answers questions in sequence.
+ */
+function mockReadline(answers: string[]) {
+  let index = 0;
+  return {
+    question(_query: string, callback: (answer: string) => void) {
+      callback(answers[index++] ?? '');
+    },
+    close() {},
+  };
+}
+
+describe('runSetup', () => {
+  it('accepts all defaults', async () => {
+    const rl = mockReadline([
+      '', // username (use detected)
+      '', // languages
+      '', // labels
+      '', // scope
+      '', // minStars
+      '', // preferredOrgs
+      '', // projectCategories
+      '', // excludeRepos
+    ]);
+
+    const prefs = await runSetup({
+      rl,
+      detectUsername: async () => 'detected-user',
+    });
+
+    expect(prefs.githubUsername).toBe('detected-user');
+    expect(prefs.languages).toEqual(['typescript', 'javascript']);
+    expect(prefs.labels).toEqual(['good first issue', 'help wanted']);
+    expect(prefs.scope).toEqual(['beginner', 'intermediate', 'advanced']);
+    expect(prefs.minStars).toBe(50);
+    expect(prefs.preferredOrgs).toEqual([]);
+    expect(prefs.projectCategories).toEqual([]);
+    expect(prefs.excludeRepos).toEqual([]);
+  });
+
+  it('accepts custom values', async () => {
+    const rl = mockReadline([
+      'customuser',        // username
+      'python, rust',      // languages
+      'bug, enhancement',  // labels
+      'beginner',          // scope
+      '100',               // minStars
+      'facebook, google',  // preferredOrgs
+      'devtools, data-ml', // projectCategories
+      'owner/repo1, owner/repo2', // excludeRepos
+    ]);
+
+    const prefs = await runSetup({
+      rl,
+      detectUsername: async () => 'detected-user',
+    });
+
+    expect(prefs.githubUsername).toBe('customuser');
+    expect(prefs.languages).toEqual(['python', 'rust']);
+    expect(prefs.labels).toEqual(['bug', 'enhancement']);
+    expect(prefs.scope).toEqual(['beginner']);
+    expect(prefs.minStars).toBe(100);
+    expect(prefs.preferredOrgs).toEqual(['facebook', 'google']);
+    expect(prefs.projectCategories).toEqual(['devtools', 'data-ml']);
+    expect(prefs.excludeRepos).toEqual(['owner/repo1', 'owner/repo2']);
+  });
+
+  it('handles no detected username', async () => {
+    const rl = mockReadline([
+      'manualuser', // username (no detection)
+      '', '', '', '', '', '', '',
+    ]);
+
+    const prefs = await runSetup({
+      rl,
+      detectUsername: async () => '',
+    });
+
+    expect(prefs.githubUsername).toBe('manualuser');
+  });
+
+  it('handles invalid minStars gracefully', async () => {
+    const rl = mockReadline([
+      '', // username
+      '', // languages
+      '', // labels
+      '', // scope
+      'not-a-number', // minStars — should fall back to 50
+      '', '', '',
+    ]);
+
+    const prefs = await runSetup({
+      rl,
+      detectUsername: async () => '',
+    });
+
+    expect(prefs.minStars).toBe(50);
+  });
+
+  it('filters invalid scope values', async () => {
+    const rl = mockReadline([
+      '', '', '',
+      'beginner, expert, advanced', // expert is invalid
+      '', '', '', '',
+    ]);
+
+    const prefs = await runSetup({
+      rl,
+      detectUsername: async () => '',
+    });
+
+    expect(prefs.scope).toEqual(['beginner', 'advanced']);
+  });
+
+  it('filters invalid category values', async () => {
+    const rl = mockReadline([
+      '', '', '', '', '', '',
+      'devtools, gaming', // gaming is invalid
+      '',
+    ]);
+
+    const prefs = await runSetup({
+      rl,
+      detectUsername: async () => '',
+    });
+
+    expect(prefs.projectCategories).toEqual(['devtools']);
+  });
+});

--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { runSetup } from './setup.js';
-import type { ScoutPreferences } from '../core/schemas.js';
 
 /**
  * Creates a mock readline interface that answers questions in sequence.

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -1,0 +1,131 @@
+/**
+ * Setup command — interactive first-run configuration for oss-scout.
+ */
+
+import * as readline from 'readline';
+import { execFile } from 'child_process';
+import type { ScoutPreferences, ProjectCategory, IssueScope } from '../core/schemas.js';
+import { ScoutPreferencesSchema, ProjectCategorySchema, IssueScopeSchema } from '../core/schemas.js';
+
+const ALL_CATEGORIES = ProjectCategorySchema.options as readonly ProjectCategory[];
+const ALL_SCOPES = IssueScopeSchema.options as readonly IssueScope[];
+
+interface ReadlineInterface {
+  question(query: string, callback: (answer: string) => void): void;
+  close(): void;
+}
+
+function createReadlineInterface(): ReadlineInterface {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+function ask(rl: ReadlineInterface, query: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(query, (answer) => resolve(answer.trim()));
+  });
+}
+
+function detectGitHubUsername(): Promise<string> {
+  return new Promise((resolve) => {
+    execFile('gh', ['api', 'user', '--jq', '.login'], { timeout: 5000 }, (err, stdout) => {
+      if (err || !stdout.trim()) {
+        resolve('');
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+  });
+}
+
+function parseCSV(input: string): string[] {
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function parseMultiSelect<T extends string>(input: string, options: readonly T[]): T[] {
+  if (!input) return [];
+  const selected = parseCSV(input);
+  return selected.filter((s): s is T => (options as readonly string[]).includes(s));
+}
+
+export interface SetupOptions {
+  rl?: ReadlineInterface;
+  detectUsername?: () => Promise<string>;
+}
+
+/**
+ * Run the interactive setup flow and return the configured preferences.
+ */
+export async function runSetup(options?: SetupOptions): Promise<ScoutPreferences> {
+  const rl = options?.rl ?? createReadlineInterface();
+  const detect = options?.detectUsername ?? detectGitHubUsername;
+
+  try {
+    console.log('\n🔧 oss-scout setup\n');
+
+    // Detect GitHub username
+    console.log('Detecting GitHub username...');
+    const detectedUsername = await detect();
+    const usernameDefault = detectedUsername || '';
+    const usernamePrompt = detectedUsername
+      ? `GitHub username [${detectedUsername}]: `
+      : 'GitHub username: ';
+    const usernameInput = await ask(rl, usernamePrompt);
+    const githubUsername = usernameInput || usernameDefault;
+
+    // Languages
+    const defaultLangs = 'typescript, javascript';
+    const langsInput = await ask(rl, `Preferred languages [${defaultLangs}]: `);
+    const languages = langsInput ? parseCSV(langsInput) : ['typescript', 'javascript'];
+
+    // Issue labels
+    const defaultLabels = 'good first issue, help wanted';
+    const labelsInput = await ask(rl, `Issue labels to search for [${defaultLabels}]: `);
+    const labels = labelsInput ? parseCSV(labelsInput) : ['good first issue', 'help wanted'];
+
+    // Difficulty scope
+    const scopeOptions = ALL_SCOPES.join(', ');
+    const scopeInput = await ask(rl, `Difficulty scope (${scopeOptions}) [all]: `);
+    const scope = scopeInput ? parseMultiSelect(scopeInput, ALL_SCOPES) : [...ALL_SCOPES];
+
+    // Minimum stars
+    const minStarsInput = await ask(rl, 'Minimum repo stars [50]: ');
+    const minStars = minStarsInput ? parseInt(minStarsInput, 10) : 50;
+
+    // Preferred organizations
+    const orgsInput = await ask(rl, 'Preferred organizations (comma-separated, optional): ');
+    const preferredOrgs = parseCSV(orgsInput);
+
+    // Project categories
+    const categoryOptions = ALL_CATEGORIES.join(', ');
+    const categoriesInput = await ask(rl, `Project categories (${categoryOptions}) [none]: `);
+    const projectCategories = parseMultiSelect(categoriesInput, ALL_CATEGORIES);
+
+    // Repos to exclude
+    const excludeInput = await ask(rl, 'Repos to exclude (owner/repo, comma-separated, optional): ');
+    const excludeRepos = parseCSV(excludeInput);
+
+    const prefs = ScoutPreferencesSchema.parse({
+      githubUsername,
+      languages,
+      labels,
+      scope: scope.length > 0 ? scope : undefined,
+      excludeRepos,
+      preferredOrgs,
+      projectCategories,
+      minStars: isNaN(minStars) ? 50 : minStars,
+    });
+
+    console.log('\n✅ Setup complete! Preferences saved.\n');
+    return prefs;
+  } finally {
+    if (!options?.rl) {
+      rl.close();
+    }
+  }
+}

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -5,7 +5,7 @@
 import { createScout } from '../scout.js';
 import { requireGitHubToken } from '../core/utils.js';
 import type { ProjectHealth } from '../core/types.js';
-import type { IssueVettingResult } from '../core/schemas.js';
+import type { IssueVettingResult, ScoutState } from '../core/schemas.js';
 import { ISSUE_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
 
 export interface VetOutput {
@@ -25,6 +25,7 @@ export interface VetOutput {
 
 interface VetCommandOptions {
   issueUrl: string;
+  state?: ScoutState;
 }
 
 export async function runVet(options: VetCommandOptions): Promise<VetOutput> {
@@ -32,7 +33,9 @@ export async function runVet(options: VetCommandOptions): Promise<VetOutput> {
   validateGitHubUrl(options.issueUrl, ISSUE_URL_PATTERN, 'issue');
 
   const token = requireGitHubToken();
-  const scout = await createScout({ githubToken: token });
+  const scout = options.state
+    ? await createScout({ githubToken: token, persistence: 'provided', initialState: options.state })
+    : await createScout({ githubToken: token });
   const candidate = await scout.vetIssue(options.issueUrl);
 
   return {

--- a/packages/core/src/core/local-state.test.ts
+++ b/packages/core/src/core/local-state.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { loadLocalState, saveLocalState, hasLocalState } from './local-state.js';
+import { ScoutStateSchema } from './schemas.js';
+import type { ScoutState } from './schemas.js';
+
+// Mock getDataDir to use a temp directory
+let tmpDir: string;
+
+vi.mock('./utils.js', () => ({
+  getDataDir: () => tmpDir,
+}));
+
+vi.mock('./logger.js', () => ({
+  debug: () => {},
+}));
+
+describe('local-state', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-scout-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('hasLocalState', () => {
+    it('returns false when no state file exists', () => {
+      expect(hasLocalState()).toBe(false);
+    });
+
+    it('returns true when state file exists', () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      fs.writeFileSync(path.join(tmpDir, 'state.json'), JSON.stringify(state));
+      expect(hasLocalState()).toBe(true);
+    });
+  });
+
+  describe('loadLocalState', () => {
+    it('returns fresh default state when no file exists', () => {
+      const state = loadLocalState();
+      expect(state.version).toBe(1);
+      expect(state.preferences.languages).toEqual(['typescript', 'javascript']);
+      expect(state.repoScores).toEqual({});
+    });
+
+    it('loads existing valid state', () => {
+      const existing = ScoutStateSchema.parse({
+        version: 1,
+        preferences: { githubUsername: 'testuser', languages: ['python'] },
+      });
+      fs.writeFileSync(path.join(tmpDir, 'state.json'), JSON.stringify(existing));
+
+      const state = loadLocalState();
+      expect(state.preferences.githubUsername).toBe('testuser');
+      expect(state.preferences.languages).toEqual(['python']);
+    });
+
+    it('returns fresh state on corrupt JSON', () => {
+      fs.writeFileSync(path.join(tmpDir, 'state.json'), '{invalid json');
+
+      const state = loadLocalState();
+      expect(state.version).toBe(1);
+      expect(state.preferences.languages).toEqual(['typescript', 'javascript']);
+    });
+
+    it('returns fresh state on invalid schema', () => {
+      fs.writeFileSync(path.join(tmpDir, 'state.json'), JSON.stringify({ version: 99 }));
+
+      const state = loadLocalState();
+      expect(state.version).toBe(1);
+    });
+  });
+
+  describe('saveLocalState', () => {
+    it('writes state to file', () => {
+      const state = ScoutStateSchema.parse({
+        version: 1,
+        preferences: { githubUsername: 'saved-user' },
+      });
+      saveLocalState(state);
+
+      const raw = fs.readFileSync(path.join(tmpDir, 'state.json'), 'utf-8');
+      const loaded = JSON.parse(raw);
+      expect(loaded.preferences.githubUsername).toBe('saved-user');
+    });
+
+    it('performs atomic write (no .tmp file left behind)', () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      saveLocalState(state);
+
+      expect(fs.existsSync(path.join(tmpDir, 'state.json'))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, 'state.json.tmp'))).toBe(false);
+    });
+
+    it('overwrites existing state', () => {
+      const state1: ScoutState = ScoutStateSchema.parse({
+        version: 1,
+        preferences: { githubUsername: 'first' },
+      });
+      saveLocalState(state1);
+
+      const state2: ScoutState = ScoutStateSchema.parse({
+        version: 1,
+        preferences: { githubUsername: 'second' },
+      });
+      saveLocalState(state2);
+
+      const loaded = loadLocalState();
+      expect(loaded.preferences.githubUsername).toBe('second');
+    });
+  });
+});

--- a/packages/core/src/core/local-state.ts
+++ b/packages/core/src/core/local-state.ts
@@ -1,0 +1,57 @@
+/**
+ * Local state persistence — reads/writes ScoutState to ~/.oss-scout/state.json.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ScoutStateSchema } from './schemas.js';
+import type { ScoutState } from './schemas.js';
+import { getDataDir } from './utils.js';
+import { debug } from './logger.js';
+
+const MODULE = 'local-state';
+
+function getStatePath(): string {
+  return path.join(getDataDir(), 'state.json');
+}
+
+/**
+ * Check if a local state file exists.
+ */
+export function hasLocalState(): boolean {
+  return fs.existsSync(getStatePath());
+}
+
+/**
+ * Load state from local file. Returns fresh default state if file doesn't exist or is corrupt.
+ */
+export function loadLocalState(): ScoutState {
+  const statePath = getStatePath();
+
+  if (!fs.existsSync(statePath)) {
+    debug(MODULE, 'No state file found, returning fresh state');
+    return ScoutStateSchema.parse({ version: 1 });
+  }
+
+  try {
+    const raw = fs.readFileSync(statePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return ScoutStateSchema.parse(parsed);
+  } catch (err) {
+    debug(MODULE, `Failed to load state: ${err instanceof Error ? err.message : String(err)}`);
+    return ScoutStateSchema.parse({ version: 1 });
+  }
+}
+
+/**
+ * Save state to local file using atomic write (write to .tmp, then rename).
+ */
+export function saveLocalState(state: ScoutState): void {
+  const statePath = getStatePath();
+  const tmpPath = statePath + '.tmp';
+
+  const data = JSON.stringify(state, null, 2) + '\n';
+  fs.writeFileSync(tmpPath, data, { mode: 0o600 });
+  fs.renameSync(tmpPath, statePath);
+  debug(MODULE, 'State saved');
+}


### PR DESCRIPTION
## Summary
- Adds `oss-scout setup` interactive first-run command that prompts for GitHub username (auto-detected via `gh` CLI), preferred languages, issue labels, difficulty scope, minimum stars, preferred organizations, project categories, and repos to exclude
- Adds local state persistence (`~/.oss-scout/state.json`) with atomic writes and corrupt-file recovery
- Wires `search` and `vet` commands to load user preferences from local state
- Adds first-run detection: `search` prints a hint to run `setup` when no state file exists
- 15 new tests (6 setup, 9 local-state), all passing

## Test plan
- [ ] Run `pnpm test` — all 182 tests pass
- [ ] Run `npx tsc --noEmit` — no type errors
- [ ] Run `oss-scout setup` interactively — verify prompts, defaults, and saved state
- [ ] Run `oss-scout search` without state file — verify first-run hint appears
- [ ] Run `oss-scout search` after setup — verify preferences are used

Closes #1