### PR TITLE
feat: add skip list with 90-day auto-cull, search filtering, and CLI/MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,19 @@ oss-scout results clear       # wipe saved results
 oss-scout vet-list --prune    # re-vet and remove stale issues
 ```
 
+### Skip list
+
+Skip issues you don't want to see again. Skipped issues are excluded from future search results and auto-expire after 90 days.
+
+```bash
+oss-scout skip add https://github.com/owner/repo/issues/123    # skip an issue
+oss-scout skip list                                              # show skipped issues
+oss-scout skip remove https://github.com/owner/repo/issues/123  # unskip
+oss-scout skip clear                                             # clear all skips
+```
+
+Skipping an issue also removes it from saved results. When you skip an issue that was in your saved results, metadata (repo, title, number) is preserved in the skip entry for context.
+
 ### Cross-machine sync with gist persistence
 
 Enable gist persistence to sync your state (preferences, repo scores, PR history, saved results) across machines via a private GitHub gist:
@@ -266,7 +279,7 @@ Agents (dispatched automatically by Claude):
 }
 ```
 
-**Tools:** search, vet, config, config-set
+**Tools:** search, vet, skip, config, config-set
 **Resources:** scout://config, scout://results, scout://scores
 
 ### As a Library
@@ -343,6 +356,12 @@ Search:
 Results:
   results                       Show saved search results
   results clear                 Clear saved results
+
+Skip:
+  skip add <issue-url>          Skip an issue (exclude from searches)
+  skip list                     Show all skipped issues
+  skip remove <issue-url>       Unskip an issue
+  skip clear                    Clear all skipped issues
 
 Config:
   config                        Show current preferences

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -53,6 +53,10 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli
 | `results clear --json` | Clear saved results |
 | `vet-list --json` | Re-vet all saved results for availability |
 | `vet-list --prune --json` | Re-vet and remove unavailable issues |
+| `skip add <issue-url> --json` | Skip an issue (exclude from future searches) |
+| `skip list --json` | Show all skipped issues |
+| `skip remove <issue-url> --json` | Unskip a specific issue |
+| `skip clear --json` | Clear all skipped issues |
 
 **Search for Issues:**
 ```bash

--- a/commands/scout.md
+++ b/commands/scout.md
@@ -92,19 +92,29 @@ After presenting results, offer:
    GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" vet https://github.com/owner/repo/issues/123 --json
    ```
 
-2. **"Search again"** — Run another search with different parameters (more results, different strategy)
+2. **"Skip an issue"** — Skip an issue to exclude it from future searches (auto-expires after 90 days):
+   ```bash
+   GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" skip add https://github.com/owner/repo/issues/123 --json
+   ```
 
-3. **"View saved results"** — Show previously saved search results:
+3. **"Search again"** — Run another search with different parameters (more results, different strategy)
+
+4. **"View saved results"** — Show previously saved search results:
    ```bash
    GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" results --json
    ```
 
-4. **"Re-vet saved results"** — Check availability of all saved results:
+5. **"Re-vet saved results"** — Check availability of all saved results:
    ```bash
    GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" vet-list --json
    ```
 
-5. **"Done"** — End the search session
+6. **"View skip list"** — Show issues excluded from search:
+   ```bash
+   GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" skip list --json
+   ```
+
+7. **"Done"** — End the search session
 
 ## Error Handling
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -390,6 +390,114 @@ program
     },
   );
 
