### PR TITLE
feat: persist search results and add results command

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -97,6 +97,79 @@ program
     }
   });
 
+// ── results command ────────────────────────────────────────────────
+
+const resultsCmd = program
+  .command('results')
+  .description('Show saved search results');
+
+resultsCmd
+  .command('show', { isDefault: true })
+  .description('Display saved search results')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const { runResults } = await import('./commands/results.js');
+      const results = await runResults(options);
+      if (options.json) {
+        console.log(formatJsonSuccess(results));
+      } else {
+        if (results.length === 0) {
+          console.log('\nNo saved results. Run `oss-scout search` to find issues.\n');
+          return;
+        }
+        console.log(`\nSaved results (${results.length}):\n`);
+        console.log(
+          '  Score  Repo                              Issue   Recommendation  Title',
+        );
+        console.log(
+          '  ─────  ────────────────────────────────  ──────  ──────────────  ─────',
+        );
+        for (const r of results) {
+          const score = String(r.viabilityScore).padStart(3);
+          const repo = r.repo.padEnd(32).slice(0, 32);
+          const issue = `#${r.number}`.padEnd(6);
+          const rec = r.recommendation.padEnd(14);
+          const title = r.title.length > 50 ? r.title.slice(0, 47) + '...' : r.title;
+          console.log(`  ${score}    ${repo}  ${issue}  ${rec}  ${title}`);
+        }
+        console.log();
+      }
+    } catch (err) {
+      if (options.json) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(formatJsonError(msg, resolveErrorCode(err)));
+      } else {
+        console.error('Error:', err instanceof Error ? err.message : String(err));
+      }
+      process.exit(1);
+    }
+  });
+
+resultsCmd
+  .command('clear')
+  .description('Clear all saved results')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const { runResultsClear } = await import('./commands/results.js');
+      await runResultsClear();
+      if (options.json) {
+        console.log(formatJsonSuccess({ cleared: true }));
+      } else {
+        console.log('Saved results cleared.');
+      }
+    } catch (err) {
+      if (options.json) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(formatJsonError(msg, resolveErrorCode(err)));
+      } else {
+        console.error('Error:', err instanceof Error ? err.message : String(err));
+      }
+      process.exit(1);
+    }
+  });
+
 program
   .command('vet <issue-url>')
   .description('Vet a specific GitHub issue for claimability and project health')

