### PR TITLE
refactor: remove preferredOrgs / Phase 0.5 feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ oss-scout is a standalone tool for finding open source issues personalized to yo
 - **No singletons in public API.** `OssScout` accepts config via constructor injection. Implements `ScoutStateReader` to bridge state with the search engine.
 - **Two persistence modes:** `'gist'` (standalone, state in private GitHub gist) and `'provided'` (library, caller provides state — used by OSS Autopilot).
 - **Extracted from OSS Autopilot.** Search modules refactored to remove `StateManager` singleton. OSS Autopilot imports `@oss-scout/core` as a dependency.
-- **5-phase search** with configurable strategy selection (merged, orgs, starred, broad, maintained).
+- **4-phase search** with configurable strategy selection (merged, starred, broad, maintained).
 - **Error strategy:** Auth/rate-limit errors propagate. Cache/filesystem errors degrade gracefully with warn logging. Documented in errors.ts.
 
 ### File Structure
@@ -38,7 +38,7 @@ packages/core/src/
 ├── core/                 # Domain logic
 │   ├── schemas.ts        # Zod schemas for ScoutState, ScoutPreferences
 │   ├── types.ts          # Ephemeral types, config interfaces
-│   ├── issue-discovery.ts # 5 extracted phase functions + orchestrator
+│   ├── issue-discovery.ts # 4 extracted phase functions + orchestrator
 │   ├── issue-vetting.ts  # Parallel vetting pipeline + ScoutStateReader
 │   ├── issue-eligibility.ts # PR existence, claim detection, requirements
 │   ├── issue-scoring.ts  # Viability scoring (pure functions, 0-100)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Preferred languages (or "any" for all) [any]: typescript, rust
 Issue labels to search for [good first issue, help wanted]:
 Difficulty scope (beginner, intermediate, advanced) [all]: beginner, intermediate
 Minimum repo stars [50]: 100
-Preferred organizations (comma-separated, optional): myorg, anotherorg
 Project categories (nonprofit, devtools, infrastructure, web-frameworks, data-ml, education) [none]: devtools
 Repos to exclude (owner/repo, comma-separated, optional):
 
@@ -94,12 +93,11 @@ Results are automatically saved. View them later with `oss-scout results`.
 
 ## How Search Works
 
-oss-scout runs five search strategies in priority order:
+oss-scout runs four search strategies in priority order:
 
 | Strategy | Flag | What it searches | Why it matters |
 |----------|------|-----------------|----------------|
 | `merged` | Phase 0 | Repos where you have merged PRs | Highest merge probability |
-| `orgs` | Phase 0.5 | Your preferred organizations | Explicit interest |
 | `starred` | Phase 1 | Your GitHub starred repos | Implicit interest |
 | `broad` | Phase 2 | General label/language filtered | Discovery |
 | `maintained` | Phase 3 | Actively maintained repos by topic | Exploration |
@@ -208,7 +206,6 @@ oss-scout config --json                             # JSON output
 oss-scout config set languages "typescript,rust"    # set languages
 oss-scout config set minStars 100                   # minimum repo stars
 oss-scout config set includeDocIssues false          # exclude doc-only issues
-oss-scout config set preferredOrgs "myorg,anotherorg"
 oss-scout config set excludeRepos "+spam/repo"       # append to exclude list
 oss-scout config set excludeRepos "-spam/repo"       # remove from exclude list
 oss-scout config reset                               # reset to defaults
@@ -227,7 +224,6 @@ oss-scout config reset                               # reset to defaults
 | `minRepoScoreThreshold` | number | 4 | Skip repos scoring below this (1-10) |
 | `excludeRepos` | string[] | [] | Repos to never search |
 | `aiPolicyBlocklist` | string[] | matplotlib/matplotlib | Repos with anti-AI policies |
-| `preferredOrgs` | string[] | [] | Priority organizations for Phase 0.5 |
 | `projectCategories` | enum[] | [] | Topic filter: devtools, web-frameworks, etc. |
 | `persistence` | enum | local | State storage: local or gist |
 
@@ -338,7 +334,7 @@ Setup:
 
 Search:
   search [count]                Search for issues (default: 10)