+// ── skip command ───────────────────────────────────────────────────
+
+const skipCmd = program
+  .command("skip")
+  .description("Manage the skip list — exclude issues from future searches");
+
+skipCmd
+  .command("add <issue-url>")
+  .description("Skip an issue by URL")
+  .option("--json", "Output as JSON")
+  .action(async (issueUrl: string, options: { json?: boolean }) => {
+    try {
+      const { runSkip } = await import("./commands/skip.js");
+      const state = loadLocalState();
+      const result = runSkip({ issueUrl, state });
+      if (options.json) {
+        console.log(formatJsonSuccess(result));
+      } else {
+        if (result.alreadySkipped) {
+          console.log("Issue already in skip list.");
+        } else {
+          console.log(`Skipped: ${issueUrl}`);
+        }
+      }
+    } catch (err) {
+      handleCommandError(err, options);
+    }
+  });
+
+skipCmd
+  .command("list")
+  .description("Show all skipped issues")
+  .option("--json", "Output as JSON")
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const { runSkipList } = await import("./commands/skip.js");
+      const results = runSkipList();
+      if (options.json) {
+        console.log(formatJsonSuccess(results));
+      } else {
+        if (results.length === 0) {
+          console.log("\nNo skipped issues.\n");
+          return;
+        }
+        console.log(`\nSkipped issues (${results.length}):\n`);
+        console.log(
+          "  Repo                              Issue   Skipped     Title",
+        );
+        console.log(
+          "  ────────────────────────────────  ──────  ──────────  ─────",
+        );
+        for (const s of results) {
+          const repo = (s.repo || "unknown").padEnd(32).slice(0, 32);
+          const issue = s.number ? `#${s.number}`.padEnd(6) : "—".padEnd(6);
+          const skippedDate = s.skippedAt.split("T")[0] ?? "";
+          const title =
+            s.title.length > 50
+              ? s.title.slice(0, 47) + "..."
+              : s.title || s.url;
+          console.log(`  ${repo}  ${issue}  ${skippedDate}  ${title}`);
+        }
+        console.log();
+      }
+    } catch (err) {
+      handleCommandError(err, options);
+    }
+  });
+
+skipCmd
+  .command("remove <issue-url>")
+  .description("Remove an issue from the skip list (unskip)")
+  .option("--json", "Output as JSON")
+  .action(async (issueUrl: string, options: { json?: boolean }) => {
+    try {
+      const { runSkipRemove } = await import("./commands/skip.js");
+      const result = runSkipRemove({ issueUrl });
+      if (options.json) {
+        console.log(formatJsonSuccess(result));
+      } else {
+        if (result.removed) {
+          console.log(`Removed from skip list: ${issueUrl}`);
+        } else {
+          console.log("Issue was not in the skip list.");
+        }
+      }
+    } catch (err) {
+      handleCommandError(err, options);
+    }
+  });
+
+skipCmd
+  .command("clear")
+  .description("Clear all skipped issues")
+  .option("--json", "Output as JSON")
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const { runSkipClear } = await import("./commands/skip.js");
+      runSkipClear();
+      if (options.json) {
+        console.log(formatJsonSuccess({ cleared: true }));
+      } else {
+        console.log("Skip list cleared.");
+      }
+    } catch (err) {
+      handleCommandError(err, options);
+    }
+  });
+
 program
   .command("vet <issue-url>")
   .description(

--- a/packages/core/src/commands/skip.test.ts
+++ b/packages/core/src/commands/skip.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ScoutStateSchema } from "../core/schemas.js";
+import type { SavedCandidate } from "../core/schemas.js";
+
+// Mock local-state module
+vi.mock("../core/local-state.js", () => {
+  let mockState: any = { version: 1, skippedIssues: [], savedResults: [] };
+  return {
+    loadLocalState: () => mockState,
+    saveLocalState: (state: any) => {
+      mockState = state;
+    },
+    hasLocalState: () => true,
+    _setMockState: (state: any) => {
+      mockState = state;
+    },
+    _getMockState: () => mockState,
+  };
+});
+
+const { runSkip, runSkipList, runSkipClear, runSkipRemove } =
+  await import("./skip.js");
+
+async function setMockState(state: any) {
+  const mod = (await import("../core/local-state.js")) as any;
+  mod._setMockState(state);
+}
+
+async function getMockState(): Promise<any> {
+  const mod = (await import("../core/local-state.js")) as any;
+  return mod._getMockState();
+}
+
+function makeSavedCandidate(
+  overrides: Partial<SavedCandidate> = {},
+): SavedCandidate {
+  return {
+    issueUrl: "https://github.com/owner/repo/issues/1",
+    repo: "owner/repo",
+    number: 1,
+    title: "Fix the bug",
+    labels: ["good first issue"],
+    recommendation: "approve",
+    viabilityScore: 75,
+    searchPriority: "normal",
+    firstSeenAt: "2026-03-01T00:00:00.000Z",
+    lastSeenAt: "2026-03-01T00:00:00.000Z",
+    lastScore: 75,
+    ...overrides,
+  };
+}
+
+describe("skip command", () => {
+  beforeEach(async () => {
+    const freshState = ScoutStateSchema.parse({ version: 1 });
+    await setMockState(freshState);
+  });
+
+  describe("runSkip", () => {
+    it("adds an issue to the skip list", async () => {
+      const result = runSkip({
+        issueUrl: "https://github.com/owner/repo/issues/1",
+      });
+      expect(result.skipped).toBe(true);
+      expect(result.alreadySkipped).toBe(false);
+
+      const state = await getMockState();
+      expect(state.skippedIssues).toHaveLength(1);
+      expect(state.skippedIssues[0].url).toBe(
+        "https://github.com/owner/repo/issues/1",
+      );
+      expect(state.skippedIssues[0].repo).toBe("owner/repo");
+      expect(state.skippedIssues[0].number).toBe(1);
+    });
+
+    it("deduplicates — same URL not added twice", async () => {
+      const url = "https://github.com/owner/repo/issues/1";
+      runSkip({ issueUrl: url });
+      const result = runSkip({ issueUrl: url });
+
+      expect(result.skipped).toBe(false);
+      expect(result.alreadySkipped).toBe(true);
+
+      const state = await getMockState();
+      expect(state.skippedIssues).toHaveLength(1);
+    });
+
+    it("removes issue from saved results when skipping", async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      const url = "https://github.com/owner/repo/issues/1";
+      state.savedResults = [makeSavedCandidate({ issueUrl: url })];
+      await setMockState(state);
+
+      runSkip({ issueUrl: url, state });
+
+      const updated = await getMockState();
+      expect(updated.savedResults).toHaveLength(0);
+      expect(updated.skippedIssues).toHaveLength(1);
+    });
+
+    it("enriches metadata from saved results", async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      const url = "https://github.com/owner/repo/issues/42";
+      state.savedResults = [
+        makeSavedCandidate({
+          issueUrl: url,
+          repo: "owner/repo",
+          number: 42,
+          title: "Important bug",
+        }),
+      ];
+      await setMockState(state);
+
+      runSkip({ issueUrl: url, state });
+
+      const updated = await getMockState();
+      expect(updated.skippedIssues[0].repo).toBe("owner/repo");
+      expect(updated.skippedIssues[0].number).toBe(42);
+      expect(updated.skippedIssues[0].title).toBe("Important bug");
+    });
+  });
+
+  describe("runSkipList", () => {
+    it("returns empty array when no skipped issues", () => {
+      const results = runSkipList();
+      expect(results).toEqual([]);
+    });
+
+    it("returns skipped issues from state", async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      state.skippedIssues = [
+        {
+          url: "https://github.com/a/b/issues/1",
+          repo: "a/b",
+          number: 1,
+          title: "Test",
+          skippedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ];
+      await setMockState(state);
+
+      const results = runSkipList();
+      expect(results).toHaveLength(1);
+      expect(results[0].url).toBe("https://github.com/a/b/issues/1");
+    });
+  });
+
+  describe("runSkipRemove", () => {
+    it("removes a specific issue from the skip list", async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      const url = "https://github.com/a/b/issues/1";
+      state.skippedIssues = [
+        {
+          url,
+          repo: "a/b",
+          number: 1,
+          title: "Test",
+          skippedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ];
+      await setMockState(state);
+
+      const result = runSkipRemove({ issueUrl: url });
+      expect(result.removed).toBe(true);
+
+      const updated = await getMockState();
+      expect(updated.skippedIssues).toHaveLength(0);
+    });
+
+    it("returns removed=false for unknown URL", () => {
+      const result = runSkipRemove({
+        issueUrl: "https://github.com/x/y/issues/999",
+      });
+      expect(result.removed).toBe(false);
+    });
+  });
+
+  describe("runSkipClear", () => {
+    it("clears all skipped issues", async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      state.skippedIssues = [
+        {
+          url: "https://github.com/a/b/issues/1",
+          repo: "a/b",
+          number: 1,
+          title: "Test",
+          skippedAt: "2026-03-01T00:00:00.000Z",
+        },
+        {
+          url: "https://github.com/c/d/issues/2",
+          repo: "c/d",
+          number: 2,
+          title: "Another",
+          skippedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ];
+      await setMockState(state);
+
+      runSkipClear();
+
+      const updated = await getMockState();
+      expect(updated.skippedIssues).toEqual([]);
+    });
+
+    it("is a no-op when already empty", async () => {
+      runSkipClear();
+      const updated = await getMockState();
+      expect(updated.skippedIssues).toEqual([]);
+    });
+  });
+});
+
+describe("OssScout skip methods", () => {
+  it("skipIssue adds to list and marks dirty", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout("fake-token", state);
+
+    scout.skipIssue("https://github.com/a/b/issues/1", {
+      repo: "a/b",
+      number: 1,
+      title: "Test",
+    });
+
+    expect(scout.getSkippedIssues()).toHaveLength(1);
+    expect(scout.isDirty()).toBe(true);
+  });
+
+  it("skipIssue deduplicates", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout("fake-token", state);
+
+    scout.skipIssue("https://github.com/a/b/issues/1");
+    scout.skipIssue("https://github.com/a/b/issues/1");
+
+    expect(scout.getSkippedIssues()).toHaveLength(1);
+  });
+
+  it("skipIssue removes from saved results", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout("fake-token", state);
+
+    // Save a result first
+    scout.saveResults([
+      {
+        issue: {
+          id: 1,
+          url: "https://github.com/a/b/issues/1",
+          repo: "a/b",
+          number: 1,
+          title: "Test",
+          status: "candidate" as const,
+          labels: [],
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          vetted: false,
+        },
+        vettingResult: {
+          passedAllChecks: true,
+          checks: {
+            noExistingPR: true,
+            notClaimed: true,
+            projectActive: true,
+            clearRequirements: true,
+            contributionGuidelinesFound: true,
+          },
+          notes: [],
+        },
+        projectHealth: {
+          repo: "a/b",
+          lastCommitAt: "2026-03-01T00:00:00.000Z",
+          daysSinceLastCommit: 1,
+          openIssuesCount: 10,
+          avgIssueResponseDays: 2,
+          ciStatus: "passing" as const,
+          isActive: true,
+        },
+        recommendation: "approve" as const,
+        reasonsToSkip: [],
+        reasonsToApprove: [],
+        viabilityScore: 60,
+        searchPriority: "normal" as const,
+      },
+    ]);
+    expect(scout.getSavedResults()).toHaveLength(1);
+
+    scout.skipIssue("https://github.com/a/b/issues/1");
+    expect(scout.getSavedResults()).toHaveLength(0);
+    expect(scout.getSkippedIssues()).toHaveLength(1);
+  });
+
+  it("unskipIssue removes specific issue", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout("fake-token", state);
+
+    scout.skipIssue("https://github.com/a/b/issues/1");
+    scout.skipIssue("https://github.com/c/d/issues/2");
+    expect(scout.getSkippedIssues()).toHaveLength(2);
+
+    scout.unskipIssue("https://github.com/a/b/issues/1");
+    expect(scout.getSkippedIssues()).toHaveLength(1);
+    expect(scout.getSkippedIssues()[0].url).toBe(
+      "https://github.com/c/d/issues/2",
+    );
+  });
+
+  it("clearSkippedIssues empties the list", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout("fake-token", state);
+
+    scout.skipIssue("https://github.com/a/b/issues/1");
+    scout.skipIssue("https://github.com/c/d/issues/2");
+    expect(scout.getSkippedIssues()).toHaveLength(2);
+
+    scout.clearSkippedIssues();
+    expect(scout.getSkippedIssues()).toHaveLength(0);
+  });
+
+  it("cullExpiredSkips removes old entries and keeps recent ones", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout("fake-token", state);
+
+    // Add an old skip (100 days ago)
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 100);
+    state.skippedIssues = [
+      {
+        url: "https://github.com/old/repo/issues/1",
+        repo: "old/repo",
+        number: 1,
+        title: "Old issue",
+        skippedAt: oldDate.toISOString(),
+      },
+    ];
+
+    // Add a recent skip
+    scout.skipIssue("https://github.com/new/repo/issues/2", {
+      repo: "new/repo",
+      number: 2,
+      title: "New issue",
+    });
+
+    expect(scout.getSkippedIssues()).toHaveLength(2);
+
+    const culled = scout.cullExpiredSkips(90);
+    expect(culled).toBe(1);
+    expect(scout.getSkippedIssues()).toHaveLength(1);
+    expect(scout.getSkippedIssues()[0].url).toBe(
+      "https://github.com/new/repo/issues/2",
+    );
+  });
+
+  it("cullExpiredSkips returns 0 when nothing to cull", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    const scout = new OssScout("fake-token", state);
+
+    scout.skipIssue("https://github.com/a/b/issues/1");
+    const culled = scout.cullExpiredSkips(90);
+    expect(culled).toBe(0);
+  });
+});

