### PR TITLE
feat: add first-run bootstrap for starred repos and PR history

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -51,6 +51,42 @@ program
   });
 
 program
+  .command('bootstrap')
+  .description('Import starred repos and PR history from GitHub')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const { bootstrapScout } = await import('./core/bootstrap.js');
+      const { createScout } = await import('./scout.js');
+      const { requireGitHubToken } = await import('./core/utils.js');
+      const token = requireGitHubToken();
+      const state = loadLocalState();
+      const scout = await createScout({ githubToken: token, persistence: 'provided', initialState: state });
+      const result = await bootstrapScout(scout, token);
+      saveLocalState(scout.getState());
+
+      if (options.json) {
+        console.log(formatJsonSuccess(result));
+      } else {
+        if (result.skippedDueToRateLimit) {
+          console.log('Skipped: GitHub API rate limit too low. Try again later.');
+        } else {
+          console.log(`Imported ${result.mergedPRCount} merged PRs, ${result.closedPRCount} closed PRs, ${result.starredRepoCount} starred repos`);
+          console.log(`Scored ${result.reposScoredCount} repositories`);
+        }
+      }
+    } catch (err) {
+      if (options.json) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(formatJsonError(msg, resolveErrorCode(err)));
+      } else {
+        console.error('Error:', err instanceof Error ? err.message : String(err));
+      }
+      process.exit(1);
+    }
+  });
+
+program
   .command('search [count]')
   .description('Search for contributable issues using multi-strategy discovery')
   .option('--json', 'Output as JSON')
@@ -66,6 +102,13 @@ program
         process.exit(1);
       }
       const state = loadLocalState();