-    --strategy <s>              Strategies: merged,orgs,starred,broad,maintained,all
+    --strategy <s>              Strategies: merged,starred,broad,maintained,all
   vet <issue-url>               Vet a specific issue
   vet-list                      Re-vet all saved results
     --prune                     Remove unavailable issues

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -47,7 +47,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli
 | Command | Purpose |
 |---------|---------|
 | `search [n] --json` | Search for new issues (n = number of results, default 10) |
-| `search [n] --strategy <s> --json` | Search with specific strategy (merged, orgs, starred, broad, maintained, all) |
+| `search [n] --strategy <s> --json` | Search with specific strategy (merged, starred, broad, maintained, all) |
 | `vet <issue-url> --json` | Deep-vet a specific issue for suitability |
 | `results --json` | Show saved search results |
 | `results clear --json` | Clear saved results |

--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -74,11 +74,6 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config set projectCategories "devtools,infrastructure" --json
 ```
 
-**Preferred Organizations**:
-```bash
-GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config set preferredOrgs "vercel,remix-run" --json
-```
-
 **Excluded Repos** (repos to skip):
 ```bash
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config set excludeRepos "owner/repo1,owner/repo2" --json
@@ -104,7 +99,6 @@ Show summary:
 - **Languages**: [list]
 - **Labels**: [list]
 - **Project Categories**: [list or "No preference"]
-- **Preferred Orgs**: [list or "None"]
 
 ### Next Steps
 - Run `/scout` to search for contribution opportunities