--- a/packages/core/src/commands/skip.ts
+++ b/packages/core/src/commands/skip.ts
@@ -1,0 +1,82 @@
+/**
+ * Skip command — manage the skip list for excluding issues from future searches.
+ */
+
+import { loadLocalState, saveLocalState } from "../core/local-state.js";
+import type { SkippedIssue, ScoutState } from "../core/schemas.js";
+import { OssScout } from "../scout.js";
+
+/**
+ * Skip an issue by URL — adds it to the skip list and removes it from saved results.
+ * Tries to enrich metadata from saved results if available.
+ */
+export function runSkip(options: { issueUrl: string; state?: ScoutState }): {
+  skipped: boolean;
+  alreadySkipped: boolean;
+} {
+  const state = options.state ?? loadLocalState();
+  const scout = new OssScout("", state);
+
+  const alreadySkipped = scout
+    .getSkippedIssues()
+    .some((s) => s.url === options.issueUrl);
+  if (alreadySkipped) {
+    return { skipped: false, alreadySkipped: true };
+  }
+
+  // Try to enrich metadata from saved results
+  const saved = scout
+    .getSavedResults()
+    .find((r) => r.issueUrl === options.issueUrl);
+  const metadata = saved
+    ? { repo: saved.repo, number: saved.number, title: saved.title }
+    : parseIssueUrl(options.issueUrl);
+
+  scout.skipIssue(options.issueUrl, metadata);
+  saveLocalState(scout.getState() as ScoutState);
+  return { skipped: true, alreadySkipped: false };
+}
+
+/**
+ * List all skipped issues.
+ */
+export function runSkipList(options?: { state?: ScoutState }): SkippedIssue[] {
+  const state = options?.state ?? loadLocalState();
+  return state.skippedIssues ?? [];
+}
+
+/**
+ * Clear all skipped issues.
+ */
+export function runSkipClear(): void {
+  const state = loadLocalState();
+  state.skippedIssues = [];
+  saveLocalState(state);
+}
+
+/**
+ * Remove a specific issue from the skip list (unskip).
+ */
+export function runSkipRemove(options: { issueUrl: string }): {
+  removed: boolean;
+} {
+  const state = loadLocalState();
+  const before = (state.skippedIssues ?? []).length;
+  state.skippedIssues = (state.skippedIssues ?? []).filter(
+    (s) => s.url !== options.issueUrl,
+  );
+  const removed = before !== state.skippedIssues.length;
+  saveLocalState(state);
+  return { removed };
+}
+
+/**
+ * Parse a GitHub issue URL to extract repo and number.
+ */
+function parseIssueUrl(
+  url: string,
+): { repo: string; number: number; title: string } | undefined {
+  const match = url.match(/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/);
+  if (!match) return undefined;
+  return { repo: match[1], number: parseInt(match[2], 10), title: "" };
+}

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -8,7 +8,12 @@
 import * as fs from "fs";
 import * as path from "path";
 import { ScoutStateSchema } from "./schemas.js";
