### PR TITLE
fix: add rate limit delay and skip logic before broad search phase

### DIFF
--- a/packages/core/src/commands/config.test.ts
+++ b/packages/core/src/commands/config.test.ts
@@ -300,6 +300,34 @@ describe("config command", () => {
       });
     });
 
+    describe("broad phase settings", () => {
+      it("should set broadPhaseDelayMs", () => {
+        writeState(makeState());
+
+        const result = runConfigSet("broadPhaseDelayMs", "60000");
+
+        expect(result.broadPhaseDelayMs).toBe(60000);
+        expect(readState().preferences.broadPhaseDelayMs).toBe(60000);
+      });
+
+      it("should set skipBroadWhenSufficientResults", () => {
+        writeState(makeState());
+
+        const result = runConfigSet("skipBroadWhenSufficientResults", "20");
+
+        expect(result.skipBroadWhenSufficientResults).toBe(20);
+        expect(readState().preferences.skipBroadWhenSufficientResults).toBe(20);
+      });
+
+      it("should set skipBroadWhenSufficientResults to 0 to disable skipping", () => {
+        writeState(makeState());
+
+        const result = runConfigSet("skipBroadWhenSufficientResults", "0");
+
+        expect(result.skipBroadWhenSufficientResults).toBe(0);
+      });
+    });
+
     describe("validation", () => {
       it("should reject unknown keys", () => {
         writeState(makeState());

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -39,6 +39,8 @@ const FIELD_CONFIGS: Record<string, FieldConfig> = {
     validValues: SearchStrategySchema.options,
   },
   githubUsername: { type: "string" },
+  broadPhaseDelayMs: { type: "number" },
+  skipBroadWhenSufficientResults: { type: "number" },
 };
 
 function parseBoolean(value: string): boolean {
@@ -123,6 +125,8 @@ export function runConfigShow(): void {
     `  defaultStrategy:      ${prefs.defaultStrategy ? formatArray(prefs.defaultStrategy) : "(all)"}`,
   );
   console.log(`  persistence:          ${prefs.persistence}`);
+  console.log(`  broadPhaseDelayMs:    ${prefs.broadPhaseDelayMs}ms (${(prefs.broadPhaseDelayMs / 1000).toFixed(0)}s)`);
+  console.log(`  skipBroadWhenSufficientResults: ${prefs.skipBroadWhenSufficientResults}`);
   console.log();
 }
 

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -125,8 +125,12 @@ export function runConfigShow(): void {
     `  defaultStrategy:      ${prefs.defaultStrategy ? formatArray(prefs.defaultStrategy) : "(all)"}`,
   );
   console.log(`  persistence:          ${prefs.persistence}`);
-  console.log(`  broadPhaseDelayMs:    ${prefs.broadPhaseDelayMs}ms (${(prefs.broadPhaseDelayMs / 1000).toFixed(0)}s)`);
-  console.log(`  skipBroadWhenSufficientResults: ${prefs.skipBroadWhenSufficientResults}`);
+  console.log(
+    `  broadPhaseDelayMs:    ${prefs.broadPhaseDelayMs}ms (${(prefs.broadPhaseDelayMs / 1000).toFixed(0)}s)`,
+  );
+  console.log(
+    `  skipBroadWhenSufficientResults: ${prefs.skipBroadWhenSufficientResults}`,
+  );
   console.log();
 }
 

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -79,7 +79,7 @@ vi.mock("./errors.js", () => ({
 
 const mockSearchInRepos = vi.fn().mockResolvedValue({
   candidates: [],
-  allBatchesFailed: false,
+  allReposFailed: false,
   rateLimitHit: false,
 });
 
@@ -236,9 +236,9 @@ describe("IssueDiscovery", () => {
     vi.clearAllMocks();
 
     // Reset mocks to defaults
-    mockSearchInRepos.mockResolvedValue({
+    mockFetchIssuesFromKnownRepos.mockResolvedValue({
       candidates: [],
-      allBatchesFailed: false,
+      allReposFailed: false,
       rateLimitHit: false,
     });
     mockFetchIssuesFromKnownRepos.mockResolvedValue({
@@ -571,7 +571,7 @@ describe("IssueDiscovery", () => {
           getReposWithMergedPRs: vi.fn(() => ["org/merged-repo"]),
           getStarredRepos: vi.fn(() => ["org/starred-repo"]),
         },
-        { interPhaseDelayMs: 0 },
+        { interPhaseDelayMs: 0, broadPhaseDelayMs: 0 },
       );
 
       await discovery.searchIssues({ maxResults: 5 });
@@ -740,9 +740,9 @@ describe("IssueDiscovery", () => {
       const candidates = Array.from({ length: 15 }, (_, i) =>
         makeCandidate(`org/repo-${i}`, "merged_pr"),
       );
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates,
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
       vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
@@ -768,9 +768,9 @@ describe("IssueDiscovery", () => {
         makeCandidate("org/merged-1", "merged_pr"),
         makeCandidate("org/merged-2", "merged_pr"),
       ];
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: phase0Candidates,
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
       vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
@@ -788,9 +788,9 @@ describe("IssueDiscovery", () => {
 
     it("skips delay when previous phases found 0 results", async () => {
       // No Phase 0/1 candidates, so Phase 2 should run without the broad delay
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -821,9 +821,9 @@ describe("IssueDiscovery", () => {
       const candidates = Array.from({ length: 20 }, (_, i) =>
         makeCandidate(`org/repo-${i}`, "merged_pr"),
       );
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates,
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
       vi.mocked(applyPerRepoCap).mockImplementation((c) => c);

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -752,7 +752,9 @@ describe("IssueDiscovery", () => {
         { skipBroadWhenSufficientResults: 15 },
       );
 
-      const { strategiesUsed } = await discovery.searchIssues({ maxResults: 20 });
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 20,
+      });
 
       // broad should still be listed in strategiesUsed (strategy was enabled)
       // but searchWithChunkedLabels should NOT have been called (Phase 2 body skipped)

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -733,4 +733,109 @@ describe("IssueDiscovery", () => {
       expect(discovery.rateLimitWarning).toBeTruthy();
     });
   });
+
+  describe("searchIssues — broad phase delay/skip logic", () => {
+    it("skips Phase 2 when allCandidates >= skipBroadWhenSufficientResults", async () => {
+      // Phase 0 returns enough candidates to exceed the skip threshold
+      const candidates = Array.from({ length: 15 }, (_, i) =>
+        makeCandidate(`org/repo-${i}`, "merged_pr"),
+      );
+      mockSearchInRepos.mockResolvedValue({
+        candidates,
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery(
+        { getReposWithMergedPRs: vi.fn(() => ["org/repo-0"]) },
+        { skipBroadWhenSufficientResults: 15 },
+      );
+
+      const { strategiesUsed } = await discovery.searchIssues({ maxResults: 20 });
+
+      // broad should still be listed in strategiesUsed (strategy was enabled)
+      // but searchWithChunkedLabels should NOT have been called (Phase 2 body skipped)
+      expect(strategiesUsed).toContain("broad");
+      expect(mockSearchWithChunkedLabels).not.toHaveBeenCalled();
+    });
+
+    it("applies broadPhaseDelayMs before Phase 2 when previous phases found some results", async () => {
+      // Phase 0 returns 2 candidates (below skip threshold)
+      const phase0Candidates = [
+        makeCandidate("org/merged-1", "merged_pr"),
+        makeCandidate("org/merged-2", "merged_pr"),
+      ];
+      mockSearchInRepos.mockResolvedValue({
+        candidates: phase0Candidates,
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery(
+        { getReposWithMergedPRs: vi.fn(() => ["org/merged-1"]) },
+        { broadPhaseDelayMs: 60000, skipBroadWhenSufficientResults: 15 },
+      );
+
+      await discovery.searchIssues({ maxResults: 10 });
+
+      // sleep should have been called with 60000 for the broad phase delay
+      expect(sleep).toHaveBeenCalledWith(60000);
+    });
+
+    it("skips delay when previous phases found 0 results", async () => {
+      // No Phase 0/1 candidates, so Phase 2 should run without the broad delay
+      mockSearchInRepos.mockResolvedValue({
+        candidates: [],
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+
+      // Phase 2 returns candidates so we don't throw
+      const broadCandidate = makeCandidate("broad/repo", "normal");
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [broadCandidate],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery(
+        {},
+        { broadPhaseDelayMs: 90000, skipBroadWhenSufficientResults: 15 },
+      );
+
+      await discovery.searchIssues({ maxResults: 10 });
+
+      // sleep should NOT have been called with 90000 (the broad delay)
+      // It may have been called with the inter-phase delay (2000), but not the broad delay
+      const sleepCalls = vi.mocked(sleep).mock.calls.map((c) => c[0]);
+      expect(sleepCalls).not.toContain(90000);
+    });
+
+    it("skipBroadWhenSufficientResults=0 means never skip Phase 2", async () => {
+      // Phase 0 returns many candidates
+      const candidates = Array.from({ length: 20 }, (_, i) =>
+        makeCandidate(`org/repo-${i}`, "merged_pr"),
+      );
+      mockSearchInRepos.mockResolvedValue({
+        candidates,
+        allBatchesFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery(
+        { getReposWithMergedPRs: vi.fn(() => ["org/repo-0"]) },
+        { skipBroadWhenSufficientResults: 0 },
+      );
+
+      // maxResults must be higher than candidates count so Phase 2 condition passes
+      await discovery.searchIssues({ maxResults: 25 });
+
+      // Phase 2 should have run (searchWithChunkedLabels called)
+      expect(mockSearchWithChunkedLabels).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -651,37 +651,64 @@ export class IssueDiscovery {
       strategiesUsed.push("starred");
     }
 
-    // Phase 2: General search
+    // Phase 2: General search (with rate limit mitigation)
+    const broadDelay = config.broadPhaseDelayMs ?? 90000;
+    const skipThreshold = config.skipBroadWhenSufficientResults ?? 15;
+
     if (
       allCandidates.length < maxResults &&
       searchBudget >= LOW_BUDGET_THRESHOLD &&
       enabledStrategies.has("broad")
     ) {
-      if (interPhaseDelay > 0) {
+      // Skip broad search if we already have enough candidates
+      if (skipThreshold > 0 && allCandidates.length >= skipThreshold) {
         info(
           MODULE,
-          `Waiting ${(interPhaseDelay / 1000).toFixed(0)}s between phases for rate limit management...`,
+          `Skipping broad search: already found ${allCandidates.length} candidates (threshold: ${skipThreshold})`,
         );
-        await sleep(interPhaseDelay);
+      } else {
+        // Always apply baseline inter-phase delay
+        if (interPhaseDelay > 0) {
+          info(
+            MODULE,
+            `Waiting ${(interPhaseDelay / 1000).toFixed(0)}s between phases for rate limit management...`,
+          );
+          await sleep(interPhaseDelay);
+        }
+
+        // Apply additional broad-phase cooldown, but skip if previous phases found nothing
+        if (allCandidates.length > 0 && broadDelay > 0) {
+          info(
+            MODULE,
+            `Waiting ${(broadDelay / 1000).toFixed(0)}s for rate limit cooldown before broad search...`,
+          );
+          await sleep(broadDelay);
+        } else if (allCandidates.length === 0) {
+          info(
+            MODULE,
+            `Skipping broad phase delay: no results from previous phases, proceeding immediately`,
+          );
+        }
+
+        const remaining = maxResults - allCandidates.length;
+        const result = await runPhase2(
+          this.octokit,
+          this.vetter,
+          scopes,
+          labels,
+          config.labels,
+          baseQualifiers,
+          remaining,
+          minStars,
+          phase0RepoSet,
+          starredRepoSet,
+          allCandidates,
+          filterIssues,
+        );
+        allCandidates.push(...result.candidates);
+        phaseErrors["2"] = result.error;
+        if (result.rateLimitHit) rateLimitHitDuringSearch = true;
       }
-      const remaining = maxResults - allCandidates.length;
-      const result = await runPhase2(
-        this.octokit,
-        this.vetter,
-        scopes,
-        labels,
-        config.labels,
-        baseQualifiers,
-        remaining,
-        minStars,
-        phase0RepoSet,
-        starredRepoSet,
-        allCandidates,
-        filterIssues,
-      );
-      allCandidates.push(...result.candidates);
-      phaseErrors["2"] = result.error;
-      if (result.rateLimitHit) rateLimitHitDuringSearch = true;
       strategiesUsed.push("broad");
     }
 

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -147,6 +147,34 @@ describe("ScoutPreferencesSchema", () => {
       ScoutPreferencesSchema.parse({ interPhaseDelayMs: -1 }),
     ).toThrow();
   });
+
+  it("applies broadPhaseDelayMs default of 90000", () => {
+    const prefs = ScoutPreferencesSchema.parse({});
+    expect(prefs.broadPhaseDelayMs).toBe(90000);
+  });
+
+  it("applies skipBroadWhenSufficientResults default of 15", () => {
+    const prefs = ScoutPreferencesSchema.parse({});
+    expect(prefs.skipBroadWhenSufficientResults).toBe(15);
+  });
+
+  it("accepts custom broadPhaseDelayMs", () => {
+    const prefs = ScoutPreferencesSchema.parse({ broadPhaseDelayMs: 60000 });
+    expect(prefs.broadPhaseDelayMs).toBe(60000);
+  });
+
+  it("rejects broadPhaseDelayMs exceeding 300000", () => {
+    expect(() =>
+      ScoutPreferencesSchema.parse({ broadPhaseDelayMs: 400000 }),
+    ).toThrow();
+  });
+
+  it("accepts skipBroadWhenSufficientResults of 0", () => {
+    const prefs = ScoutPreferencesSchema.parse({
+      skipBroadWhenSufficientResults: 0,
+    });
+    expect(prefs.skipBroadWhenSufficientResults).toBe(0);
+  });
 });
 
 describe("RepoScoreSchema", () => {

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -171,6 +171,8 @@ export const ScoutPreferencesSchema = z.object({
   interPhaseDelayMs: z.number().min(0).max(120000).default(30000),
   persistence: PersistenceModeSchema.default("local"),
   defaultStrategy: z.array(SearchStrategySchema).optional(),
+  broadPhaseDelayMs: z.number().min(0).max(300000).default(90000),
+  skipBroadWhenSufficientResults: z.number().int().min(0).max(100).default(15),
 });
 
 // ── Root state schema ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a configurable delay (default 90s) after Phases 0+1 and before Phase 2 (broad search) to let GitHub's secondary rate limit window cool down
- Skips Phase 2 entirely when Phases 0+1 already returned sufficient candidates (configurable threshold, default 15)
- Skips the delay when previous phases found 0 results, since Phase 2 is the only hope

Two new preferences: `broadPhaseDelayMs` and `skipBroadWhenSufficientResults`, both configurable via `oss-scout config set`.

## Test plan

- [x] Schema tests verify defaults (90000ms, 15) and validation (max 300000, min 0)
- [x] Issue discovery tests verify Phase 2 skip when candidates >= threshold
- [x] Issue discovery tests verify delay is applied when previous phases found some results
- [x] Issue discovery tests verify delay is skipped when previous phases found 0 results
- [x] Issue discovery tests verify `skipBroadWhenSufficientResults=0` means never skip
- [x] Config tests verify setting both new preferences
- [x] All 464 core tests pass, lint clean, typecheck clean

Closes #51