--- a/packages/core/src/commands/results.test.ts
+++ b/packages/core/src/commands/results.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SavedCandidate } from '../core/schemas.js';
+import { ScoutStateSchema } from '../core/schemas.js';
+
+// Mock local-state module — factory must not reference top-level imports
+vi.mock('../core/local-state.js', () => {
+  let mockState: any = { version: 1, savedResults: [] };
+  return {
+    loadLocalState: () => mockState,
+    saveLocalState: (state: any) => {
+      mockState = state;
+    },
+    hasLocalState: () => true,
+    _setMockState: (state: any) => {
+      mockState = state;
+    },
+    _getMockState: () => mockState,
+  };
+});
+
+// Import after mock setup
+const { runResults, runResultsClear } = await import('./results.js');
+
+async function setMockState(state: any) {
+  const mod = (await import('../core/local-state.js')) as any;
+  mod._setMockState(state);
+}
+
+async function getMockState(): Promise<any> {
+  const mod = (await import('../core/local-state.js')) as any;
+  return mod._getMockState();
+}
+
+function makeSavedCandidate(overrides: Partial<SavedCandidate> = {}): SavedCandidate {
+  return {
+    issueUrl: 'https://github.com/owner/repo/issues/1',
+    repo: 'owner/repo',
+    number: 1,
+    title: 'Fix the bug',
+    labels: ['good first issue'],
+    recommendation: 'approve',
+    viabilityScore: 75,
+    searchPriority: 'normal',
+    firstSeenAt: '2026-03-01T00:00:00.000Z',
+    lastSeenAt: '2026-03-01T00:00:00.000Z',
+    lastScore: 75,
+    ...overrides,
+  };
+}
+
+describe('results command', () => {
+  beforeEach(async () => {
+    const freshState = ScoutStateSchema.parse({ version: 1 });
+    await setMockState(freshState);
+  });
+
+  describe('runResults', () => {
+    it('returns empty array when no saved results', async () => {
+      const results = await runResults({});
+      expect(results).toEqual([]);
+    });
+
+    it('returns saved results from state', async () => {
+      const candidate = makeSavedCandidate();
+      const state = ScoutStateSchema.parse({ version: 1 });
+      state.savedResults = [candidate];
+      await setMockState(state);
+
+      const results = await runResults({});
+      expect(results).toHaveLength(1);
+      expect(results[0].issueUrl).toBe('https://github.com/owner/repo/issues/1');
+      expect(results[0].repo).toBe('owner/repo');
+      expect(results[0].recommendation).toBe('approve');
+    });
+
+    it('returns multiple saved results', async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      state.savedResults = [
+        makeSavedCandidate({ issueUrl: 'https://github.com/a/b/issues/1', repo: 'a/b', number: 1 }),
+        makeSavedCandidate({
+          issueUrl: 'https://github.com/c/d/issues/2',
+          repo: 'c/d',
+          number: 2,
+          recommendation: 'skip',
+        }),
+      ];
+      await setMockState(state);
+
+      const results = await runResults({ json: true });
+      expect(results).toHaveLength(2);
+      expect(results[0].repo).toBe('a/b');
+      expect(results[1].recommendation).toBe('skip');
+    });
+  });
+
+  describe('runResultsClear', () => {
+    it('clears saved results from state', async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      state.savedResults = [makeSavedCandidate()];
+      await setMockState(state);
+
+      await runResultsClear();
+
+      const updated = await getMockState();
+      expect(updated.savedResults).toEqual([]);
+    });
+
+    it('is a no-op when already empty', async () => {
+      await runResultsClear();
+      const updated = await getMockState();
+      expect(updated.savedResults).toEqual([]);
+    });
+  });
+});
+
+describe('saveResults deduplication (via OssScout)', () => {
+  it('preserves firstSeenAt on re-save and updates score', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout('fake-token', state);
+
+    const makeCandidate = (score: number) => ({
+      issue: {
+        id: 1,
+        url: 'https://github.com/owner/repo/issues/1',
+        repo: 'owner/repo',
+        number: 1,
+        title: 'Fix the bug',
+        status: 'candidate' as const,
+        labels: ['good first issue'],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        vetted: true,
+      },
+      vettingResult: {
+        passedAllChecks: true,
+        checks: {
+          noExistingPR: true,
+          notClaimed: true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+      },
+      projectHealth: {
+        repo: 'owner/repo',
+        lastCommitAt: '2026-03-01T00:00:00.000Z',
+        daysSinceLastCommit: 1,
+        openIssuesCount: 10,
+        avgIssueResponseDays: 2,
+        ciStatus: 'passing' as const,
+        isActive: true,
+      },
+      recommendation: 'approve' as const,
+      reasonsToSkip: [],
+      reasonsToApprove: ['Active project'],
+      viabilityScore: score,
+      searchPriority: 'normal' as const,
+    });
+
+    // First save
+    scout.saveResults([makeCandidate(70)]);
+    const firstSave = scout.getSavedResults();
+    expect(firstSave).toHaveLength(1);
+    expect(firstSave[0].viabilityScore).toBe(70);
+    expect(firstSave[0].lastScore).toBe(70);
+    const originalFirstSeen = firstSave[0].firstSeenAt;
+
+    // Second save with updated score
+    scout.saveResults([makeCandidate(85)]);
+    const secondSave = scout.getSavedResults();
+    expect(secondSave).toHaveLength(1);
+    expect(secondSave[0].viabilityScore).toBe(85);
+    expect(secondSave[0].lastScore).toBe(85);
+    expect(secondSave[0].firstSeenAt).toBe(originalFirstSeen);
+  });
+
+  it('adds new candidates alongside existing ones', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout('fake-token', state);
+
+    const makeCandidate = (num: number) => ({
+      issue: {
+        id: num,
+        url: `https://github.com/owner/repo/issues/${num}`,
+        repo: 'owner/repo',
+        number: num,
+        title: `Issue ${num}`,
+        status: 'candidate' as const,
+        labels: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        vetted: false,
+      },
+      vettingResult: {
+        passedAllChecks: true,
+        checks: {
+          noExistingPR: true,
+          notClaimed: true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+      },
+      projectHealth: {
+        repo: 'owner/repo',
+        lastCommitAt: '2026-03-01T00:00:00.000Z',
+        daysSinceLastCommit: 1,
+        openIssuesCount: 10,
+        avgIssueResponseDays: 2,
+        ciStatus: 'passing' as const,
+        isActive: true,
+      },
+      recommendation: 'approve' as const,
+      reasonsToSkip: [],
+      reasonsToApprove: [],
+      viabilityScore: 60,
+      searchPriority: 'normal' as const,
+    });
+
+    scout.saveResults([makeCandidate(1)]);
+    expect(scout.getSavedResults()).toHaveLength(1);
+
+    scout.saveResults([makeCandidate(2)]);
+    expect(scout.getSavedResults()).toHaveLength(2);
+  });
+
+  it('clearResults removes all saved results', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout('fake-token', state);
+
+    const candidate = {
+      issue: {
+        id: 1,
+        url: 'https://github.com/owner/repo/issues/1',
+        repo: 'owner/repo',
+        number: 1,
+        title: 'Fix the bug',
+        status: 'candidate' as const,
+        labels: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        vetted: false,
+      },
+      vettingResult: {
+        passedAllChecks: true,
+        checks: {
+          noExistingPR: true,
+          notClaimed: true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+      },
+      projectHealth: {
+        repo: 'owner/repo',
+        lastCommitAt: '2026-03-01T00:00:00.000Z',
+        daysSinceLastCommit: 1,
+        openIssuesCount: 10,
+        avgIssueResponseDays: 2,
+        ciStatus: 'passing' as const,
+        isActive: true,
+      },
+      recommendation: 'approve' as const,
+      reasonsToSkip: [],
+      reasonsToApprove: [],
+      viabilityScore: 60,
+      searchPriority: 'normal' as const,
+    };
+
+    scout.saveResults([candidate]);
+    expect(scout.getSavedResults()).toHaveLength(1);
+
+    scout.clearResults();
+    expect(scout.getSavedResults()).toEqual([]);
+  });
+});