-import type { ScoutState, RepoScore, SavedCandidate } from "./schemas.js";
+import type {
+  ScoutState,
+  RepoScore,
+  SavedCandidate,
+  SkippedIssue,
+} from "./schemas.js";
 import { getDataDir } from "./utils.js";
 import { debug, warn } from "./logger.js";
 import { errorMessage } from "./errors.js";
@@ -318,6 +323,10 @@ export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
       local.savedResults ?? [],
       remote.savedResults ?? [],
     ),
+    skippedIssues: mergeSkippedIssues(
+      local.skippedIssues ?? [],
+      remote.skippedIssues ?? [],
+    ),
     lastSearchAt: pickFresherTimestamp(local.lastSearchAt, remote.lastSearchAt),
     lastRunAt:
       pickFresherTimestamp(local.lastRunAt, remote.lastRunAt) ??
@@ -375,6 +384,21 @@ function mergeSavedResults(
     const existing = merged.get(item.issueUrl);
     if (!existing || item.lastSeenAt > existing.lastSeenAt) {
       merged.set(item.issueUrl, item);
+    }
+  }
+  return [...merged.values()];
+}
+
+function mergeSkippedIssues(
+  local: SkippedIssue[],
+  remote: SkippedIssue[],
+): SkippedIssue[] {
+  const merged = new Map<string, SkippedIssue>();
+  for (const item of local) merged.set(item.url, item);
+  for (const item of remote) {
+    const existing = merged.get(item.url);
+    if (!existing || item.skippedAt > existing.skippedAt) {
+      merged.set(item.url, item);
     }
   }
   return [...merged.values()];

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -77,6 +77,7 @@ interface IssueFilterConfig {
   excludeOrgs: Set<string>;
   aiBlocklisted: Set<string>;
   lowScoringRepos: Set<string>;
+  skippedUrls: Set<string>;
   maxAgeDays: number;
   now: Date;
   includeDocIssues: boolean;
@@ -97,6 +98,7 @@ function buildIssueFilter(
       }
       if (config.aiBlocklisted.has(repoFullName)) return false;
       if (config.lowScoringRepos.has(repoFullName)) return false;
+      if (config.skippedUrls.has(item.html_url)) return false;
       const updatedAt = new Date(item.updated_at);
       const ageDays = daysBetween(updatedAt, config.now);
       if (ageDays > config.maxAgeDays) return false;
@@ -434,6 +436,7 @@ export class IssueDiscovery {
       labels?: string[];
       maxResults?: number;
       strategies?: SearchStrategy[];
+      skippedUrls?: Set<string>;
     } = {},
   ): Promise<{
     candidates: IssueCandidate[];
@@ -539,6 +542,7 @@ export class IssueDiscovery {
       ),
       aiBlocklisted,
       lowScoringRepos,
+      skippedUrls: options.skippedUrls ?? new Set(),
       maxAgeDays: config.maxIssueAgeDays || 90,
       now: new Date(),
       includeDocIssues: config.includeDocIssues ?? true,

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -125,6 +125,16 @@ export const TrackedIssueSchema = z.object({
   vettingResult: IssueVettingResultSchema.optional(),
 });
 
+// ── Skipped issue schema ──────────────────────────────────────────
+
+export const SkippedIssueSchema = z.object({
+  url: z.string(),
+  repo: z.string(),
+  number: z.number(),
+  title: z.string(),
+  skippedAt: z.string(),
+});
+
 // ── Saved candidate schema ─────────────────────────────────────────
 
 export const SavedCandidateSchema = z.object({
@@ -180,6 +190,7 @@ export const ScoutStateSchema = z.object({
   closedPRs: z.array(StoredClosedPRSchema).default([]),
 
   savedResults: z.array(SavedCandidateSchema).default([]),
+  skippedIssues: z.array(SkippedIssueSchema).default([]),
 
   lastSearchAt: z.string().optional(),
   lastRunAt: z.string().default(() => new Date().toISOString()),
@@ -203,4 +214,5 @@ export type IssueVettingResult = z.infer<typeof IssueVettingResultSchema>;
 export type TrackedIssue = z.infer<typeof TrackedIssueSchema>;
 export type ScoutPreferences = z.infer<typeof ScoutPreferencesSchema>;
 export type SavedCandidate = z.infer<typeof SavedCandidateSchema>;
+export type SkippedIssue = z.infer<typeof SkippedIssueSchema>;
 export type ScoutState = z.infer<typeof ScoutStateSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export type {
   StoredMergedPR,
   StoredClosedPR,
   SearchStrategy,
+  SkippedIssue,
 } from "./core/schemas.js";
 
 // Schemas (for consumers who need runtime validation)
@@ -59,6 +60,7 @@ export {
   IssueScopeSchema,
   ProjectCategorySchema,
   SearchStrategySchema,
+  SkippedIssueSchema,
 } from "./core/schemas.js";
 
 // Utilities

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -13,6 +13,7 @@ import type {
   ScoutPreferences,
   RepoScore,
   SavedCandidate,
+  SkippedIssue,
 } from "./core/schemas.js";
 import type {
   ScoutConfig,
@@ -152,8 +153,15 @@ export class OssScout implements ScoutStateReader {
 
   /**
    * Multi-strategy issue search. Returns scored, sorted candidates.
+   * Automatically culls expired skip entries and filters skipped issues.
    */
   async search(options?: SearchOptions): Promise<SearchResult> {
+    // Auto-cull expired skips before searching
+    this.cullExpiredSkips();
+
+    const skippedUrls = new Set(
+      (this.state.skippedIssues ?? []).map((s) => s.url),
+    );
     const discovery = new IssueDiscovery(
       this.githubToken,
       this.state.preferences,
@@ -162,6 +170,7 @@ export class OssScout implements ScoutStateReader {
     const { candidates, strategiesUsed } = await discovery.searchIssues({
       maxResults: options?.maxResults,
       strategies: options?.strategies,
+      skippedUrls,
     });
 
     this.state.lastSearchAt = new Date().toISOString();
@@ -442,6 +451,77 @@ export class OssScout implements ScoutStateReader {
   clearResults(): void {
     this.state.savedResults = [];
     this.dirty = true;
+  }
+
+  // ── Skip List ───────────────────────────────────────────────────────
+
+  /**
+   * Skip an issue — excludes it from future searches. Auto-culled after 90 days.
+   */
+  skipIssue(
+    url: string,
+    metadata?: { repo?: string; number?: number; title?: string },
+  ): void {
+    const existing = this.state.skippedIssues ?? [];
+    if (existing.some((s) => s.url === url)) return; // already skipped
+    this.state.skippedIssues = [
+      ...existing,
+      {
+        url,
+        repo: metadata?.repo ?? "",
+        number: metadata?.number ?? 0,
+        title: metadata?.title ?? "",
+        skippedAt: new Date().toISOString(),
+      },
+    ];
+    // Also remove from saved results if present
+    if (this.state.savedResults) {
+      this.state.savedResults = this.state.savedResults.filter(
+        (r) => r.issueUrl !== url,
+      );
+    }
+    this.dirty = true;
+  }
+
+  /**
+   * Get all skipped issues.
+   */
+  getSkippedIssues(): SkippedIssue[] {
+    return this.state.skippedIssues ?? [];
+  }
+
+  /**
+   * Remove a specific issue from the skip list.
+   */
+  unskipIssue(url: string): void {
+    this.state.skippedIssues = (this.state.skippedIssues ?? []).filter(
+      (s) => s.url !== url,
+    );
+    this.dirty = true;
+  }
+
+  /**
+   * Clear all skipped issues.
+   */
+  clearSkippedIssues(): void {
+    this.state.skippedIssues = [];
+    this.dirty = true;
+  }
+
+  /**
+   * Remove skipped issues older than maxDays (default 90). Called automatically during search.
+   * @returns The number of expired entries that were removed.
+   */
+  cullExpiredSkips(maxDays: number = 90): number {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - maxDays);
+    const before = (this.state.skippedIssues ?? []).length;
+    this.state.skippedIssues = (this.state.skippedIssues ?? []).filter(
+      (s) => new Date(s.skippedAt) >= cutoff,
+    );
+    const culled = before - this.state.skippedIssues.length;
+    if (culled > 0) this.dirty = true;
+    return culled;
   }
 
   // ── Persistence ─────────────────────────────────────────────────────

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -27,6 +27,11 @@ function createMockScout(overrides: Partial<OssScout> = {}): OssScout {
     }),
     updatePreferences: vi.fn(),
     saveResults: vi.fn(),
+    getSavedResults: vi.fn().mockReturnValue([]),
+    getSkippedIssues: vi.fn().mockReturnValue([]),
+    skipIssue: vi.fn(),
+    unskipIssue: vi.fn(),
+    clearSkippedIssues: vi.fn(),
     checkpoint: vi.fn().mockResolvedValue(true),
     ...overrides,
   } as unknown as OssScout;
@@ -59,13 +64,14 @@ describe("registerTools", () => {
     registerTools(server, scout);
   });
 
-  it("registers all four tools", () => {
-    expect(server.tool).toHaveBeenCalledTimes(4);
+  it("registers all five tools", () => {
+    expect(server.tool).toHaveBeenCalledTimes(5);
 
     const calls = vi.mocked(server.tool).mock.calls;
     const names = calls.map((c) => c[0]);
     expect(names).toContain("search");
     expect(names).toContain("vet");
+    expect(names).toContain("skip");
     expect(names).toContain("config");
     expect(names).toContain("config-set");
   });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -103,6 +103,87 @@ export function registerTools(server: McpServer, scout: OssScout): void {
     },
   );
 
+  server.tool(
+    "skip",
+    "Skip, unskip, list, or clear skipped issues. Skipped issues are excluded from future searches and auto-expire after 90 days.",
+    {
+      action: z
+        .enum(["add", "remove", "list", "clear"])
+        .default("add")
+        .describe("Action to perform (default: add)"),
+      issueUrl: z
+        .string()
+        .optional()
+        .describe("GitHub issue URL (required for add/remove actions)"),
+    },
+    async ({ action, issueUrl }) => {
+      try {
+        if ((action === "add" || action === "remove") && !issueUrl) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Error: issueUrl is required for the "${action}" action.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (action === "list") {
+          const skipped = scout.getSkippedIssues();
+          return {
+            content: [{ type: "text", text: JSON.stringify(skipped, null, 2) }],
+          };
+        }
+
+        if (action === "clear") {
+          scout.clearSkippedIssues();
+          await scout.checkpoint();
+          return {
+            content: [{ type: "text", text: "Skip list cleared." }],
+          };
+        }
+
+        if (action === "remove") {
+          scout.unskipIssue(issueUrl!);
+          await scout.checkpoint();
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Removed from skip list: ${issueUrl}`,
+              },
+            ],
+          };
+        }
+
+        // action === "add"
+        const saved = scout
+          .getSavedResults()
+          .find((r) => r.issueUrl === issueUrl);
+        const metadata = saved
+          ? {
+              repo: saved.repo,
+              number: saved.number,
+              title: saved.title,
+            }
+          : undefined;
+        scout.skipIssue(issueUrl!, metadata);
+        await scout.checkpoint();
+        return {
+          content: [{ type: "text", text: `Skipped: ${issueUrl}` }],
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error: ${msg}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
   const VALID_KEYS = Object.keys(ScoutPreferencesSchema.shape);
   const ARRAY_KEYS = new Set([
     "languages",


### PR DESCRIPTION
## Summary

- Adds `oss-scout skip` command group (`add`, `remove`, `list`, `clear`) for excluding issues from future searches
- Skipped issues auto-expire after 90 days, culled automatically at each search
- Search engine filters skipped URLs at the issue-filtering layer before vetting
- Skipping an issue also removes it from saved results (metadata preserved in skip entry)
- MCP `skip` tool with `add`/`remove`/`list`/`clear` actions
- Gist persistence merges skip lists across machines
- SkippedIssue schema + type exported from public API

## Changes across layers

| Layer | Files | What changed |
|-------|-------|-------------|
| Schema | `schemas.ts` | New `SkippedIssueSchema`, `skippedIssues` field on `ScoutStateSchema` |
| Core | `scout.ts` | 5 new methods: `skipIssue`, `getSkippedIssues`, `unskipIssue`, `clearSkippedIssues`, `cullExpiredSkips` |
| Search | `issue-discovery.ts` | `skippedUrls` param on `searchIssues()`, filter in `buildIssueFilter()` |
| CLI | `cli.ts`, `commands/skip.ts` | `skip add/list/remove/clear` subcommands with `--json` support |
| MCP | `tools.ts` | New `skip` tool with action parameter |
| Persistence | `gist-state-store.ts` | `mergeSkippedIssues()` for cross-machine sync |
| Plugin | `scout.md`, `issue-scout.md` | Skip commands in follow-up actions and CLI reference |
| Public API | `index.ts` | Export `SkippedIssue` type + `SkippedIssueSchema` |
| Tests | `skip.test.ts`, `tools.test.ts` | Full coverage for skip operations + MCP tool count update |

## Test plan

- [x] `pnpm run format` — no changes
- [x] `pnpm run lint` — clean
- [x] `pnpm --filter @oss-scout/core run typecheck` — clean
- [x] `pnpm --filter @oss-scout/mcp run typecheck` — clean
- [x] `pnpm --filter @oss-scout/core run test` — 451 tests pass
- [x] `pnpm --filter @oss-scout/mcp run test` — 16 tests pass
- [ ] CI passes