--- a/commands/scout.md
+++ b/commands/scout.md
@@ -48,7 +48,7 @@ The CLI automatically:
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" search 10 --strategy starred --json
 ```
 
-Available strategies: `merged`, `orgs`, `starred`, `broad`, `maintained`, `all` (default).
+Available strategies: `merged`, `starred`, `broad`, `maintained`, `all` (default).
 
 ## Step 3: Present Results
 

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -23,7 +23,6 @@ const FIELD_CONFIGS: Record<string, FieldConfig> = {
   excludeRepos: { type: "array" },
   excludeOrgs: { type: "array" },
   aiPolicyBlocklist: { type: "array" },
-  preferredOrgs: { type: "array" },
   minStars: { type: "number" },
   maxIssueAgeDays: { type: "number" },
   minRepoScoreThreshold: { type: "number" },
@@ -108,7 +107,6 @@ export function runConfigShow(): void {
   console.log(`  maxIssueAgeDays:      ${prefs.maxIssueAgeDays}`);
   console.log(`  minRepoScoreThreshold: ${prefs.minRepoScoreThreshold}`);
   console.log(`  includeDocIssues:     ${prefs.includeDocIssues}`);
-  console.log(`  preferredOrgs:        ${formatArray(prefs.preferredOrgs)}`);
   console.log(
     `  projectCategories:    ${formatArray(prefs.projectCategories)}`,
   );

--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -22,7 +22,6 @@ describe("runSetup", () => {
       "", // labels
       "", // scope
       "", // minStars
-      "", // preferredOrgs
       "", // projectCategories
       "", // excludeRepos
     ]);
@@ -37,7 +36,6 @@ describe("runSetup", () => {
     expect(prefs.labels).toEqual(["good first issue", "help wanted"]);
     expect(prefs.scope).toEqual(["beginner", "intermediate", "advanced"]);
     expect(prefs.minStars).toBe(50);
-    expect(prefs.preferredOrgs).toEqual([]);
     expect(prefs.projectCategories).toEqual([]);
     expect(prefs.excludeRepos).toEqual([]);
   });
@@ -49,7 +47,6 @@ describe("runSetup", () => {
       "bug, enhancement", // labels
       "beginner", // scope
       "100", // minStars
-      "facebook, google", // preferredOrgs
       "devtools, data-ml", // projectCategories
       "owner/repo1, owner/repo2", // excludeRepos
     ]);
@@ -64,7 +61,6 @@ describe("runSetup", () => {
     expect(prefs.labels).toEqual(["bug", "enhancement"]);
     expect(prefs.scope).toEqual(["beginner"]);
     expect(prefs.minStars).toBe(100);
-    expect(prefs.preferredOrgs).toEqual(["facebook", "google"]);
     expect(prefs.projectCategories).toEqual(["devtools", "data-ml"]);
     expect(prefs.excludeRepos).toEqual(["owner/repo1", "owner/repo2"]);
   });
@@ -72,7 +68,6 @@ describe("runSetup", () => {
   it("handles no detected username", async () => {
     const rl = mockReadline([
       "manualuser", // username (no detection)
-      "",
       "",
       "",
       "",
@@ -98,7 +93,6 @@ describe("runSetup", () => {
       "not-a-number", // minStars — should fall back to 50
       "",
       "",
-      "",
     ]);
 
     const prefs = await runSetup({
@@ -118,7 +112,6 @@ describe("runSetup", () => {
       "",
       "",
       "",
-      "",
     ]);
 
     const prefs = await runSetup({
@@ -131,7 +124,6 @@ describe("runSetup", () => {
 
   it("filters invalid category values", async () => {
     const rl = mockReadline([
-      "",
       "",
       "",
       "",

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -131,13 +131,6 @@ export async function runSetup(
     const minStarsInput = await ask(rl, "Minimum repo stars [50]: ");
     const minStars = minStarsInput ? parseInt(minStarsInput, 10) : 50;
 
-    // Preferred organizations
-    const orgsInput = await ask(
-      rl,
-      "Preferred organizations (comma-separated, optional): ",
-    );
-    const preferredOrgs = parseCSV(orgsInput);
-
     // Project categories
     const categoryOptions = ALL_CATEGORIES.join(", ");
     const categoriesInput = await ask(
@@ -159,7 +152,6 @@ export async function runSetup(
       labels,
       scope: scope.length > 0 ? scope : undefined,
       excludeRepos,
-      preferredOrgs,
       projectCategories,
       minStars: isNaN(minStars) ? 50 : minStars,
     });

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -40,11 +40,6 @@ vi.mock("./search-budget.js", () => ({
   })),
 }));
 
-let lastVetterInstance: {
-  vetIssue: ReturnType<typeof vi.fn>;
-  vetIssuesParallel: ReturnType<typeof vi.fn>;
-} | null = null;
-
 vi.mock("./issue-vetting.js", () => ({
   IssueVetter: vi.fn().mockImplementation(function (
     this: Record<string, unknown>,
@@ -55,7 +50,6 @@ vi.mock("./issue-vetting.js", () => ({
       allFailed: false,
       rateLimitHit: false,
     });
-    lastVetterInstance = this as unknown as typeof lastVetterInstance;
   }),
 }));
 
@@ -124,7 +118,7 @@ import type { ScoutPreferences } from "./schemas.js";
 
 function makeCandidate(
   repo: string,
-  priority: "merged_pr" | "preferred_org" | "starred" | "normal" = "normal",
+  priority: "merged_pr" | "starred" | "normal" = "normal",
   recommendation: "approve" | "skip" | "needs_review" = "approve",
   score = 80,
 ): IssueCandidate {
@@ -187,7 +181,6 @@ function makeStateReader(
   return {
     getReposWithMergedPRs: vi.fn(() => []),
     getStarredRepos: vi.fn(() => []),
-    getPreferredOrgs: vi.fn(() => []),
     getProjectCategories: vi.fn(() => []),
     getRepoScore: vi.fn(() => null),
     ...overrides,
@@ -276,37 +269,6 @@ describe("IssueDiscovery", () => {
         "merged_pr",
         expect.any(Function),
       );
-    });
-
-    it("Phase 0.5: calls searchWithChunkedLabels for preferred orgs", async () => {
-      const c = makeCandidate("preferred-org/repo", "preferred_org");
-      mockSearchWithChunkedLabels.mockResolvedValue([
-        {
-          html_url: "https://github.com/preferred-org/repo/issues/1",
-          repository_url: "https://api.github.com/repos/preferred-org/repo",
-          updated_at: "2026-01-01T00:00:00Z",
-        },
-      ]);
-
-      const discovery = makeDiscovery(
-        {
-          getReposWithMergedPRs: vi.fn(() => []),
-        },
-        {
-          preferredOrgs: ["preferred-org"],
-        },
-      );
-
-      // After constructing discovery, configure the vetter mock to return candidates
-      lastVetterInstance!.vetIssuesParallel.mockResolvedValue({
-        candidates: [c],
-        allFailed: false,
-        rateLimitHit: false,
-      });
-
-      const { candidates } = await discovery.searchIssues({ maxResults: 5 });
-      expect(mockSearchWithChunkedLabels).toHaveBeenCalled();
-      expect(candidates.length).toBeGreaterThanOrEqual(1);
     });
 
     it("Phase 1: calls searchInRepos with starred repos, priority starred", async () => {

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -140,75 +140,6 @@ async function runPhase0(
   };
 }
 
-/** Phase 0.5: Search preferred organizations. */
-async function runPhase05(
-  octokit: Octokit,
-  vetter: IssueVetter,
-  orgsToSearch: string[],
-  baseQualifiers: string,
-  labels: string[],
-  maxResults: number,
-  phase0RepoSet: Set<string>,
-  filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
-): Promise<PhaseResult> {
-  info(
-    MODULE,
-    `Phase 0.5: Searching issues in ${orgsToSearch.length} preferred org(s)...`,
-  );
-
-  const orgRepoFilter = orgsToSearch.map((org) => `org:${org}`).join(" OR ");
-  const orgOps = orgsToSearch.length - 1;
-
-  try {
-    const allItems = await searchWithChunkedLabels(
-      octokit,
-      labels,
-      orgOps,
-      (labelQ) =>
-        `${baseQualifiers} ${labelQ} (${orgRepoFilter})`
-          .replace(/  +/g, " ")
-          .trim(),
-      maxResults * 3,
-    );
-
-    if (allItems.length === 0) {
-      return { candidates: [], error: null, rateLimitHit: false };
-    }
-
-    const filtered = filterIssues(allItems).filter((item) => {
-      const repoFullName = extractRepoFromUrl(item.repository_url);
-      if (!repoFullName) return false;
-      return !phase0RepoSet.has(repoFullName);
-    });
-
-    const {
-      candidates,
-      allFailed: allVetFailed,
-      rateLimitHit,
-    } = await vetter.vetIssuesParallel(
-      filtered.slice(0, maxResults * 2).map((i) => i.html_url),
-      maxResults,
-      "preferred_org",
-    );
-
-    info(MODULE, `Found ${candidates.length} candidates from preferred orgs`);
-
-    return {
-      candidates,
-      error: allVetFailed ? "All preferred org issue vetting failed" : null,
-      rateLimitHit,
-    };
-  } catch (error) {
-    const errMsg = errorMessage(error);
-    warn(MODULE, `Error searching preferred orgs: ${errMsg}`);
-    return {
-      candidates: [],
-      error: errMsg,
-      rateLimitHit: isRateLimitError(error),
-    };
-  }
-}
-
 /** Phase 1: Search starred repos. */
 async function runPhase1(
   octokit: Octokit,
@@ -436,7 +367,6 @@ async function runPhase3(
  *
  * Search phases (in priority order):
  * 0. Repos where user has merged PRs (highest merge probability)
- * 0.5. Preferred organizations
  * 1. Starred repos
  * 2. General label-filtered search
  * 3. Actively maintained repos
@@ -476,8 +406,8 @@ export class IssueDiscovery {
 
   /**
    * Search for issues matching our criteria.
-   * Searches in priority order: merged-PR repos first (no label filter), then preferred
-   * organizations, then starred repos, then general search, then actively maintained repos.
+   * Searches in priority order: merged-PR repos first (no label filter), then starred
+   * repos, then general search, then actively maintained repos.
    * Filters out issues from low-scoring and excluded repos.
    *
    * @param options - Search configuration
@@ -636,41 +566,6 @@ export class IssueDiscovery {
       strategiesUsed.push("merged");
     }
 
-    // Phase 0.5: Preferred organizations
-    const preferredOrgs = config.preferredOrgs ?? [];
-    if (
-      allCandidates.length < maxResults &&
-      preferredOrgs.length > 0 &&
-      searchBudget >= CRITICAL_BUDGET_THRESHOLD &&
-      enabledStrategies.has("orgs")
-    ) {
-      if (phase0Repos.length > 0) await sleep(INTER_PHASE_DELAY_MS);
-      const phase0Orgs = new Set(
-        phase0Repos.map((r) => r.split("/")[0]?.toLowerCase()),
-      );
-      const orgsToSearch = preferredOrgs
-        .filter((org) => !phase0Orgs.has(org.toLowerCase()))
-        .slice(0, 5);
-
-      if (orgsToSearch.length > 0) {
-        const remaining = maxResults - allCandidates.length;
-        const result = await runPhase05(
-          this.octokit,
-          this.vetter,
-          orgsToSearch,
-          baseQualifiers,
-          labels,
-          remaining,
-          phase0RepoSet,
-          filterIssues,
-        );
-        allCandidates.push(...result.candidates);
-        phaseErrors["0.5"] = result.error;
-        if (result.rateLimitHit) rateLimitHitDuringSearch = true;
-      }
-      strategiesUsed.push("orgs");
-    }
-
     // Phase 1: Starred repos
     if (
       allCandidates.length < maxResults &&
@@ -768,9 +663,6 @@ export class IssueDiscovery {
         phaseErrors["0"]
           ? `Phase 0 (merged-PR repos): ${phaseErrors["0"]}`
           : null,
-        phaseErrors["0.5"]
-          ? `Phase 0.5 (preferred orgs): ${phaseErrors["0.5"]}`
-          : null,
         phaseErrors["1"]
           ? `Phase 1 (starred repos): ${phaseErrors["1"]}`
           : null,
@@ -806,9 +698,8 @@ export class IssueDiscovery {
     allCandidates.sort((a, b) => {
       const priorityOrder: Record<SearchPriority, number> = {
         merged_pr: 0,
-        preferred_org: 1,
-        starred: 2,
-        normal: 3,
+        starred: 1,
+        normal: 2,
       };
       const priorityDiff =
         priorityOrder[a.searchPriority] - priorityOrder[b.searchPriority];

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -103,7 +103,6 @@ function makeStubStateReader(
   return {
     getReposWithMergedPRs: vi.fn(() => []),
     getStarredRepos: vi.fn(() => []),
-    getPreferredOrgs: vi.fn(() => []),
     getProjectCategories: vi.fn(() => []),
     getRepoScore: vi.fn(() => null),
     ...overrides,

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -52,8 +52,6 @@ export interface ScoutStateReader {
   getReposWithMergedPRs(): string[];
   /** User's starred repos (from GitHub). */
   getStarredRepos(): string[];
-  /** Preferred GitHub orgs from user preferences. */
-  getPreferredOrgs(): string[];
   /** Preferred project categories from user preferences. */
   getProjectCategories(): ProjectCategory[];
   /** Numeric quality score for a repo, or null if not evaluated. */
@@ -295,14 +293,9 @@ export class IssueVetter {
     });
 
     const starredRepos = this.stateReader.getStarredRepos();
-    const preferredOrgs = this.stateReader.getPreferredOrgs();
     let searchPriority: SearchPriority = "normal";
     if (effectiveMergedCount > 0) {
       searchPriority = "merged_pr";
-    } else if (
-      preferredOrgs.some((o) => o.toLowerCase() === orgName?.toLowerCase())
-    ) {
-      searchPriority = "preferred_org";
     } else if (starredRepos.includes(repoFullName)) {
       searchPriority = "starred";
     }

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -99,7 +99,6 @@ describe("ScoutPreferencesSchema", () => {
     expect(prefs.languages).toEqual(["any"]);
     expect(prefs.labels).toEqual(["good first issue", "help wanted"]);
     expect(prefs.excludeRepos).toEqual([]);
-    expect(prefs.preferredOrgs).toEqual([]);
     expect(prefs.projectCategories).toEqual([]);
   });
 

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -32,7 +32,6 @@ export const IssueScopeSchema = z.enum([
 
 export const SearchStrategySchema = z.enum([
   "merged",
-  "orgs",
   "starred",
   "broad",
   "maintained",
@@ -42,7 +41,6 @@ export const SearchStrategySchema = z.enum([
 /** All concrete strategies (excludes 'all' meta-strategy). */
 export const CONCRETE_STRATEGIES = [
   "merged",
-  "orgs",
   "starred",
   "broad",
   "maintained",
@@ -155,7 +153,6 @@ export const ScoutPreferencesSchema = z.object({
   excludeRepos: z.array(z.string()).default([]),
   excludeOrgs: z.array(z.string()).default([]),
   aiPolicyBlocklist: z.array(z.string()).default(["matplotlib/matplotlib"]),
-  preferredOrgs: z.array(z.string()).default([]),
   projectCategories: z.array(ProjectCategorySchema).default([]),
   minStars: z.number().default(50),
   maxIssueAgeDays: z.number().default(90),

--- a/packages/core/src/core/strategy-selection.test.ts
+++ b/packages/core/src/core/strategy-selection.test.ts
@@ -132,8 +132,7 @@ function makeFakeCandidate(repo: string, priority: string) {
 // ── Import after mocks ─────────────────────────────────────────────
 
 const { IssueDiscovery } = await import("./issue-discovery.js");
-const { searchInRepos, searchWithChunkedLabels } =
-  await import("./search-phases.js");
+const { searchInRepos } = await import("./search-phases.js");
 
 const basePreferences = {
   githubUsername: "test",
@@ -141,7 +140,6 @@ const basePreferences = {
   labels: ["good first issue"],
   excludeRepos: [],
   aiPolicyBlocklist: [],
-  preferredOrgs: [],
   projectCategories: [],
   minStars: 50,
   maxIssueAgeDays: 90,
@@ -152,7 +150,6 @@ const basePreferences = {
 const baseStateReader = {
   getReposWithMergedPRs: () => [] as string[],
   getStarredRepos: () => [] as string[],
-  getPreferredOrgs: () => [] as string[],
   getProjectCategories: () => [] as string[],
   getRepoScore: () => null,
 };
@@ -196,26 +193,6 @@ describe("Strategy Selection", () => {
     expect(searchInRepos).toHaveBeenCalledTimes(1);
   });
 
-  it("only runs orgs strategy when specified", async () => {
-    const prefs = { ...basePreferences, preferredOrgs: ["myorg"] };
-    const discovery = new IssueDiscovery("token", prefs, baseStateReader);
-    (searchWithChunkedLabels as ReturnType<typeof vi.fn>).mockResolvedValue([
-      {
-        html_url: "https://github.com/myorg/repo/issues/1",
-        repository_url: "https://api.github.com/repos/myorg/repo",
-        updated_at: new Date().toISOString(),
-      },
-    ]);
-    mockVetIssuesParallel.mockResolvedValue({
-      candidates: [makeFakeCandidate("myorg/repo", "preferred_org")],
-      allFailed: false,
-      rateLimitHit: false,
-    });
-    const result = await discovery.searchIssues({ strategies: ["orgs"] });
-    expect(result.strategiesUsed).toEqual(["orgs"]);
-    expect(searchInRepos).not.toHaveBeenCalled();
-  });
-
   it("only runs starred strategy when specified", async () => {
     const stateReader = {
       ...baseStateReader,
@@ -233,13 +210,12 @@ describe("Strategy Selection", () => {
   });
 
   it('runs all strategies when "all" is specified', async () => {
-    const prefs = { ...basePreferences, preferredOrgs: ["myorg"] };
     const stateReader = {
       ...baseStateReader,
       getReposWithMergedPRs: () => ["owner/repo"],
       getStarredRepos: () => ["owner/starred"],
     };
-    const discovery = new IssueDiscovery("token", prefs, stateReader);
+    const discovery = new IssueDiscovery("token", basePreferences, stateReader);
     const result = await discovery.searchIssues({
       strategies: ["all"],
       maxResults: 100,
@@ -333,6 +309,6 @@ describe("SearchStrategySchema", () => {
 
   it('CONCRETE_STRATEGIES excludes "all"', () => {
     expect(CONCRETE_STRATEGIES).not.toContain("all");
-    expect(CONCRETE_STRATEGIES).toHaveLength(5);
+    expect(CONCRETE_STRATEGIES).toHaveLength(4);
   });
 });

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -47,11 +47,7 @@ export interface ProjectHealth {
 }
 
 /** Priority tier for issue search results. */
-export type SearchPriority =
-  | "merged_pr"
-  | "preferred_org"
-  | "starred"
-  | "normal";
+export type SearchPriority = "merged_pr" | "starred" | "normal";
 
 /** A fully vetted issue candidate with scoring. */
 export interface IssueCandidate {

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -22,7 +22,6 @@ describe("createScout", () => {
         labels: ["help wanted"],
         excludeRepos: [],
         aiPolicyBlocklist: [],
-        preferredOrgs: [],
         projectCategories: [],
         minStars: 100,
         maxIssueAgeDays: 60,
@@ -50,7 +49,6 @@ describe("OssScout", () => {
       const scout = makeScout();
       expect(scout.getReposWithMergedPRs()).toEqual([]);
       expect(scout.getStarredRepos()).toEqual([]);
-      expect(scout.getPreferredOrgs()).toEqual([]);
     });
 
     it("returns preferences", () => {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -292,10 +292,6 @@ export class OssScout implements ScoutStateReader {
     return this.state.starredRepos;
   }
 
-  getPreferredOrgs(): string[] {
-    return this.state.preferences.preferredOrgs;
-  }
-
   getProjectCategories(): ProjectCategory[] {
     return this.state.preferences.projectCategories;
   }

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -32,7 +32,7 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         .string()
         .optional()
         .describe(
-          "Comma-separated search strategies: merged, orgs, starred, broad, maintained, all",
+          "Comma-separated search strategies: merged, starred, broad, maintained, all",
         ),
     },
     async ({ maxResults, strategies }) => {
@@ -107,7 +107,6 @@ export function registerTools(server: McpServer, scout: OssScout): void {
   const ARRAY_KEYS = new Set([
     "languages",
     "labels",
-    "preferredOrgs",
     "projectCategories",
     "excludeRepos",
     "excludeOrgs",

--- a/skills/oss-search/SKILL.md
+++ b/skills/oss-search/SKILL.md
@@ -8,7 +8,7 @@ version: 1.1.0
 
 ## Multi-Strategy Search
 
-OSS Scout uses five search strategies, run as phases in priority order. Each targets a different source of issues. Use `--strategy` to select specific strategies or `all` (default) to run them all.
+OSS Scout uses four search strategies, run as phases in priority order. Each targets a different source of issues. Use `--strategy` to select specific strategies or `all` (default) to run them all.
 
 ### Strategy: `merged` (Phase 0)
 
@@ -18,15 +18,6 @@ Searches repos where you have previously had PRs merged.
 
 **Strengths:** Highest merge probability, established trust with maintainers.
 **Weaknesses:** Only works if you have prior contribution history.
-
-### Strategy: `orgs` (Phase 0.5)
-
-Searches your preferred organizations (configured via `oss-scout config set preferredOrgs`).
-
-**When to use:** When you have specific orgs you want to contribute to.
-
-**Strengths:** Targeted to orgs you care about.
-**Weaknesses:** Requires explicit configuration.
 
 ### Strategy: `starred` (Phase 1)
 
@@ -71,7 +62,7 @@ oss-scout search --strategy merged,starred
 oss-scout config set defaultStrategy "merged,starred"
 ```
 