--- a/packages/core/src/commands/results.ts
+++ b/packages/core/src/commands/results.ts
@@ -1,0 +1,17 @@
+/**
+ * Results command — display and manage saved search results.
+ */
+
+import { loadLocalState, saveLocalState } from '../core/local-state.js';
+import type { SavedCandidate } from '../core/schemas.js';
+
+export async function runResults(_options: { json?: boolean }): Promise<SavedCandidate[]> {
+  const state = loadLocalState();
+  return state.savedResults ?? [];
+}
+
+export async function runResultsClear(): Promise<void> {
+  const state = loadLocalState();
+  state.savedResults = [];
+  saveLocalState(state);
+}

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -4,6 +4,7 @@
 
 import { createScout } from '../scout.js';
 import { requireGitHubToken } from '../core/utils.js';
+import { saveLocalState } from '../core/local-state.js';
 import type { ScoutState } from '../core/schemas.js';
 
 export interface SearchOutput {
@@ -45,6 +46,10 @@ export async function runSearch(options: SearchCommandOptions): Promise<SearchOu
     ? await createScout({ githubToken: token, persistence: 'provided', initialState: options.state })
     : await createScout({ githubToken: token });
   const result = await scout.search({ maxResults: options.maxResults });
+
+  // Persist results to local state
+  scout.saveResults(result.candidates);
+  saveLocalState(scout.getState() as ScoutState);
 
   return {
     candidates: result.candidates.map((c) => {

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -100,6 +100,22 @@ export const TrackedIssueSchema = z.object({
   vettingResult: IssueVettingResultSchema.optional(),
 });
 
+// ── Saved candidate schema ─────────────────────────────────────────
+
+export const SavedCandidateSchema = z.object({
+  issueUrl: z.string(),
+  repo: z.string(),
+  number: z.number(),
+  title: z.string(),
+  labels: z.array(z.string()),
+  recommendation: z.enum(['approve', 'skip', 'needs_review']),
+  viabilityScore: z.number(),
+  searchPriority: z.string(),
+  firstSeenAt: z.string(),
+  lastSeenAt: z.string(),
+  lastScore: z.number(),
+});
+
 // ── Scout preferences schema ────────────────────────────────────────
 
 export const ScoutPreferencesSchema = z.object({
@@ -132,6 +148,8 @@ export const ScoutStateSchema = z.object({
   mergedPRs: z.array(StoredMergedPRSchema).default([]),
   closedPRs: z.array(StoredClosedPRSchema).default([]),
 
+  savedResults: z.array(SavedCandidateSchema).default([]),
+
   lastSearchAt: z.string().optional(),
   lastRunAt: z.string().default(() => new Date().toISOString()),
 
@@ -151,4 +169,5 @@ export type ContributionGuidelines = z.infer<typeof ContributionGuidelinesSchema
 export type IssueVettingResult = z.infer<typeof IssueVettingResultSchema>;
 export type TrackedIssue = z.infer<typeof TrackedIssueSchema>;
 export type ScoutPreferences = z.infer<typeof ScoutPreferencesSchema>;
+export type SavedCandidate = z.infer<typeof SavedCandidateSchema>;
 export type ScoutState = z.infer<typeof ScoutStateSchema>;

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -22,6 +22,7 @@ export type {
   IssueVettingResult,
   TrackedIssue,
   ScoutPreferences,
+  SavedCandidate,
   ScoutState,
 } from './schemas.js';
 

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -12,6 +12,7 @@ import type {
   ScoutState,
   ScoutPreferences,
   RepoScore,
+  SavedCandidate,
 } from './core/schemas.js';
 import type {
   ScoutConfig,
@@ -219,6 +220,55 @@ export class OssScout implements ScoutStateReader {
   setStarredRepos(repos: string[]): void {
     this.state.starredRepos = repos;
     this.state.starredReposLastFetched = new Date().toISOString();
+    this.dirty = true;
+  }
+
+  // ── Saved Results ───────────────────────────────────────────────────
+
+  /**
+   * Save search candidates to state, deduplicating by URL.
+   * If a candidate already exists, updates score/recommendation/lastSeenAt
+   * but preserves firstSeenAt.
+   */
+  saveResults(candidates: IssueCandidate[]): void {
+    const now = new Date().toISOString();
+    const existing = new Map(
+      (this.state.savedResults ?? []).map((r) => [r.issueUrl, r]),
+    );
+
+    for (const c of candidates) {
+      const prev = existing.get(c.issue.url);
+      existing.set(c.issue.url, {
+        issueUrl: c.issue.url,
+        repo: c.issue.repo,
+        number: c.issue.number,
+        title: c.issue.title,
+        labels: c.issue.labels,
+        recommendation: c.recommendation,
+        viabilityScore: c.viabilityScore,
+        searchPriority: c.searchPriority,
+        firstSeenAt: prev?.firstSeenAt ?? now,
+        lastSeenAt: now,
+        lastScore: c.viabilityScore,
+      });
+    }
+
+    this.state.savedResults = [...existing.values()];
+    this.dirty = true;
+  }
+
+  /**
+   * Get all saved results.
+   */
+  getSavedResults(): SavedCandidate[] {
+    return this.state.savedResults ?? [];
+  }
+
+  /**
+   * Clear all saved results.
+   */
+  clearResults(): void {
+    this.state.savedResults = [];
     this.dirty = true;
   }
 


### PR DESCRIPTION
## Summary

Closes #6

- Adds `SavedCandidate` schema to `ScoutState` for lightweight persistence of search results (issue URL, repo, score, recommendation, timestamps)
- Adds `saveResults()`, `getSavedResults()`, `clearResults()` methods to `OssScout` with URL-based deduplication (preserves `firstSeenAt`, updates score/recommendation on re-save)
- Search command now auto-persists candidates to `~/.oss-scout/state.json` after each run
- New `oss-scout results` command displays saved results in a table (with `--json` support)
- New `oss-scout results clear` subcommand to wipe saved results

## Test plan

- [x] 8 new tests covering results display, clear, deduplication, score updates
- [x] All 190 tests pass
- [x] TypeScript typecheck clean
- [x] ESLint clean