+      if (
+        state.mergedPRs.length === 0 &&
+        state.starredRepos.length === 0 &&
+        state.preferences.githubUsername
+      ) {
+        console.log('Run `oss-scout bootstrap` to import your starred repos and PR history for better results.\n');
+      }
       const results = await runSearch({ maxResults, state });
       if (options.json) {
         console.log(formatJsonSuccess(results));

--- a/packages/core/src/core/bootstrap.test.ts
+++ b/packages/core/src/core/bootstrap.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScoutStateSchema } from './schemas.js';
+import type { ScoutState } from './schemas.js';
+import { OssScout } from '../scout.js';
+
+let mockOctokitInstance: any;
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: {
+    plugin: () =>
+      class MockOctokit {
+        constructor() {
+          return mockOctokitInstance;
+        }
+      },
+  },
+}));
+
+vi.mock('@octokit/plugin-throttling', () => ({
+  throttling: {},
+}));
+
+vi.mock('./logger.js', () => ({
+  debug: () => {},
+  warn: () => {},
+}));
+
+const { bootstrapScout } = await import('./bootstrap.js');
+
+let tokenCounter = 0;
+function uniqueToken(): string {
+  return `test-token-bootstrap-${++tokenCounter}`;
+}
+
+function makeState(overrides: Partial<ScoutState> = {}): ScoutState {
+  return ScoutStateSchema.parse({
+    version: 1,
+    preferences: { githubUsername: 'testuser' },
+    ...overrides,
+  });
+}
+
+function mockRateLimit(remaining: number) {
+  mockOctokitInstance.rateLimit = {
+    get: vi.fn().mockResolvedValue({
+      data: {
+        resources: {
+          search: { remaining, limit: 30, reset: Math.floor(Date.now() / 1000) + 3600 },
+        },
+      },
+    }),
+  };
+}
+
+function makePRItem(n: number, repo: string) {
+  return {
+    html_url: `https://github.com/${repo}/pull/${n}`,
+    title: `PR #${n}`,
+    closed_at: '2026-01-15T00:00:00Z',
+  };
+}
+
+describe('bootstrapScout', () => {
+  beforeEach(() => {
+    mockOctokitInstance = {
+      rateLimit: { get: vi.fn() },
+      activity: { listReposStarredByAuthenticatedUser: vi.fn() },
+      search: { issuesAndPullRequests: vi.fn() },
+      paginate: { iterator: vi.fn() },
+    };
+  });
+
+  it('skips when rate limit is too low', async () => {
+    mockRateLimit(5);
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    const result = await bootstrapScout(scout, token);
+    expect(result.skippedDueToRateLimit).toBe(true);
+    expect(result.starredRepoCount).toBe(0);
+    expect(result.mergedPRCount).toBe(0);
+    expect(result.closedPRCount).toBe(0);
+  });
+
+  it('fetches starred repos and PRs', async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        yield { data: [{ full_name: 'org/repo-a' }, { full_name: 'org/repo-b' }] };
+      })(),
+    );
+    mockOctokitInstance.search.issuesAndPullRequests = vi.fn()
+      .mockResolvedValueOnce({ data: { items: [makePRItem(1, 'org/repo-a'), makePRItem(2, 'org/repo-b')] } })
+      .mockResolvedValueOnce({ data: { items: [makePRItem(3, 'org/repo-c')] } });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    const result = await bootstrapScout(scout, token);
+
+    expect(result.skippedDueToRateLimit).toBe(false);
+    expect(result.starredRepoCount).toBe(2);
+    expect(result.mergedPRCount).toBe(2);
+    expect(result.closedPRCount).toBe(1);
+    expect(result.reposScoredCount).toBeGreaterThanOrEqual(2);
+    const state = scout.getState();
+    expect(state.starredRepos).toEqual(['org/repo-a', 'org/repo-b']);
+    expect(state.mergedPRs).toHaveLength(2);
+    expect(state.closedPRs).toHaveLength(1);
+  });
+
+  it('handles empty results', async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () { yield { data: [] }; })(),
+    );
+    mockOctokitInstance.search.issuesAndPullRequests = vi.fn()
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ data: { items: [] } });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    const result = await bootstrapScout(scout, token);
+    expect(result.starredRepoCount).toBe(0);
+    expect(result.mergedPRCount).toBe(0);
+    expect(result.closedPRCount).toBe(0);
+    expect(result.reposScoredCount).toBe(0);
+  });
+
+  it('throws when githubUsername is not set', async () => {
+    const state = ScoutStateSchema.parse({ version: 1, preferences: { githubUsername: '' } });
+    const token = uniqueToken();
+    const scout = new OssScout(token, state);
+    await expect(bootstrapScout(scout, token)).rejects.toThrow('GitHub username not configured');
+  });
+
+  it('deduplicates PRs already in state', async () => {
+    mockRateLimit(30);
+    const existingState = makeState();
+    existingState.mergedPRs = [{ url: 'https://github.com/org/repo-a/pull/1', title: 'PR #1', mergedAt: '2026-01-15T00:00:00Z' }];
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () { yield { data: [] }; })(),
+    );
+    mockOctokitInstance.search.issuesAndPullRequests = vi.fn()
+      .mockResolvedValueOnce({ data: { items: [makePRItem(1, 'org/repo-a'), makePRItem(2, 'org/repo-a')] } })
+      .mockResolvedValueOnce({ data: { items: [] } });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, existingState);
+    const result = await bootstrapScout(scout, token);
+    expect(result.mergedPRCount).toBe(2);
+    expect(scout.getState().mergedPRs).toHaveLength(2);
+  });
+
+  it('paginates search results across multiple pages', async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () { yield { data: [] }; })(),
+    );
+    const fullPage = Array.from({ length: 100 }, (_, i) => makePRItem(i + 1, 'org/repo-a'));
+    mockOctokitInstance.search.issuesAndPullRequests = vi.fn()
+      .mockResolvedValueOnce({ data: { items: fullPage } })
+      .mockResolvedValueOnce({ data: { items: [makePRItem(101, 'org/repo-a')] } })
+      .mockResolvedValueOnce({ data: { items: [] } });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    const result = await bootstrapScout(scout, token);
+    expect(result.mergedPRCount).toBe(101);
+    expect(mockOctokitInstance.search.issuesAndPullRequests).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -1,0 +1,125 @@
+/**
+ * First-run bootstrap — fetches starred repos and PR history from GitHub
+ * to seed the scout's state with the user's contribution context.
+ */
+
+import { getOctokit, checkRateLimit } from './github.js';
+import { debug } from './logger.js';
+import type { OssScout } from '../scout.js';
+
+const MODULE = 'bootstrap';
+
+export interface BootstrapResult {
+  starredRepoCount: number;
+  mergedPRCount: number;
+  closedPRCount: number;
+  reposScoredCount: number;
+  skippedDueToRateLimit: boolean;
+}
+
+const STARRED_MAX_PAGES = 5;
+const SEARCH_MAX_PAGES = 3;
+const PER_PAGE = 100;
+
+export async function bootstrapScout(scout: OssScout, token: string): Promise<BootstrapResult> {
+  const username = scout.getPreferences().githubUsername;
+  if (!username) {
+    throw new Error('GitHub username not configured. Run `oss-scout setup` first.');
+  }
+
+  const rateLimit = await checkRateLimit(token);
+  debug(MODULE, `Rate limit: ${rateLimit.remaining}/${rateLimit.limit}, resets at ${rateLimit.resetAt}`);
+
+  if (rateLimit.remaining < 15) {
+    debug(MODULE, 'Insufficient rate limit, skipping bootstrap');
+    return {
+      starredRepoCount: 0,
+      mergedPRCount: 0,
+      closedPRCount: 0,
+      reposScoredCount: 0,
+      skippedDueToRateLimit: true,
+    };
+  }
+
+  const octokit = getOctokit(token);
+
+  // 1. Fetch starred repos (up to 500)
+  const starredRepos: string[] = [];
+  let starredPage = 0;
+  for await (const response of octokit.paginate.iterator(
+    octokit.activity.listReposStarredByAuthenticatedUser,
+    { per_page: PER_PAGE, headers: { accept: 'application/vnd.github.v3+json' } },
+  )) {
+    for (const repo of response.data) {
+      const r = repo as { full_name: string };
+      starredRepos.push(r.full_name);
+    }
+    starredPage++;
+    if (starredPage >= STARRED_MAX_PAGES) break;
+  }
+  debug(MODULE, `Fetched ${starredRepos.length} starred repos`);
+  scout.setStarredRepos(starredRepos);
+
+  // 2. Fetch merged PRs via Search API
+  let mergedPRCount = 0;
+  for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
+    const { data } = await octokit.search.issuesAndPullRequests({
+      q: `is:pr is:merged author:${username}`,
+      per_page: PER_PAGE,
+      page,
+    });
+
+    for (const item of data.items) {
+      const repoMatch = item.html_url.match(/github\.com\/([^/]+\/[^/]+)\//);
+      if (!repoMatch) continue;
+
+      scout.recordMergedPR({
+        url: item.html_url,
+        title: item.title,
+        mergedAt: item.closed_at ?? new Date().toISOString(),
+        repo: repoMatch[1],
+      });
+      mergedPRCount++;
+    }
+
+    if (data.items.length < PER_PAGE) break;
+  }
+  debug(MODULE, `Imported ${mergedPRCount} merged PRs`);
+
+  // 3. Fetch closed-without-merge PRs via Search API
+  let closedPRCount = 0;
+  for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
+    const { data } = await octokit.search.issuesAndPullRequests({
+      q: `is:pr is:closed is:unmerged author:${username}`,
+      per_page: PER_PAGE,
+      page,
+    });
+
+    for (const item of data.items) {
+      const repoMatch = item.html_url.match(/github\.com\/([^/]+\/[^/]+)\//);
+      if (!repoMatch) continue;
+
+      scout.recordClosedPR({
+        url: item.html_url,
+        title: item.title,
+        closedAt: item.closed_at ?? new Date().toISOString(),
+        repo: repoMatch[1],
+      });
+      closedPRCount++;
+    }
+
+    if (data.items.length < PER_PAGE) break;
+  }
+  debug(MODULE, `Imported ${closedPRCount} closed PRs`);
+
+  const state = scout.getState();
+  const reposScoredCount = Object.keys(state.repoScores).length;
+
+  return {
+    starredRepoCount: starredRepos.length,
+    mergedPRCount,
+    closedPRCount,
+    reposScoredCount,
+    skippedDueToRateLimit: false,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `oss-scout bootstrap` command that fetches starred repos and PR history from GitHub to seed local state
- Fetches up to 500 starred repos, 300 merged PRs, and 300 closed PRs via GitHub APIs
- Includes rate limit protection (skips if < 15 requests remaining)
- Search command auto-detects empty state and suggests running bootstrap
- 6 tests covering rate limits, pagination, deduplication, and empty results

## Test plan
- [x] `pnpm test` — all 196 tests pass (6 new)
- [x] `tsc --noEmit` — no type errors
- [ ] Manual: `oss-scout bootstrap --json` returns structured result
- [ ] Manual: `oss-scout search` shows bootstrap hint when state is empty

Closes #5