-The `all` strategy runs phases in order: merged (0) -> orgs (0.5) -> starred (1) -> broad (2) -> maintained (3). Results are deduplicated and sorted by priority, then recommendation, then score. Rate-limit-aware: heavy phases (broad, maintained) are skipped when API budget is low.
+The `all` strategy runs phases in order: merged (0) -> starred (1) -> broad (2) -> maintained (3). Results are deduplicated and sorted by priority, then recommendation, then score. Rate-limit-aware: heavy phases (broad, maintained) are skipped when API budget is low.
 
 ## Viability Scoring (0-100)
 
@@ -139,7 +130,7 @@ Or use the CLI directly for specific strategies.
 
 Look at the top-scored issues. Pay attention to:
 - Viability score and recommendation
-- Search priority (merged_pr > preferred_org > starred > normal)
+- Search priority (merged_pr > starred > normal)
 - Reasons to approve vs. skip
 
 ### 3. Deep Vet


### PR DESCRIPTION
## Summary

- Removes the preferred organizations feature (Phase 0.5 search strategy) entirely
- Users can star repos they care about instead, which feeds the existing starred strategy
- Removes `preferredOrgs` from preferences schema, `'orgs'` from search strategies, `'preferred_org'` from priority types, and the `getPreferredOrgs()` interface method
- Updates all documentation, plugin commands/agents/skills, and test fixtures

## Changes across 20 files

**Core logic:** schemas.ts, types.ts, issue-discovery.ts, issue-vetting.ts, scout.ts
**Commands:** setup.ts, config.ts
**MCP server:** tools.ts
**Docs:** README.md, CLAUDE.md, SKILL.md, issue-scout.md, scout.md, scout-setup.md
**Tests:** 6 test files updated — all 450 tests pass

## Test plan

- [x] `pnpm run format` — clean
- [x] `pnpm run lint` — no errors
- [x] `pnpm --filter @oss-scout/core run typecheck` — passes
- [x] `pnpm --filter @oss-scout/mcp run typecheck` — passes
- [x] `pnpm --filter @oss-scout/core run test` — 434 tests pass
- [x] `pnpm --filter @oss-scout/mcp run test` — 16 tests pass