### PR TITLE
test: add missing core test files

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -1,0 +1,632 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IssueCandidate } from "./types.js";
+import type { GitHubSearchItem } from "./issue-filtering.js";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("./utils.js", () => ({
+  daysBetween: vi.fn(() => 5),
+  extractRepoFromUrl: (url: string) => {
+    const api = url.match(/api\.github\.com\/repos\/([^/]+\/[^/]+)/);
+    if (api) return api[1];
+    const web = url.match(/github\.com\/([^/]+\/[^/]+)/);
+    return web ? web[1] : null;
+  },
+  sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./github.js", () => ({
+  getOctokit: vi.fn(() => ({})),
+  checkRateLimit: vi.fn().mockResolvedValue({
+    remaining: 30,
+    limit: 30,
+    resetAt: new Date(Date.now() + 60000).toISOString(),
+  }),
+}));
+
+vi.mock("./search-budget.js", () => ({
+  getSearchBudgetTracker: vi.fn(() => ({
+    init: vi.fn(),
+    recordCall: vi.fn(),
+    getTotalCalls: vi.fn(() => 5),
+    canAfford: vi.fn(() => true),
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+let lastVetterInstance: {
+  vetIssue: ReturnType<typeof vi.fn>;
+  vetIssuesParallel: ReturnType<typeof vi.fn>;
+} | null = null;
+
+vi.mock("./issue-vetting.js", () => ({
+  IssueVetter: vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+  ) {
+    this.vetIssue = vi.fn();
+    this.vetIssuesParallel = vi.fn().mockResolvedValue({
+      candidates: [],
+      allFailed: false,
+      rateLimitHit: false,
+    });
+    lastVetterInstance = this as unknown as typeof lastVetterInstance;
+  }),
+}));
+
+vi.mock("./issue-filtering.js", () => ({
+  isDocOnlyIssue: vi.fn(() => false),
+  applyPerRepoCap: vi.fn((candidates: IssueCandidate[]) => candidates),
+}));
+
+vi.mock("./category-mapping.js", () => ({
+  getTopicsForCategories: vi.fn(() => ["devtools"]),
+}));
+
+vi.mock("./errors.js", () => ({
+  ValidationError: class ValidationError extends Error {
+    code = "VALIDATION_ERROR";
+    constructor(message: string) {
+      super(message);
+      this.name = "ValidationError";
+    }
+  },
+  errorMessage: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
+  getHttpStatusCode: vi.fn(() => undefined),
+  isRateLimitError: vi.fn(() => false),
+}));
+
+const mockSearchInRepos = vi.fn().mockResolvedValue({
+  candidates: [],
+  allBatchesFailed: false,
+  rateLimitHit: false,
+});
+
+const mockSearchWithChunkedLabels = vi.fn().mockResolvedValue([]);
+
+const mockFilterVetAndScore = vi.fn().mockResolvedValue({
+  candidates: [],
+  allVetFailed: false,
+  rateLimitHit: false,
+});
+
+const mockCachedSearchIssues = vi.fn().mockResolvedValue({
+  total_count: 0,
+  items: [],
+});
+
+vi.mock("./search-phases.js", () => ({
+  buildEffectiveLabels: vi.fn((_scopes: string[], labels: string[]) =>
+    labels.length > 0 ? labels : ["good first issue"],
+  ),
+  interleaveArrays: vi.fn((arrays: unknown[][]) => arrays.flat()),
+  searchInRepos: (...args: unknown[]) => mockSearchInRepos(...args),
+  searchWithChunkedLabels: (...args: unknown[]) =>
+    mockSearchWithChunkedLabels(...args),
+  filterVetAndScore: (...args: unknown[]) => mockFilterVetAndScore(...args),
+  cachedSearchIssues: (...args: unknown[]) => mockCachedSearchIssues(...args),
+}));
+
+import { IssueDiscovery } from "./issue-discovery.js";
+import { checkRateLimit } from "./github.js";
+import { applyPerRepoCap } from "./issue-filtering.js";
+import type { ScoutStateReader } from "./issue-vetting.js";
+import type { ScoutPreferences } from "./schemas.js";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function makeCandidate(
+  repo: string,
+  priority: "merged_pr" | "preferred_org" | "starred" | "normal" = "normal",
+  recommendation: "approve" | "skip" | "needs_review" = "approve",
+  score = 80,
+): IssueCandidate {
+  return {
+    issue: {
+      id: 1,
+      url: `https://github.com/${repo}/issues/1`,
+      repo,
+      number: 1,
+      title: "Test issue",
+      status: "candidate",
+      labels: [],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+      vetted: true,
+      vettingResult: {
+        passedAllChecks: true,
+        checks: {
+          noExistingPR: true,
+          notClaimed: true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+      },
+    },
+    vettingResult: {
+      passedAllChecks: true,
+      checks: {
+        noExistingPR: true,
+        notClaimed: true,
+        projectActive: true,
+        clearRequirements: true,
+        contributionGuidelinesFound: true,
+      },
+      notes: [],
+    },
+    projectHealth: {
+      repo,
+      lastCommitAt: "",
+      daysSinceLastCommit: 1,
+      openIssuesCount: 10,
+      avgIssueResponseDays: 2,
+      ciStatus: "passing",
+      isActive: true,
+      stargazersCount: 500,
+    },
+    recommendation,
+    reasonsToSkip: [],
+    reasonsToApprove: [],
+    viabilityScore: score,
+    searchPriority: priority,
+  };
+}
+
+function makeStateReader(
+  overrides: Partial<ScoutStateReader> = {},
+): ScoutStateReader {
+  return {
+    getReposWithMergedPRs: vi.fn(() => []),
+    getStarredRepos: vi.fn(() => []),
+    getPreferredOrgs: vi.fn(() => []),
+    getProjectCategories: vi.fn(() => []),
+    getRepoScore: vi.fn(() => null),
+    ...overrides,
+  };
+}
+
+function makePreferences(
+  overrides: Partial<ScoutPreferences> = {},
+): ScoutPreferences {
+  return {
+    languages: ["TypeScript"],
+    labels: ["good first issue", "help wanted"],
+    excludeRepos: [],
+    aiPolicyBlocklist: [],
+    minStars: 50,
+    minRepoScoreThreshold: 0,
+    maxIssueAgeDays: 90,
+    includeDocIssues: true,
+    ...overrides,
+  } as ScoutPreferences;
+}
+
+function makeDiscovery(
+  stateOverrides: Partial<ScoutStateReader> = {},
+  prefOverrides: Partial<ScoutPreferences> = {},
+): IssueDiscovery {
+  return new IssueDiscovery(
+    "test-token",
+    makePreferences(prefOverrides),
+    makeStateReader(stateOverrides),
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("IssueDiscovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset mocks to defaults
+    mockSearchInRepos.mockResolvedValue({
+      candidates: [],
+      allBatchesFailed: false,
+      rateLimitHit: false,
+    });
+    mockSearchWithChunkedLabels.mockResolvedValue([]);
+    mockFilterVetAndScore.mockResolvedValue({
+      candidates: [],
+      allVetFailed: false,
+      rateLimitHit: false,
+    });
+    mockCachedSearchIssues.mockResolvedValue({
+      total_count: 0,
+      items: [],
+    });
+
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      remaining: 30,
+      limit: 30,
+      resetAt: new Date(Date.now() + 60000).toISOString(),
+    });
+  });
+
+  describe("searchIssues — phase execution", () => {
+    it("Phase 0: calls searchInRepos with merged-PR repos, priority merged_pr", async () => {
+      const c = makeCandidate("org/merged-repo", "merged_pr");
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [c],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged-repo"]),
+      });
+
+      const { candidates } = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+      expect(mockSearchInRepos).toHaveBeenCalledWith(
+        expect.anything(), // octokit
+        expect.anything(), // vetter
+        ["org/merged-repo"],
+        expect.stringContaining("is:issue"),
+        [], // no labels for Phase 0
+        expect.any(Number),
+        "merged_pr",
+        expect.any(Function),
+      );
+    });
+
+    it("Phase 0.5: calls searchWithChunkedLabels for preferred orgs", async () => {
+      const c = makeCandidate("preferred-org/repo", "preferred_org");
+      mockSearchWithChunkedLabels.mockResolvedValue([
+        {
+          html_url: "https://github.com/preferred-org/repo/issues/1",
+          repository_url: "https://api.github.com/repos/preferred-org/repo",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+
+      const discovery = makeDiscovery(
+        {
+          getReposWithMergedPRs: vi.fn(() => []),
+        },
+        {
+          preferredOrgs: ["preferred-org"],
+        },
+      );
+
+      // After constructing discovery, configure the vetter mock to return candidates
+      lastVetterInstance!.vetIssuesParallel.mockResolvedValue({
+        candidates: [c],
+        allFailed: false,
+        rateLimitHit: false,
+      });
+
+      const { candidates } = await discovery.searchIssues({ maxResults: 5 });
+      expect(mockSearchWithChunkedLabels).toHaveBeenCalled();
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("Phase 1: calls searchInRepos with starred repos, priority starred", async () => {
+      const c = makeCandidate("org/starred-repo", "starred");
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [c],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getStarredRepos: vi.fn(() => ["org/starred-repo"]),
+      });
+
+      await discovery.searchIssues({ maxResults: 5 });
+      // Phase 1 calls searchInRepos with "starred" priority
+      const phase1Call = mockSearchInRepos.mock.calls.find(
+        (call) => call[6] === "starred",
+      );
+      expect(phase1Call).toBeDefined();
+      expect(phase1Call![2]).toEqual(["org/starred-repo"]);
+    });
+
+    it("Phase 2: calls searchWithChunkedLabels then filterVetAndScore", async () => {
+      const item: GitHubSearchItem = {
+        html_url: "https://github.com/broad/repo/issues/1",
+        repository_url: "https://api.github.com/repos/broad/repo",
+        updated_at: "2026-01-01T00:00:00Z",
+      };
+      mockSearchWithChunkedLabels.mockResolvedValue([item]);
+      const c = makeCandidate("broad/repo", "normal");
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [c],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery();
+      await discovery.searchIssues({ maxResults: 5 });
+
+      expect(mockSearchWithChunkedLabels).toHaveBeenCalled();
+      expect(mockFilterVetAndScore).toHaveBeenCalled();
+    });
+
+    it("Phase 3: calls cachedSearchIssues then filterVetAndScore", async () => {
+      mockCachedSearchIssues.mockResolvedValue({
+        total_count: 5,
+        items: [
+          {
+            html_url: "https://github.com/maintained/repo/issues/1",
+            repository_url: "https://api.github.com/repos/maintained/repo",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      });
+      const c = makeCandidate("maintained/repo", "normal");
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [c],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery();
+      await discovery.searchIssues({ maxResults: 5 });
+
+      expect(mockCachedSearchIssues).toHaveBeenCalled();
+    });
+  });
+
+  describe("searchIssues — strategy filtering", () => {
+    it("strategies=[merged] runs only Phase 0", async () => {
+      const c = makeCandidate("org/merged-repo", "merged_pr");
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [c],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged-repo"]),
+        getStarredRepos: vi.fn(() => ["org/starred-repo"]),
+      });
+
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 5,
+        strategies: ["merged"],
+      });
+
+      expect(strategiesUsed).toContain("merged");
+      expect(strategiesUsed).not.toContain("starred");
+      expect(strategiesUsed).not.toContain("broad");
+      expect(strategiesUsed).not.toContain("maintained");
+    });
+
+    it("strategies=[starred,broad] runs only Phases 1 and 2", async () => {
+      const c = makeCandidate("org/starred-repo", "starred");
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [c],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getStarredRepos: vi.fn(() => ["org/starred-repo"]),
+        getReposWithMergedPRs: vi.fn(() => ["org/merged-repo"]),
+      });
+
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 5,
+        strategies: ["starred", "broad"],
+      });
+
+      expect(strategiesUsed).not.toContain("merged");
+      expect(strategiesUsed).toContain("starred");
+      expect(strategiesUsed).toContain("broad");
+    });
+  });
+
+  describe("searchIssues — budget management", () => {
+    it("only runs Phase 0 when budget is critical (<10)", async () => {
+      vi.mocked(checkRateLimit).mockResolvedValue({
+        remaining: 5,
+        limit: 30,
+        resetAt: new Date(Date.now() + 60000).toISOString(),
+      });
+
+      const c = makeCandidate("org/merged", "merged_pr");
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [c],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged"]),
+        getStarredRepos: vi.fn(() => ["org/starred"]),
+      });
+
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 10,
+      });
+
+      expect(strategiesUsed).toContain("merged");
+      expect(strategiesUsed).not.toContain("starred");
+      expect(strategiesUsed).not.toContain("broad");
+      expect(strategiesUsed).not.toContain("maintained");
+    });
+
+    it("skips Phases 2 and 3 when budget is low (<20)", async () => {
+      vi.mocked(checkRateLimit).mockResolvedValue({
+        remaining: 15,
+        limit: 30,
+        resetAt: new Date(Date.now() + 60000).toISOString(),
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged"]),
+        getStarredRepos: vi.fn(() => ["org/starred"]),
+      });
+
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 10,
+      });
+
+      expect(strategiesUsed).not.toContain("broad");
+      expect(strategiesUsed).not.toContain("maintained");
+    });
+  });
+
+  describe("searchIssues — rate limit handling", () => {
+    it("sets rateLimitWarning when remaining < 5", async () => {
+      vi.mocked(checkRateLimit).mockResolvedValue({
+        remaining: 3,
+        limit: 30,
+        resetAt: new Date(Date.now() + 60000).toISOString(),
+      });
+
+      const c = makeCandidate("org/repo", "merged_pr");
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [c],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/repo"]),
+      });
+
+      await discovery.searchIssues({ maxResults: 5 });
+      expect(discovery.rateLimitWarning).toBeTruthy();
+      expect(discovery.rateLimitWarning).toContain("quota");
+    });
+  });
+
+  describe("searchIssues — post-processing", () => {
+    it("calls applyPerRepoCap on results", async () => {
+      const candidates = [
+        makeCandidate("org/repo1", "normal"),
+        makeCandidate("org/repo2", "normal"),
+      ];
+      mockSearchInRepos.mockResolvedValue({
+        candidates,
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/repo1", "org/repo2"]),
+      });
+
+      await discovery.searchIssues({ maxResults: 10 });
+      expect(applyPerRepoCap).toHaveBeenCalled();
+    });
+
+    it("sorts by priority > recommendation > score", async () => {
+      const merged = makeCandidate("org/merged", "merged_pr", "approve", 60);
+      const starred = makeCandidate("org/starred", "starred", "approve", 90);
+      const normal = makeCandidate("org/normal", "normal", "approve", 95);
+
+      // Phase 0 returns merged
+      mockSearchInRepos.mockResolvedValueOnce({
+        candidates: [merged],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+      // Phase 1 returns starred
+      mockSearchInRepos.mockResolvedValueOnce({
+        candidates: [starred],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+      // Phase 2 returns normal
+      mockSearchWithChunkedLabels.mockResolvedValue([]);
+      mockFilterVetAndScore.mockResolvedValueOnce({
+        candidates: [normal],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      // applyPerRepoCap returns as-is to verify sort order
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged"]),
+        getStarredRepos: vi.fn(() => ["org/starred"]),
+      });
+
+      const { candidates } = await discovery.searchIssues({ maxResults: 10 });
+      // merged_pr (priority 0) should come before starred (priority 2) before normal (priority 3)
+      if (candidates.length >= 3) {
+        expect(candidates[0].searchPriority).toBe("merged_pr");
+        expect(candidates[1].searchPriority).toBe("starred");
+        expect(candidates[2].searchPriority).toBe("normal");
+      }
+    });
+  });
+
+  describe("searchIssues — filtering", () => {
+    it("filterIssues excludes repos in excludeRepos", async () => {
+      const items: GitHubSearchItem[] = [
+        {
+          html_url: "https://github.com/excluded/repo/issues/1",
+          repository_url: "https://api.github.com/repos/excluded/repo",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ];
+      mockSearchWithChunkedLabels.mockResolvedValue(items);
+
+      const discovery = makeDiscovery({}, { excludeRepos: ["excluded/repo"] });
+
+      // The filter function is passed to search phases; items matching
+      // excludeRepos should be excluded. With no candidates from any phase,
+      // searchIssues throws ValidationError.
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(
+        "No issue candidates found",
+      );
+    });
+
+    it("filterIssues excludes repos in aiPolicyBlocklist", async () => {
+      // Provide a candidate so the search doesn't throw
+      const c = makeCandidate("allowed/repo", "merged_pr");
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [c],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery(
+        { getReposWithMergedPRs: vi.fn(() => ["allowed/repo"]) },
+        { aiPolicyBlocklist: ["blocked/repo"] },
+      );
+
+      const { candidates } = await discovery.searchIssues({ maxResults: 5 });
+      // Verify discovery was constructed without error when blocklist is set
+      // and candidates from non-blocked repos are returned
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("searchIssues — error handling", () => {
+    it("throws ValidationError when no candidates found and no rate limits", async () => {
+      const discovery = makeDiscovery();
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(
+        "No issue candidates found",
+      );
+    });
+
+    it("returns empty with warning when rate limited", async () => {
+      vi.mocked(checkRateLimit).mockResolvedValue({
+        remaining: 5,
+        limit: 30,
+        resetAt: new Date(Date.now() + 60000).toISOString(),
+      });
+
+      // budget < CRITICAL_BUDGET_THRESHOLD = 10 triggers skipping most phases
+      // and phasesSkippedForBudget = true when budget < LOW_BUDGET_THRESHOLD
+      const discovery = makeDiscovery();
+      const { candidates } = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates).toHaveLength(0);
+      expect(discovery.rateLimitWarning).toBeTruthy();
+    });
+  });
+});

--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("./search-budget.js", () => ({
+  getSearchBudgetTracker: vi.fn(() => ({
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+    recordCall: vi.fn(),
+  })),
+}));
+
+vi.mock("./http-cache.js", () => ({
+  getHttpCache: vi.fn(() => ({
+    getIfFresh: vi.fn(() => null),
+    set: vi.fn(),
+  })),
+}));
+
+vi.mock("./pagination.js", () => ({
+  paginateAll: vi.fn(),
+}));
+
+import {
+  checkNoExistingPR,
+  checkNotClaimed,
+  checkUserMergedPRsInRepo,
+  analyzeRequirements,
+} from "./issue-eligibility.js";
+import { paginateAll } from "./pagination.js";
+import type { Octokit } from "@octokit/rest";
+
+const mockPaginateAll = vi.mocked(paginateAll);
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function makeMockOctokit(overrides: Record<string, unknown> = {}): Octokit {
+  return {
+    issues: {
+      listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
+      listComments: vi.fn(),
+    },
+    search: {
+      issuesAndPullRequests: vi.fn().mockResolvedValue({
+        data: { total_count: 0, items: [] },
+      }),
+    },
+    paginate: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as Octokit;
+}
+
+// ── checkNoExistingPR ─────────────────────────────────────────────
+
+describe("checkNoExistingPR", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns passed:true when no PRs are linked", async () => {
+    mockPaginateAll.mockResolvedValue([]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 1);
+    expect(result.passed).toBe(true);
+    expect(result.inconclusive).toBeUndefined();
+  });
+
+  it("returns passed:false when an open PR is found via cross-reference", async () => {
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: { issue: { pull_request: { url: "some-url" } } },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 42);
+    expect(result.passed).toBe(false);
+  });
+
+  it("returns passed:false when a merged PR is found via cross-reference", async () => {
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: {
+          issue: { pull_request: { url: "some-url", merged_at: "2026-01-01" } },
+        },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 10);
+    expect(result.passed).toBe(false);
+  });
+
+  it("returns passed:true and inconclusive:true on API error", async () => {
+    mockPaginateAll.mockRejectedValue(new Error("API timeout"));
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 5);
+    expect(result.passed).toBe(true);
+    expect(result.inconclusive).toBe(true);
+    expect(result.reason).toContain("API timeout");
+  });
+
+  it("returns passed:true when timeline is empty", async () => {
+    mockPaginateAll.mockResolvedValue([]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 99);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ── checkNotClaimed ───────────────────────────────────────────────
+
+describe("checkNotClaimed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns passed:true when there are no comments", async () => {
+    const octokit = makeMockOctokit();
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 0);
+    expect(result.passed).toBe(true);
+  });
+
+  it('returns passed:false when a comment says "i\'m working on this"', async () => {
+    const octokit = makeMockOctokit({
+      paginate: vi
+        .fn()
+        .mockResolvedValue([{ body: "I'm working on this already" }]),
+    });
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 3);
+    expect(result.passed).toBe(false);
+  });
+
+  it('returns passed:false when a comment says "i\'ll take this"', async () => {
+    const octokit = makeMockOctokit({
+      paginate: vi.fn().mockResolvedValue([{ body: "I'll take this issue" }]),
+    });
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 2);
+    expect(result.passed).toBe(false);
+  });
+
+  it("returns passed:true when comments are normal discussion", async () => {
+    const octokit = makeMockOctokit({
+      paginate: vi
+        .fn()
+        .mockResolvedValue([
+          { body: "This would be a nice feature." },
+          { body: "I agree, we should add this." },
+        ]),
+    });
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 2);
+    expect(result.passed).toBe(true);
+  });
+
+  it("returns passed:true and inconclusive:true on API error", async () => {
+    const octokit = makeMockOctokit({
+      paginate: vi.fn().mockRejectedValue(new Error("Network error")),
+    });
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 5);
+    expect(result.passed).toBe(true);
+    expect(result.inconclusive).toBe(true);
+    expect(result.reason).toContain("Network error");
+  });
+
+  it("returns passed:true when commentCount is zero (skips API)", async () => {
+    const paginateFn = vi.fn();
+    const octokit = makeMockOctokit({ paginate: paginateFn });
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 0);
+    expect(result.passed).toBe(true);
+    expect(paginateFn).not.toHaveBeenCalled();
+  });
+
+  it("performs case insensitive matching on claim phrases", async () => {
+    const octokit = makeMockOctokit({
+      paginate: vi
+        .fn()
+        .mockResolvedValue([{ body: "WORKING ON IT right now" }]),
+    });
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 1);
+    expect(result.passed).toBe(false);
+  });
+});
+
+// ── checkUserMergedPRsInRepo ──────────────────────────────────────
+
+describe("checkUserMergedPRsInRepo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the count when merged PRs are found", async () => {
+    const octokit = makeMockOctokit({
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 3, items: [{}, {}, {}] },
+        }),
+      },
+    });
+    const result = await checkUserMergedPRsInRepo(octokit, "owner", "repo");
+    expect(result).toBe(3);
+  });
+
+  it("returns 0 when no merged PRs are found", async () => {
+    const octokit = makeMockOctokit({
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 0, items: [] },
+        }),
+      },
+    });
+    const result = await checkUserMergedPRsInRepo(octokit, "owner", "repo");
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 on API error (non-fatal, not cached)", async () => {
+    const octokit = makeMockOctokit({
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockRejectedValue(new Error("Search failed")),
+      },
+    });
+    const result = await checkUserMergedPRsInRepo(octokit, "owner", "repo");
+    expect(result).toBe(0);
+  });
+});
+
+// ── analyzeRequirements ───────────────────────────────────────────
+
+describe("analyzeRequirements", () => {
+  it("returns true for numbered steps + code blocks", () => {
+    const body =
+      "1. First step\n2. Second step\n```js\nconsole.log('hello');\n```\nPlease implement this.";
+    expect(analyzeRequirements(body)).toBe(true);
+  });
+
+  it("returns true for keywords (should, expect) + sufficient length", () => {
+    const body =
+      "This feature should allow users to configure the output format. " +
+      "We expect the CLI to accept a --format flag with values json, table, csv. " +
+      "The default should be table. Users should be able to pipe output to other tools.";
+    expect(analyzeRequirements(body)).toBe(true);
+  });
+
+  it("returns true for >200 chars + 2+ indicators", () => {
+    const body =
+      "We need a new feature that should handle edge cases properly. " +
+      "- Step 1: Parse the input\n- Step 2: Validate the data\n" +
+      "This must be backward compatible with the existing API. " +
+      "Additional context: the system currently processes about 1000 requests per second.";
+    expect(analyzeRequirements(body)).toBe(true);
+  });
+
+  it("returns false for short vague body", () => {
+    const body = "This is broken. Please fix it.";
+    expect(analyzeRequirements(body)).toBe(false);
+  });
+
+  it("returns false for empty/null body", () => {
+    expect(analyzeRequirements("")).toBe(false);
+    expect(analyzeRequirements(null as unknown as string)).toBe(false);
+  });
+
+  it("returns false for only 1 indicator", () => {
+    // Only has length > 200, no steps/code/keywords
+    const body =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+      "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+      "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris " +
+      "nisi ut aliquip ex ea commodo consequat.";
+    expect(analyzeRequirements(body)).toBe(false);
+  });
+});

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IssueCandidate, ProjectHealth } from "./types.js";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("./utils.js", () => ({
+  parseGitHubUrl: vi.fn((url: string) => {
+    const match = url.match(
+      /github\.com\/([^/]+)\/([^/]+)\/(issues|pull)\/(\d+)/,
+    );
+    if (!match) return null;
+    return {
+      owner: match[1],
+      repo: match[2],
+      type: match[3],
+      number: parseInt(match[4], 10),
+    };
+  }),
+}));
+
+vi.mock("./errors.js", () => ({
+  ValidationError: class ValidationError extends Error {
+    code = "VALIDATION_ERROR";
+    constructor(message: string) {
+      super(message);
+      this.name = "ValidationError";
+    }
+  },
+  errorMessage: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
+  isRateLimitError: vi.fn(() => false),
+}));
+
+vi.mock("./issue-scoring.js", () => ({
+  calculateRepoQualityBonus: vi.fn(() => 5),
+  calculateViabilityScore: vi.fn(() => 75),
+}));
+
+vi.mock("./category-mapping.js", () => ({
+  repoBelongsToCategory: vi.fn(() => false),
+}));
+
+vi.mock("./issue-eligibility.js", () => ({
+  checkNoExistingPR: vi.fn().mockResolvedValue({ passed: true }),
+  checkNotClaimed: vi.fn().mockResolvedValue({ passed: true }),
+  checkUserMergedPRsInRepo: vi.fn().mockResolvedValue(0),
+  analyzeRequirements: vi.fn(() => true),
+}));
+
+vi.mock("./repo-health.js", () => ({
+  checkProjectHealth: vi.fn().mockResolvedValue({
+    repo: "owner/repo",
+    lastCommitAt: new Date().toISOString(),
+    daysSinceLastCommit: 1,
+    openIssuesCount: 10,
+    avgIssueResponseDays: 2,
+    ciStatus: "passing",
+    isActive: true,
+    stargazersCount: 500,
+    forksCount: 50,
+  } satisfies ProjectHealth),
+  fetchContributionGuidelines: vi.fn().mockResolvedValue({
+    url: "https://github.com/owner/repo/blob/main/CONTRIBUTING.md",
+    content: "Please read before contributing.",
+  }),
+}));
+
+vi.mock("./http-cache.js", () => ({
+  getHttpCache: vi.fn(() => ({
+    getIfFresh: vi.fn(() => null),
+    set: vi.fn(),
+  })),
+}));
+
+import { IssueVetter, type ScoutStateReader } from "./issue-vetting.js";
+import {
+  checkNoExistingPR,
+  checkNotClaimed,
+  checkUserMergedPRsInRepo,
+  analyzeRequirements,
+} from "./issue-eligibility.js";
+import {
+  checkProjectHealth,
+  fetchContributionGuidelines,
+} from "./repo-health.js";
+import { repoBelongsToCategory } from "./category-mapping.js";
+import { isRateLimitError } from "./errors.js";
+import { getHttpCache } from "./http-cache.js";
+import type { Octokit } from "@octokit/rest";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function makeStubStateReader(
+  overrides: Partial<ScoutStateReader> = {},
+): ScoutStateReader {
+  return {
+    getReposWithMergedPRs: vi.fn(() => []),
+    getStarredRepos: vi.fn(() => []),
+    getPreferredOrgs: vi.fn(() => []),
+    getProjectCategories: vi.fn(() => []),
+    getRepoScore: vi.fn(() => null),
+    ...overrides,
+  };
+}
+
+function makeMockOctokit(): Octokit {
+  return {
+    issues: {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          id: 123,
+          html_url: "https://github.com/owner/repo/issues/1",
+          title: "Fix the bug",
+          body: "1. Steps to reproduce\n2. Expected\n```js\ncode\n```",
+          comments: 3,
+          labels: [{ name: "bug" }],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-03-01T00:00:00Z",
+        },
+      }),
+    },
+  } as unknown as Octokit;
+}
+
+function makeVetter(
+  stateOverrides: Partial<ScoutStateReader> = {},
+): IssueVetter {
+  const octokit = makeMockOctokit();
+  const stateReader = makeStubStateReader(stateOverrides);
+  return new IssueVetter(octokit, stateReader);
+}
+
+const VALID_ISSUE_URL = "https://github.com/owner/repo/issues/1";
+
+// ── vetIssue ──────────────────────────────────────────────────────
+
+describe("IssueVetter", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    // Re-establish default mock implementations after restoreAllMocks
+    vi.mocked(checkNoExistingPR).mockResolvedValue({ passed: true });
+    vi.mocked(checkNotClaimed).mockResolvedValue({ passed: true });
+    vi.mocked(checkUserMergedPRsInRepo).mockResolvedValue(0);
+    vi.mocked(analyzeRequirements).mockReturnValue(true);
+    vi.mocked(checkProjectHealth).mockResolvedValue({
+      repo: "owner/repo",
+      lastCommitAt: new Date().toISOString(),
+      daysSinceLastCommit: 1,
+      openIssuesCount: 10,
+      avgIssueResponseDays: 2,
+      ciStatus: "passing",
+      isActive: true,
+      stargazersCount: 500,
+      forksCount: 50,
+    });
+    vi.mocked(fetchContributionGuidelines).mockResolvedValue({
+      url: "https://github.com/owner/repo/blob/main/CONTRIBUTING.md",
+      content: "Please read before contributing.",
+    });
+    vi.mocked(repoBelongsToCategory).mockReturnValue(false);
+    vi.mocked(isRateLimitError).mockReturnValue(false);
+    vi.mocked(getHttpCache).mockReturnValue({
+      getIfFresh: vi.fn(() => null),
+      set: vi.fn(),
+    } as unknown as ReturnType<typeof getHttpCache>);
+  });
+
+  describe("vetIssue", () => {
+    it("recommends approve when all checks pass", async () => {
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.recommendation).toBe("approve");
+      expect(result.vettingResult.passedAllChecks).toBe(true);
+      expect(result.viabilityScore).toBeGreaterThan(0);
+    });
+
+    it("recommends skip when an existing PR is found", async () => {
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false });
+      vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
+      vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.recommendation).toBe("skip");
+      expect(result.reasonsToSkip).toContain("Has existing PR");
+    });
+
+    it("recommends skip when issue is claimed", async () => {
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false });
+      vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
+      vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.recommendation).toBe("skip");
+      expect(result.reasonsToSkip).toContain("Already claimed");
+    });
+
+    it("recommends skip when 2+ skip reasons exist", async () => {
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false });
+      vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
+      vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      // Has existing PR + Already claimed + Unclear requirements = 3 reasons
+      expect(result.recommendation).toBe("skip");
+      expect(result.reasonsToSkip.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("downgrades approve to needs_review when checks are inconclusive", async () => {
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({
+        passed: true,
+        inconclusive: true,
+        reason: "API error",
+      });
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.recommendation).toBe("needs_review");
+      expect(result.vettingResult.notes).toContain(
+        "Recommendation downgraded: one or more checks were inconclusive",
+      );
+    });
+
+    it("throws ValidationError for invalid URL", async () => {
+      const vetter = makeVetter();
+      await expect(vetter.vetIssue("not-a-url")).rejects.toThrow(
+        "Invalid issue URL",
+      );
+    });
+
+    it("returns cached result within 15min TTL", async () => {
+      const cachedResult: IssueCandidate = {
+        issue: {
+          id: 1,
+          url: VALID_ISSUE_URL,
+          repo: "owner/repo",
+          number: 1,
+          title: "Cached",
+          status: "candidate",
+          labels: [],
+          createdAt: "",
+          updatedAt: "",
+          vetted: true,
+          vettingResult: {
+            passedAllChecks: true,
+            checks: {
+              noExistingPR: true,
+              notClaimed: true,
+              projectActive: true,
+              clearRequirements: true,
+              contributionGuidelinesFound: true,
+            },
+            notes: [],
+          },
+        },
+        vettingResult: {
+          passedAllChecks: true,
+          checks: {
+            noExistingPR: true,
+            notClaimed: true,
+            projectActive: true,
+            clearRequirements: true,
+            contributionGuidelinesFound: true,
+          },
+          notes: [],
+        },
+        projectHealth: {
+          repo: "owner/repo",
+          lastCommitAt: "",
+          daysSinceLastCommit: 1,
+          openIssuesCount: 5,
+          avgIssueResponseDays: 1,
+          ciStatus: "passing",
+          isActive: true,
+        },
+        recommendation: "approve",
+        reasonsToSkip: [],
+        reasonsToApprove: ["Cached"],
+        viabilityScore: 90,
+        searchPriority: "normal",
+      };
+
+      vi.mocked(getHttpCache).mockReturnValue({
+        getIfFresh: vi.fn(() => cachedResult),
+        set: vi.fn(),
+      } as unknown as ReturnType<typeof getHttpCache>);
+
+      const callsBefore = vi.mocked(checkNoExistingPR).mock.calls.length;
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result).toBe(cachedResult);
+      // Verify no NEW calls were made (cache short-circuited)
+      expect(vi.mocked(checkNoExistingPR).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("sets priority to merged_pr when user has merged PRs in repo", async () => {
+      vi.mocked(checkUserMergedPRsInRepo).mockResolvedValueOnce(2);
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.searchPriority).toBe("merged_pr");
+      expect(result.reasonsToApprove).toContainEqual(
+        expect.stringContaining("Trusted project"),
+      );
+    });
+
+    it("adds org affinity reason when user has merged PRs in same org", async () => {
+      const vetter = makeVetter({
+        getReposWithMergedPRs: vi.fn(() => ["owner/other-repo"]),
+      });
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.reasonsToApprove).toContainEqual(
+        expect.stringContaining("Org affinity"),
+      );
+    });
+
+    it("adds category match reason when repo matches preferred category", async () => {
+      vi.mocked(repoBelongsToCategory).mockReturnValueOnce(true);
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.reasonsToApprove).toContain(
+        "Matches preferred project category",
+      );
+    });
+  });
+
+  // ── vetIssuesParallel ─────────────────────────────────────────────
+
+  describe("vetIssuesParallel", () => {
+    it("returns multiple candidates on success", async () => {
+      const vetter = makeVetter();
+      const urls = [
+        "https://github.com/owner/repo/issues/1",
+        "https://github.com/owner/repo/issues/2",
+      ];
+      const result = await vetter.vetIssuesParallel(urls, 10);
+      expect(result.candidates.length).toBe(2);
+      expect(result.allFailed).toBe(false);
+      expect(result.rateLimitHit).toBe(false);
+    });
+
+    it("respects concurrency limit (MAX_CONCURRENT_VETTING=3)", async () => {
+      // Create 5 URLs — only 3 should be in flight at once
+      const urls = Array.from(
+        { length: 5 },
+        (_, i) => `https://github.com/owner/repo/issues/${i + 1}`,
+      );
+
+      let maxConcurrent = 0;
+      let currentConcurrent = 0;
+
+      // Use the real Octokit mock but track concurrency
+      const octokit = makeMockOctokit();
+      vi.mocked(checkNoExistingPR).mockImplementation(async () => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+        await new Promise((r) => setTimeout(r, 10));
+        currentConcurrent--;
+        return { passed: true };
+      });
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      await vetter.vetIssuesParallel(urls, 10);
+      expect(maxConcurrent).toBeLessThanOrEqual(3);
+    });
+
+    it("returns successful candidates when some fail (partial failure)", async () => {
+      const octokit = {
+        issues: {
+          get: vi
+            .fn()
+            .mockResolvedValueOnce({
+              data: {
+                id: 1,
+                html_url: "https://github.com/owner/repo/issues/1",
+                title: "Good issue",
+                body: "1. Step\n2. Step\n```code```",
+                comments: 0,
+                labels: [],
+                created_at: "2026-01-01T00:00:00Z",
+                updated_at: "2026-03-01T00:00:00Z",
+              },
+            })
+            .mockRejectedValueOnce(new Error("Not found")),
+        },
+      } as unknown as Octokit;
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      const result = await vetter.vetIssuesParallel(
+        [
+          "https://github.com/owner/repo/issues/1",
+          "https://github.com/owner/repo/issues/2",
+        ],
+        10,
+      );
+      expect(result.candidates.length).toBe(1);
+      expect(result.allFailed).toBe(false);
+    });
+
+    it("sets allFailed:true when all vetting attempts fail", async () => {
+      const octokit = {
+        issues: {
+          get: vi.fn().mockRejectedValue(new Error("Server error")),
+        },
+      } as unknown as Octokit;
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      const result = await vetter.vetIssuesParallel(
+        [
+          "https://github.com/owner/repo/issues/1",
+          "https://github.com/owner/repo/issues/2",
+        ],
+        10,
+      );
+      expect(result.candidates).toHaveLength(0);
+      expect(result.allFailed).toBe(true);
+    });
+
+    it("sets rateLimitHit:true when failures are rate-limit errors", async () => {
+      vi.mocked(isRateLimitError).mockReturnValue(true);
+
+      const octokit = {
+        issues: {
+          get: vi
+            .fn()
+            .mockRejectedValue(
+              Object.assign(new Error("rate limit exceeded"), { status: 429 }),
+            ),
+        },
+      } as unknown as Octokit;
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      const result = await vetter.vetIssuesParallel(
+        ["https://github.com/owner/repo/issues/1"],
+        10,
+      );
+      expect(result.rateLimitHit).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `issue-discovery.test.ts` (16 tests): phase execution, strategy filtering, budget management, rate limit handling, post-processing, filtering, error handling
- Add `issue-eligibility.test.ts` (21 tests): checkNoExistingPR, checkNotClaimed, checkUserMergedPRsInRepo, analyzeRequirements
- Add `issue-vetting.test.ts` (15 tests): vetIssue recommendation logic, caching, priority assignment, org/category affinity, vetIssuesParallel concurrency and error handling

These test files were lost during a merge conflict and have been recreated from the current source code.

## Test plan
- [x] `pnpm run format` — no formatting issues
- [x] `pnpm run lint` — passes
- [x] `pnpm --filter @oss-scout/core run typecheck` — passes
- [x] `pnpm --filter @oss-scout/core run test` — 437 tests pass across 31 files