### PR TITLE
feat: add batch vetting with vet-list command

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -287,6 +287,56 @@ configCmd
   });
 
 program
+  .command('vet-list')
+  .description('Re-vet all saved search results and classify their current status')
+  .option('--prune', 'Remove unavailable issues from saved results')
+  .option('--concurrency <n>', 'Max concurrent API requests (default: 5)', parseInt)
+  .option('--json', 'Output as JSON')
+  .action(async (options: { prune?: boolean; concurrency?: number; json?: boolean }) => {
+    try {
+      const { runVetList } = await import('./commands/vet-list.js');
+      const state = loadLocalState();
+      const result = await runVetList({
+        state,
+        prune: options.prune,
+        concurrency: options.concurrency,
+      });
+      if (options.json) {
+        console.log(formatJsonSuccess(result));
+      } else {
+        if (result.results.length === 0) {
+          console.log('\nNo saved results to vet. Run `oss-scout search` first.\n');
+          return;
+        }
+        console.log(`\nVet-list results (${result.summary.total}):\n`);
+        for (const r of result.results) {
+          const icon =
+            r.status === 'still_available' ? '✅' :
+            r.status === 'claimed' ? '🔒' :
+            r.status === 'has_pr' ? '🔀' :
+            r.status === 'closed' ? '🚫' : '❌';
+          const score = r.viabilityScore != null ? ` [${r.viabilityScore}/100]` : '';
+          console.log(`  ${icon} ${r.repo}#${r.number} — ${r.status}${score}`);
+          console.log(`     ${r.title}`);
+        }
+        console.log(`\nSummary: ${result.summary.stillAvailable} available, ${result.summary.claimed} claimed, ${result.summary.hasPR} has PR, ${result.summary.closed} closed, ${result.summary.errors} errors`);
+        if (result.prunedCount != null) {
+          console.log(`Pruned ${result.prunedCount} unavailable issues from saved results.`);
+        }
+        console.log();
+      }
+    } catch (err) {
+      if (options.json) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(formatJsonError(msg, resolveErrorCode(err)));
+      } else {
+        console.error('Error:', err instanceof Error ? err.message : String(err));
+      }
+      process.exit(1);
+    }
+  });
+
+program
   .command('vet <issue-url>')
   .description('Vet a specific GitHub issue for claimability and project health')
   .option('--json', 'Output as JSON')

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScoutStateSchema } from '../core/schemas.js';
+import type { SavedCandidate } from '../core/schemas.js';
+import type { IssueCandidate } from '../core/types.js';
+
+// Mock local-state module
+vi.mock('../core/local-state.js', () => {
+  let mockState: any = { version: 1, savedResults: [] };
+  return {
+    loadLocalState: () => mockState,
+    saveLocalState: (state: any) => {
+      mockState = state;
+    },
+    hasLocalState: () => true,
+    _setMockState: (state: any) => {
+      mockState = state;
+    },
+    _getMockState: () => mockState,
+  };
+});
+
+async function setMockState(state: any) {
+  const mod = (await import('../core/local-state.js')) as any;
+  mod._setMockState(state);
+}
+
+function makeSavedCandidate(
+  overrides: Partial<SavedCandidate> = {},
+): SavedCandidate {
+  return {
+    issueUrl: 'https://github.com/owner/repo/issues/1',
+    repo: 'owner/repo',
+    number: 1,
+    title: 'Fix the bug',
+    labels: ['good first issue'],
+    recommendation: 'approve',
+    viabilityScore: 75,
+    searchPriority: 'normal',
+    firstSeenAt: '2026-03-01T00:00:00.000Z',
+    lastSeenAt: '2026-03-01T00:00:00.000Z',
+    lastScore: 75,
+    ...overrides,
+  };
+}
+
+function makeIssueCandidate(
+  overrides: {
+    url?: string;
+    noExistingPR?: boolean;
+    notClaimed?: boolean;
+    recommendation?: 'approve' | 'skip' | 'needs_review';
+    viabilityScore?: number;
+  } = {},
+): IssueCandidate {
+  return {
+    issue: {
+      id: 1,
+      url: overrides.url ?? 'https://github.com/owner/repo/issues/1',
+      repo: 'owner/repo',
+      number: 1,
+      title: 'Fix the bug',
+      status: 'candidate',
+      labels: ['good first issue'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      vetted: true,
+      vettingResult: {
+        passedAllChecks:
+          (overrides.noExistingPR ?? true) && (overrides.notClaimed ?? true),
+        checks: {
+          noExistingPR: overrides.noExistingPR ?? true,
+          notClaimed: overrides.notClaimed ?? true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+      },
+    },
+    vettingResult: {
+      passedAllChecks:
+        (overrides.noExistingPR ?? true) && (overrides.notClaimed ?? true),
+      checks: {
+        noExistingPR: overrides.noExistingPR ?? true,
+        notClaimed: overrides.notClaimed ?? true,
+        projectActive: true,
+        clearRequirements: true,
+        contributionGuidelinesFound: true,
+      },
+      notes: [],
+    },
+    projectHealth: {
+      repo: 'owner/repo',
+      lastCommitAt: '2026-03-01T00:00:00.000Z',
+      daysSinceLastCommit: 1,
+      openIssuesCount: 10,
+      avgIssueResponseDays: 2,
+      ciStatus: 'passing',
+      isActive: true,
+    },
+    recommendation: overrides.recommendation ?? 'approve',
+    reasonsToSkip: [],
+    reasonsToApprove: ['Active project'],
+    viabilityScore: overrides.viabilityScore ?? 75,
+    searchPriority: 'normal',
+  };
+}
+
+describe('vetList', () => {
+  beforeEach(async () => {
+    const freshState = ScoutStateSchema.parse({ version: 1 });
+    await setMockState(freshState);
+  });
+
+  it('returns empty results when no saved results', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout('fake-token', state);
+
+    const result = await scout.vetList();
+
+    expect(result.results).toEqual([]);
+    expect(result.summary.total).toBe(0);
+    expect(result.summary.stillAvailable).toBe(0);
+    expect(result.prunedCount).toBeUndefined();
+  });
+
+  it('classifies still_available issues correctly', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout('fake-token', state);
+
+    vi.spyOn(scout, 'vetIssue').mockResolvedValue(makeIssueCandidate());
+
+    const result = await scout.vetList();
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].status).toBe('still_available');
+    expect(result.results[0].recommendation).toBe('approve');
+    expect(result.results[0].viabilityScore).toBe(75);
+    expect(result.summary.stillAvailable).toBe(1);
+  });
+
+  it('classifies claimed issues correctly', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout('fake-token', state);
+
+    vi.spyOn(scout, 'vetIssue').mockResolvedValue(
+      makeIssueCandidate({ notClaimed: false, recommendation: 'skip' }),
+    );
+
+    const result = await scout.vetList();
+
+    expect(result.results[0].status).toBe('claimed');
+    expect(result.summary.claimed).toBe(1);
+  });
+
+  it('classifies has_pr issues correctly', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout('fake-token', state);
+
+    vi.spyOn(scout, 'vetIssue').mockResolvedValue(
+      makeIssueCandidate({ noExistingPR: false, recommendation: 'skip' }),
+    );
+
+    const result = await scout.vetList();
+
+    expect(result.results[0].status).toBe('has_pr');
+    expect(result.summary.hasPR).toBe(1);
+  });
+
+  it('classifies closed issues from 404 errors', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout('fake-token', state);
+
+    vi.spyOn(scout, 'vetIssue').mockRejectedValue(new Error('Not Found'));
+
+    const result = await scout.vetList();
+
+    expect(result.results[0].status).toBe('closed');
+    expect(result.results[0].errorMessage).toBe('Not Found');
+    expect(result.summary.closed).toBe(1);
+  });
+
+  it('classifies generic errors correctly', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout('fake-token', state);
+
+    vi.spyOn(scout, 'vetIssue').mockRejectedValue(new Error('Network timeout'));
+
+    const result = await scout.vetList();
+
+    expect(result.results[0].status).toBe('error');
+    expect(result.results[0].errorMessage).toBe('Network timeout');
+    expect(result.summary.errors).toBe(1);
+  });
+
+  it('computes summary counts correctly with mixed statuses', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/a/b/issues/1',
+        repo: 'a/b',
+        number: 1,
+      }),
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/a/b/issues/2',
+        repo: 'a/b',
+        number: 2,
+      }),
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/c/d/issues/3',
+        repo: 'c/d',
+        number: 3,
+      }),
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/e/f/issues/4',
+        repo: 'e/f',
+        number: 4,
+      }),
+    ];
+    const scout = new OssScout('fake-token', state);
+
+    let callCount = 0;
+    vi.spyOn(scout, 'vetIssue').mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return makeIssueCandidate(); // still_available
+      if (callCount === 2)
+        return makeIssueCandidate({ notClaimed: false }); // claimed
+      if (callCount === 3) throw new Error('Not Found'); // closed
+      return makeIssueCandidate({ noExistingPR: false }); // has_pr
+    });
+
+    const result = await scout.vetList();
+
+    expect(result.summary.total).toBe(4);
+    expect(result.summary.stillAvailable).toBe(1);
+    expect(result.summary.claimed).toBe(1);
+    expect(result.summary.closed).toBe(1);
+    expect(result.summary.hasPR).toBe(1);
+    expect(result.summary.errors).toBe(0);
+  });
+
+  it('prunes unavailable issues from savedResults', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/a/b/issues/1',
+        repo: 'a/b',
+        number: 1,
+      }),
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/c/d/issues/2',
+        repo: 'c/d',
+        number: 2,
+      }),
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/e/f/issues/3',
+        repo: 'e/f',
+        number: 3,
+      }),
+    ];
+    const scout = new OssScout('fake-token', state);
+
+    let callCount = 0;
+    vi.spyOn(scout, 'vetIssue').mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return makeIssueCandidate(); // still_available
+      if (callCount === 2)
+        return makeIssueCandidate({ notClaimed: false }); // claimed
+      throw new Error('Not Found'); // closed
+    });
+
+    const result = await scout.vetList({ prune: true });
+
+    expect(result.prunedCount).toBe(2);
+    expect(scout.getSavedResults()).toHaveLength(1);
+    expect(scout.getSavedResults()[0].issueUrl).toBe(
+      'https://github.com/a/b/issues/1',
+    );
+  });
+
+  it('does not prune when prune option is false', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout('fake-token', state);
+
+    vi.spyOn(scout, 'vetIssue').mockRejectedValue(new Error('Not Found'));
+
+    const result = await scout.vetList({ prune: false });
+
+    expect(result.prunedCount).toBeUndefined();
+    expect(scout.getSavedResults()).toHaveLength(1);
+  });
+
+  it('respects concurrency option', async () => {
+    const { OssScout } = await import('../scout.js');
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/a/b/issues/1',
+        repo: 'a/b',
+        number: 1,
+      }),
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/a/b/issues/2',
+        repo: 'a/b',
+        number: 2,
+      }),
+      makeSavedCandidate({
+        issueUrl: 'https://github.com/a/b/issues/3',
+        repo: 'a/b',
+        number: 3,
+      }),
+    ];
+    const scout = new OssScout('fake-token', state);
+
+    let maxConcurrent = 0;
+    let currentConcurrent = 0;
+
+    vi.spyOn(scout, 'vetIssue').mockImplementation(async () => {
+      currentConcurrent++;
+      maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      currentConcurrent--;
+      return makeIssueCandidate();
+    });
+
+    await scout.vetList({ concurrency: 2 });
+
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -1,0 +1,26 @@
+import { createScout } from '../scout.js';
+import { requireGitHubToken } from '../core/utils.js';
+import { saveLocalState } from '../core/local-state.js';
+import type { ScoutState } from '../core/schemas.js';
+import type { VetListResult } from '../core/types.js';
+
+interface VetListCommandOptions {
+  concurrency?: number;
+  prune?: boolean;
+  state?: ScoutState;
+}
+
+export async function runVetList(options: VetListCommandOptions): Promise<VetListResult> {
+  const token = requireGitHubToken();
+  const scout = options.state
+    ? await createScout({ githubToken: token, persistence: 'provided', initialState: options.state })
+    : await createScout({ githubToken: token });
+
+  const result = await scout.vetList({
+    concurrency: options.concurrency,
+    prune: options.prune,
+  });
+
+  saveLocalState(scout.getState() as ScoutState);
+  return result;
+}

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -85,6 +85,43 @@ export const SCOPE_LABELS: Record<IssueScope, string[]> = {
   advanced: ['proposal', 'RFC', 'accepted', 'design'],
 };
 
