### PR TITLE
fix: reorder search phases to run broad strategy first

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -488,6 +488,13 @@ describe("IssueDiscovery", () => {
       const starred = makeCandidate("org/starred", "starred", "approve", 90);
       const normal = makeCandidate("org/normal", "normal", "approve", 95);
 
+      // Phase 2 (broad) runs first — returns normal
+      mockSearchWithChunkedLabels.mockResolvedValue([]);
+      mockFilterVetAndScore.mockResolvedValueOnce({
+        candidates: [normal],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
       // Phase 0 returns merged
       mockSearchInRepos.mockResolvedValueOnce({
         candidates: [merged],
@@ -498,13 +505,6 @@ describe("IssueDiscovery", () => {
       mockSearchInRepos.mockResolvedValueOnce({
         candidates: [starred],
         allBatchesFailed: false,
-        rateLimitHit: false,
-      });
-      // Phase 2 returns normal
-      mockSearchWithChunkedLabels.mockResolvedValue([]);
-      mockFilterVetAndScore.mockResolvedValueOnce({
-        candidates: [normal],
-        allVetFailed: false,
         rateLimitHit: false,
       });
 

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -367,11 +367,14 @@ async function runPhase3(
 /**
  * Multi-phase issue discovery engine that searches GitHub for contributable issues.
  *
- * Search phases (in priority order):
+ * Search phases (execution order):
+ * 2. General label-filtered search (broad) — runs first for full Search API budget
  * 0. Repos where user has merged PRs (highest merge probability)
  * 1. Starred repos
- * 2. General label-filtered search
  * 3. Actively maintained repos
+ *
+ * Results are sorted by priority (merged_pr > starred > normal) regardless of
+ * execution order, so Phase 0/1 results still rank highest.
  *
  * Each candidate is vetted for claimability and scored 0-100 for viability.
  */
@@ -408,8 +411,9 @@ export class IssueDiscovery {
 
   /**
    * Search for issues matching our criteria.
-   * Searches in priority order: merged-PR repos first (no label filter), then starred
-   * repos, then general search, then actively maintained repos.
+   * Runs broad search first (for full Search API budget), then merged-PR repos,
+   * starred repos, and maintained repos. Results are sorted by priority
+   * (merged_pr > starred > normal) regardless of execution order.
    * Filters out issues from low-scoring and excluded repos.
    *
    * @param options - Search configuration
@@ -548,11 +552,40 @@ export class IssueDiscovery {
       includeDocIssues: config.includeDocIssues ?? true,
     });
 
-    // Phase 0: Merged-PR repos
+    // Derive phase0 repo set (needed by Phase 2 as exclusion set)
     const phase0Repos = mergedPRRepos.slice(0, 10);
     const phase0RepoSet = new Set(phase0Repos);
 
+    // Phase 2: Broad search (runs first for full Search API budget)
+    if (
+      allCandidates.length < maxResults &&
+      searchBudget >= LOW_BUDGET_THRESHOLD &&
+      enabledStrategies.has("broad")
+    ) {
+      const remaining = maxResults - allCandidates.length;
+      const result = await runPhase2(
+        this.octokit,
+        this.vetter,
+        scopes,
+        labels,
+        config.labels,
+        baseQualifiers,
+        remaining,
+        minStars,
+        phase0RepoSet,
+        starredRepoSet,
+        allCandidates,
+        filterIssues,
+      );
+      allCandidates.push(...result.candidates);
+      phaseErrors["2"] = result.error;
+      if (result.rateLimitHit) rateLimitHitDuringSearch = true;
+      strategiesUsed.push("broad");
+    }
+
+    // Phase 0: Merged-PR repos
     if (phase0Repos.length > 0 && enabledStrategies.has("merged")) {
+      await sleep(INTER_PHASE_DELAY_MS);
       const remaining = maxResults - allCandidates.length;
       if (remaining > 0) {
         const result = await runPhase0(
@@ -597,34 +630,6 @@ export class IssueDiscovery {
         }
       }
       strategiesUsed.push("starred");
-    }
-
-    // Phase 2: General search
-    if (
-      allCandidates.length < maxResults &&
-      searchBudget >= LOW_BUDGET_THRESHOLD &&
-      enabledStrategies.has("broad")
-    ) {
-      await sleep(INTER_PHASE_DELAY_MS);
-      const remaining = maxResults - allCandidates.length;
-      const result = await runPhase2(
-        this.octokit,
-        this.vetter,
-        scopes,
-        labels,
-        config.labels,
-        baseQualifiers,
-        remaining,
-        minStars,
-        phase0RepoSet,
-        starredRepoSet,
-        allCandidates,
-        filterIssues,
-      );
-      allCandidates.push(...result.candidates);
-      phaseErrors["2"] = result.error;
-      if (result.rateLimitHit) rateLimitHitDuringSearch = true;
-      strategiesUsed.push("broad");
     }
 
     // Phase 3: Actively maintained repos

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -492,7 +492,7 @@ export class IssueDiscovery {
       } else if (searchBudget < LOW_BUDGET_THRESHOLD) {
         info(
           MODULE,
-          `Search budget low (${searchBudget} remaining) — skipping heavy phases (2, 3)`,
+          `Search budget low (${searchBudget} remaining) — skipping broad + maintained phases`,
         );
       }
     } catch (error) {

--- a/skills/oss-search/SKILL.md
+++ b/skills/oss-search/SKILL.md
@@ -62,7 +62,7 @@ oss-scout search --strategy merged,starred
 oss-scout config set defaultStrategy "merged,starred"
 ```
 
-The `all` strategy runs phases in order: merged (0) -> starred (1) -> broad (2) -> maintained (3). Results are deduplicated and sorted by priority, then recommendation, then score. Rate-limit-aware: heavy phases (broad, maintained) are skipped when API budget is low.
+The `all` strategy runs phases in order: broad (2) -> merged (0) -> starred (1) -> maintained (3). Broad search runs first to get the full Search API budget. Results are deduplicated and sorted by priority (merged_pr > starred > normal), then recommendation, then score. Rate-limit-aware: heavy phases (broad, maintained) are skipped when API budget is low.
 
 ## Viability Scoring (0-100)
 


### PR DESCRIPTION
## Summary

- Moves Phase 2 (broad search) to execute first in `searchIssues()` so it gets the full Search API budget instead of running last after other phases have consumed quota
- New execution order: broad (2) -> merged (0) -> starred (1) -> maintained (3)
- Final sort still prioritizes merged_pr > starred > normal, so result ranking is unchanged

## Test plan

- [x] All 452 core tests pass (including updated sort-order mock sequence)
- [x] Lint clean
- [x] TypeScript compiles without errors
- [ ] Verify broad search no longer hits rate limits in production runs

Closes #53