+// ── Vet-list types ─────────────────────────────────────────────────
+
+/** Options for batch vetting saved results. */
+export interface VetListOptions {
+  concurrency?: number;
+  prune?: boolean;
+}
+
+/** A single entry in the vet-list result. */
+export interface VetListEntry {
+  issueUrl: string;
+  repo: string;
+  number: number;
+  title: string;
+  status: 'still_available' | 'claimed' | 'closed' | 'has_pr' | 'error';
+  recommendation?: 'approve' | 'skip' | 'needs_review';
+  viabilityScore?: number;
+  errorMessage?: string;
+}
+
+/** Summary counts for a vet-list run. */
+export interface VetListSummary {
+  total: number;
+  stillAvailable: number;
+  claimed: number;
+  closed: number;
+  hasPR: number;
+  errors: number;
+}
+
+/** Result of a batch vet-list operation. */
+export interface VetListResult {
+  results: VetListEntry[];
+  summary: VetListSummary;
+  prunedCount?: number;
+}
+
 // ── Config types for the OssScout API ───────────────────────────────
 
 /** Configuration for creating an OssScout instance. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,10 @@ export type {
   ProjectHealth,
   SearchPriority,
   CheckResult,
+  VetListOptions,
+  VetListResult,
+  VetListEntry,
+  VetListSummary,
 } from './core/types.js';
 
 export type {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -23,6 +23,9 @@ import type {
   ClosedPRRecord,
   RepoScoreUpdate,
   ProjectCategory,
+  VetListOptions,
+  VetListResult,
+  VetListEntry,
 } from './core/types.js';
 
 /**
@@ -104,6 +107,87 @@ export class OssScout implements ScoutStateReader {
   async vetIssue(issueUrl: string): Promise<IssueCandidate> {
     const discovery = new IssueDiscovery(this.githubToken, this.state.preferences, this);
     return discovery.vetIssue(issueUrl);
+  }
+
+  // ── Batch Vetting ───────────────────────────────────────────────────
+
+  /**
+   * Re-vet all saved results with bounded concurrency.
+   * Classifies each as still_available, claimed, has_pr, closed, or error.
+   * Optionally prunes unavailable issues from saved results.
+   */
+  async vetList(options?: VetListOptions): Promise<VetListResult> {
+    const saved = this.getSavedResults();
+    const concurrency = options?.concurrency ?? 5;
+    const results: VetListEntry[] = [];
+    const pending = new Map<string, Promise<void>>();
+
+    for (const item of saved) {
+      const task = this.vetIssue(item.issueUrl)
+        .then((candidate) => {
+          results.push({
+            issueUrl: item.issueUrl,
+            repo: item.repo,
+            number: item.number,
+            title: item.title,
+            status: this.classifyVetResult(candidate),
+            recommendation: candidate.recommendation,
+            viabilityScore: candidate.viabilityScore,
+          });
+        })
+        .catch((error) => {
+          const msg = error instanceof Error ? error.message : String(error);
+          const isGone = msg.includes('Not Found') || msg.includes('410');
+          results.push({
+            issueUrl: item.issueUrl,
+            repo: item.repo,
+            number: item.number,
+            title: item.title,
+            status: isGone ? 'closed' : 'error',
+            errorMessage: msg,
+          });
+        })
+        .finally(() => {
+          pending.delete(item.issueUrl);
+        });
+
+      pending.set(item.issueUrl, task);
+      if (pending.size >= concurrency) {
+        await Promise.race(pending.values());
+      }
+    }
+    await Promise.allSettled(pending.values());
+
+    const summary = {
+      total: results.length,
+      stillAvailable: results.filter((r) => r.status === 'still_available').length,
+      claimed: results.filter((r) => r.status === 'claimed').length,
+      closed: results.filter((r) => r.status === 'closed').length,
+      hasPR: results.filter((r) => r.status === 'has_pr').length,
+      errors: results.filter((r) => r.status === 'error').length,
+    };
+
+    let prunedCount: number | undefined;
+    if (options?.prune) {
+      const unavailableUrls = new Set(
+        results.filter((r) => r.status !== 'still_available').map((r) => r.issueUrl),
+      );
+      const before = (this.state.savedResults ?? []).length;
+      this.state.savedResults = (this.state.savedResults ?? []).filter(
+        (r) => !unavailableUrls.has(r.issueUrl),
+      );
+      prunedCount = before - (this.state.savedResults?.length ?? 0);
+      this.dirty = true;
+    }
+
+    return { results, summary, prunedCount };
+  }
+
+  private classifyVetResult(candidate: IssueCandidate): VetListEntry['status'] {
+    const checks = candidate.vettingResult.checks;
+    if (!checks.noExistingPR) return 'has_pr';
+    if (!checks.notClaimed) return 'claimed';
+    return 'still_available';
   }
 
   // ── State Reads (ScoutStateReader implementation) ───────────────────


### PR DESCRIPTION
## Summary

- Adds `oss-scout vet-list` command that re-vets all saved search results, classifying each as `still_available`, `claimed`, `has_pr`, `closed`, or `error`
- Uses bounded concurrency (`--concurrency <n>`, default 5) via `Promise.race` to efficiently process saved results without overwhelming GitHub's API
- Supports `--prune` flag to automatically remove unavailable issues from saved results
- Full `--json` support following the existing CLI contract

## Changes

- **types.ts**: `VetListOptions`, `VetListEntry`, `VetListSummary`, `VetListResult` types
- **scout.ts**: `vetList()` method with `classifyVetResult()` helper on `OssScout` class
- **cli.ts**: `vet-list` command wired with `--prune`, `--concurrency`, `--json` flags
- **commands/vet-list.ts**: Command handler
- **index.ts**: Public API exports for new types

## Test plan

- [x] 10 tests covering all classification paths (still_available, claimed, has_pr, closed, error)
- [x] Mixed status summary computation
- [x] Prune mode removes unavailable issues
- [x] No-prune mode preserves all saved results
- [x] Concurrency limiting verified
- [x] TypeScript type check passes
- [x] Full test suite passes (236 tests, 16 files)

Closes #7