### PR TITLE
fix: use REST API for Phase 3 maintained-repo search

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -96,6 +96,10 @@ const mockCachedSearchIssues = vi.fn().mockResolvedValue({
   items: [],
 });
 
+const mockFetchIssuesFromMaintainedRepos = vi
+  .fn()
+  .mockResolvedValue([] as GitHubSearchItem[]);
+
 vi.mock("./search-phases.js", () => ({
   buildEffectiveLabels: vi.fn((_scopes: string[], labels: string[]) =>
     labels.length > 0 ? labels : ["good first issue"],
@@ -106,6 +110,8 @@ vi.mock("./search-phases.js", () => ({
     mockSearchWithChunkedLabels(...args),
   filterVetAndScore: (...args: unknown[]) => mockFilterVetAndScore(...args),
   cachedSearchIssues: (...args: unknown[]) => mockCachedSearchIssues(...args),
+  fetchIssuesFromMaintainedRepos: (...args: unknown[]) =>
+    mockFetchIssuesFromMaintainedRepos(...args),
 }));
 
 import { IssueDiscovery } from "./issue-discovery.js";
@@ -237,6 +243,7 @@ describe("IssueDiscovery", () => {
       total_count: 0,
       items: [],
     });
+    mockFetchIssuesFromMaintainedRepos.mockResolvedValue([]);
 
     vi.mocked(checkRateLimit).mockResolvedValue({
       remaining: 30,
@@ -314,7 +321,41 @@ describe("IssueDiscovery", () => {
       expect(mockFilterVetAndScore).toHaveBeenCalled();
     });
 
-    it("Phase 3: calls cachedSearchIssues then filterVetAndScore", async () => {
+    it("Phase 3: tries REST API with starred repos first", async () => {
+      const restItems: GitHubSearchItem[] = [
+        {
+          html_url: "https://github.com/starred/repo/issues/1",
+          repository_url: "https://api.github.com/repos/starred/repo",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ];
+      mockFetchIssuesFromMaintainedRepos.mockResolvedValue(restItems);
+      const c = makeCandidate("starred/repo", "normal");
+      // Phase 2 calls filterVetAndScore first (return empty so Phase 3 runs with eligible repos)
+      mockFilterVetAndScore
+        .mockResolvedValueOnce({
+          candidates: [],
+          allVetFailed: false,
+          rateLimitHit: false,
+        })
+        .mockResolvedValue({
+          candidates: [c],
+          allVetFailed: false,
+          rateLimitHit: false,
+        });
+
+      const discovery = makeDiscovery({
+        getStarredRepos: vi.fn(() => ["starred/repo"]),
+      });
+      await discovery.searchIssues({ maxResults: 5 });
+
+      expect(mockFetchIssuesFromMaintainedRepos).toHaveBeenCalled();
+    });
+
+    it("Phase 3: falls back to Search API when REST yields no candidates", async () => {
+      // REST returns empty
+      mockFetchIssuesFromMaintainedRepos.mockResolvedValue([]);
+
       mockCachedSearchIssues.mockResolvedValue({
         total_count: 5,
         items: [
@@ -326,15 +367,58 @@ describe("IssueDiscovery", () => {
         ],
       });
       const c = makeCandidate("maintained/repo", "normal");
-      mockFilterVetAndScore.mockResolvedValue({
-        candidates: [c],
-        allVetFailed: false,
-        rateLimitHit: false,
+      // Phase 2 calls filterVetAndScore first (return empty so Phase 3 runs)
+      mockFilterVetAndScore
+        .mockResolvedValueOnce({
+          candidates: [],
+          allVetFailed: false,
+          rateLimitHit: false,
+        })
+        .mockResolvedValue({
+          candidates: [c],
+          allVetFailed: false,
+          rateLimitHit: false,
+        });
+
+      const discovery = makeDiscovery({
+        getStarredRepos: vi.fn(() => ["starred/repo"]),
       });
+      await discovery.searchIssues({ maxResults: 5 });
+
+      // Should fall back to Search API
+      expect(mockCachedSearchIssues).toHaveBeenCalled();
+    });
+
+    it("Phase 3: falls back to Search API when no starred repos available", async () => {
+      mockCachedSearchIssues.mockResolvedValue({
+        total_count: 5,
+        items: [
+          {
+            html_url: "https://github.com/maintained/repo/issues/1",
+            repository_url: "https://api.github.com/repos/maintained/repo",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      });
+      const c = makeCandidate("maintained/repo", "normal");
+      // Phase 2 calls filterVetAndScore first (return empty so Phase 3 runs)
+      mockFilterVetAndScore
+        .mockResolvedValueOnce({
+          candidates: [],
+          allVetFailed: false,
+          rateLimitHit: false,
+        })
+        .mockResolvedValue({
+          candidates: [c],
+          allVetFailed: false,
+          rateLimitHit: false,
+        });
 
       const discovery = makeDiscovery();
       await discovery.searchIssues({ maxResults: 5 });
 
+      // No starred repos, so REST is skipped, falls back to Search API
+      expect(mockFetchIssuesFromMaintainedRepos).not.toHaveBeenCalled();
       expect(mockCachedSearchIssues).toHaveBeenCalled();
     });
   });

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -46,6 +46,7 @@ import {
   buildEffectiveLabels,
   interleaveArrays,
   cachedSearchIssues,
+  fetchIssuesFromMaintainedRepos,
   filterVetAndScore,
   searchInRepos,
   searchWithChunkedLabels,
@@ -284,7 +285,7 @@ async function runPhase2(
   };
 }
 
-/** Phase 3: Actively maintained repos. */
+/** Phase 3: Actively maintained repos (REST-first, Search API fallback). */
 async function runPhase3(
   octokit: Octokit,
   vetter: IssueVetter,
@@ -294,10 +295,62 @@ async function runPhase3(
   maxResults: number,
   phase0RepoSet: Set<string>,
   starredRepoSet: Set<string>,
+  starredRepos: string[],
   existingCandidates: IssueCandidate[],
   filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
 ): Promise<PhaseResult> {
   info(MODULE, "Phase 3: Searching actively maintained repos...");
+
+  const seenRepos = new Set(existingCandidates.map((c) => c.issue.repo));
+
+  // Step 1: Try REST API with starred repos first (no Search API quota used)
+  const eligibleStarred = starredRepos.filter(
+    (r) => !phase0RepoSet.has(r) && !seenRepos.has(r),
+  );
+
+  if (eligibleStarred.length > 0) {
+    info(
+      MODULE,
+      `Phase 3: Checking ${eligibleStarred.length} starred repos via REST API...`,
+    );
+    const restItems = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      eligibleStarred.slice(0, 15),
+      minStars,
+      maxResults,
+    );
+
+    if (restItems.length > 0) {
+      const {
+        candidates,
+        allVetFailed,
+        rateLimitHit: vetRateLimitHit,
+      } = await filterVetAndScore(
+        vetter,
+        restItems,
+        filterIssues,
+        [phase0RepoSet, starredRepoSet, seenRepos],
+        maxResults,
+        minStars,
+        "Phase 3 (REST)",
+      );
+
+      if (candidates.length > 0) {
+        info(
+          MODULE,
+          `Found ${candidates.length} candidates from maintained-repo REST search`,
+        );
+        return {
+          candidates,
+          error: allVetFailed ? "all vetting failed" : null,
+          rateLimitHit: vetRateLimitHit,
+        };
+      }
+    }
+  }
+
+  // Step 2: Fall back to Search API if REST didn't yield results
+  info(MODULE, "Phase 3: Falling back to Search API...");
 
   const thirtyDaysAgo = new Date();
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
@@ -323,7 +376,6 @@ async function runPhase3(
       `Found ${data.total_count} issues in maintained-repo search, processing top ${data.items.length}...`,
     );
 
-    const seenRepos = new Set(existingCandidates.map((c) => c.issue.repo));
     const {
       candidates,
       allVetFailed,
@@ -660,6 +712,7 @@ export class IssueDiscovery {
         remaining,
         phase0RepoSet,
         starredRepoSet,
+        starredRepos,
         allCandidates,
         filterIssues,
       );

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -329,7 +329,7 @@ async function runPhase3(
         vetter,
         restItems,
         filterIssues,
-        [phase0RepoSet, starredRepoSet, seenRepos],
+        [phase0RepoSet, seenRepos],
         maxResults,
         minStars,
         "Phase 3 (REST)",

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -54,6 +54,7 @@ import {
   buildEffectiveLabels,
   interleaveArrays,
   cachedSearchIssues,
+  fetchIssuesFromMaintainedRepos,
   searchWithChunkedLabels,
   filterVetAndScore,
   searchInRepos,
@@ -615,5 +616,233 @@ describe("searchWithChunkedLabels", () => {
     expect(result).toHaveLength(2); // deduplicated: sharedItem appears once
     expect(result[0].html_url).toBe("https://github.com/a/b/issues/1");
     expect(result[1].html_url).toBe("https://github.com/c/d/issues/2");
+  });
+});
+
+describe("fetchIssuesFromMaintainedRepos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeMockOctokitForRest(opts: {
+    repoData?: {
+      pushed_at: string;
+      stargazers_count: number;
+      archived: boolean;
+    };
+    issues?: Array<{
+      html_url: string;
+      updated_at: string;
+      title: string;
+      labels: Array<{ name?: string } | string>;
+      pull_request?: unknown;
+    }>;
+    repoError?: Error;
+  }): Octokit {
+    return {
+      repos: {
+        get: opts.repoError
+          ? vi.fn().mockRejectedValue(opts.repoError)
+          : vi.fn().mockResolvedValue({
+              data: opts.repoData ?? {
+                pushed_at: new Date().toISOString(),
+                stargazers_count: 200,
+                archived: false,
+              },
+            }),
+      },
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: opts.issues ?? [],
+        }),
+      },
+    } as unknown as Octokit;
+  }
+
+  it("fetches issues from actively maintained repos", async () => {
+    const octokit = makeMockOctokitForRest({
+      repoData: {
+        pushed_at: new Date().toISOString(),
+        stargazers_count: 200,
+        archived: false,
+      },
+      issues: [
+        {
+          html_url: "https://github.com/owner/repo/issues/1",
+          updated_at: "2026-01-01T00:00:00Z",
+          title: "Fix bug",
+          labels: [{ name: "bug" }],
+        },
+      ],
+    });
+
+    const result = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      ["owner/repo"],
+      50,
+      10,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].html_url).toBe(
+      "https://github.com/owner/repo/issues/1",
+    );
+    expect(result[0].repository_url).toBe(
+      "https://api.github.com/repos/owner/repo",
+    );
+    expect(result[0].title).toBe("Fix bug");
+  });
+
+  it("skips repos that were pushed more than 30 days ago", async () => {
+    const sixtyDaysAgo = new Date();
+    sixtyDaysAgo.setDate(sixtyDaysAgo.getDate() - 60);
+
+    const octokit = makeMockOctokitForRest({
+      repoData: {
+        pushed_at: sixtyDaysAgo.toISOString(),
+        stargazers_count: 200,
+        archived: false,
+      },
+      issues: [
+        {
+          html_url: "https://github.com/owner/repo/issues/1",
+          updated_at: "2026-01-01T00:00:00Z",
+          title: "Bug",
+          labels: [],
+        },
+      ],
+    });
+
+    const result = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      ["owner/repo"],
+      50,
+      10,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips repos below minimum star threshold", async () => {
+    const octokit = makeMockOctokitForRest({
+      repoData: {
+        pushed_at: new Date().toISOString(),
+        stargazers_count: 10,
+        archived: false,
+      },
+    });
+
+    const result = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      ["owner/repo"],
+      50, // minStars = 50, repo has 10
+      10,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips archived repos", async () => {
+    const octokit = makeMockOctokitForRest({
+      repoData: {
+        pushed_at: new Date().toISOString(),
+        stargazers_count: 200,
+        archived: true,
+      },
+    });
+
+    const result = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      ["owner/repo"],
+      50,
+      10,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("filters out pull requests from the issues endpoint", async () => {
+    const octokit = makeMockOctokitForRest({
+      issues: [
+        {
+          html_url: "https://github.com/owner/repo/issues/1",
+          updated_at: "2026-01-01T00:00:00Z",
+          title: "Real issue",
+          labels: [],
+        },
+        {
+          html_url: "https://github.com/owner/repo/pull/2",
+          updated_at: "2026-01-01T00:00:00Z",
+          title: "A pull request",
+          labels: [],
+          pull_request: { url: "https://api.github.com/repos/owner/repo/pulls/2" },
+        },
+      ],
+    });
+
+    const result = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      ["owner/repo"],
+      50,
+      10,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Real issue");
+  });
+
+  it("handles API errors gracefully and continues", async () => {
+    const octokit = makeMockOctokitForRest({
+      repoError: new Error("Not Found"),
+    });
+
+    const result = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      ["bad/repo"],
+      50,
+      10,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("stops fetching when maxResults * 3 items are collected", async () => {
+    // Create an octokit that returns 4 issues per repo
+    const makeIssues = (repoName: string) =>
+      Array.from({ length: 4 }, (_, i) => ({
+        html_url: `https://github.com/${repoName}/issues/${i + 1}`,
+        updated_at: "2026-01-01T00:00:00Z",
+        title: `Issue ${i + 1}`,
+        labels: [],
+      }));
+
+    const octokit = {
+      repos: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            pushed_at: new Date().toISOString(),
+            stargazers_count: 200,
+            archived: false,
+          },
+        }),
+      },
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: makeIssues("owner/repo"),
+        }),
+      },
+    } as unknown as Octokit;
+
+    // maxResults=1, so cap is 1*3=3 items
+    const result = await fetchIssuesFromMaintainedRepos(
+      octokit,
+      ["owner/repo1", "owner/repo2", "owner/repo3"],
+      50,
+      1,
+    );
+
+    // Should stop after collecting >= 3 items (cap is maxResults * 3)
+    expect(result.length).toBeLessThanOrEqual(4); // first repo yields 4, then stops
+    expect((octokit.repos.get as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
   });
 });

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -684,9 +684,7 @@ describe("fetchIssuesFromMaintainedRepos", () => {
     );
 
     expect(result).toHaveLength(1);
-    expect(result[0].html_url).toBe(
-      "https://github.com/owner/repo/issues/1",
-    );
+    expect(result[0].html_url).toBe("https://github.com/owner/repo/issues/1");
     expect(result[0].repository_url).toBe(
       "https://api.github.com/repos/owner/repo",
     );
@@ -775,7 +773,9 @@ describe("fetchIssuesFromMaintainedRepos", () => {
           updated_at: "2026-01-01T00:00:00Z",
           title: "A pull request",
           labels: [],
-          pull_request: { url: "https://api.github.com/repos/owner/repo/pulls/2" },
+          pull_request: {
+            url: "https://api.github.com/repos/owner/repo/pulls/2",
+          },
         },
       ],
     });
@@ -843,6 +843,8 @@ describe("fetchIssuesFromMaintainedRepos", () => {
 
     // Should stop after collecting >= 3 items (cap is maxResults * 3)
     expect(result.length).toBeLessThanOrEqual(4); // first repo yields 4, then stops
-    expect((octokit.repos.get as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    expect(
+      (octokit.repos.get as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(1);
   });
 });

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -167,6 +167,81 @@ export async function cachedSearchIssues(
 // ── Search infrastructure ──
 
 /**
+ * Fetch issues from maintained repos using REST API (no Search API quota).
+ *
+ * Checks each repo for recent push activity and star threshold,
+ * then fetches open issues via `GET /repos/{owner}/{repo}/issues`.
+ * Falls back to the caller to use Search API if this doesn't yield enough.
+ *
+ * @param octokit     Authenticated Octokit instance
+ * @param repos       Starred repos to check (owner/repo format)
+ * @param minStars    Minimum star count to include a repo
+ * @param maxResults  Target number of issue candidates
+ */
+export async function fetchIssuesFromMaintainedRepos(
+  octokit: Octokit,
+  repos: string[],
+  minStars: number,
+  maxResults: number,
+): Promise<GitHubSearchItem[]> {
+  const items: GitHubSearchItem[] = [];
+
+  for (const repoFullName of repos) {
+    if (items.length >= maxResults * 3) break;
+
+    const [owner, repo] = repoFullName.split("/");
+    if (!owner || !repo) continue;
+
+    try {
+      // Check if repo is actively maintained (pushed recently)
+      const { data: repoData } = await octokit.repos.get({ owner, repo });
+
+      // Skip if not actively maintained or below star threshold
+      const pushedAt = new Date(repoData.pushed_at);
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+      if (pushedAt < thirtyDaysAgo) continue;
+      if ((repoData.stargazers_count ?? 0) < minStars) continue;
+      if (repoData.archived) continue;
+
+      // Fetch open issues via REST (no search quota used)
+      const { data: issues } = await octokit.issues.listForRepo({
+        owner,
+        repo,
+        state: "open",
+        sort: "created",
+        direction: "desc",
+        per_page: 5,
+      });
+
+      // Filter out pull requests (REST issues endpoint includes PRs)
+      const realIssues = issues.filter(
+        (i: { pull_request?: unknown }) => !i.pull_request,
+      );
+
+      for (const issue of realIssues) {
+        items.push({
+          html_url: issue.html_url,
+          repository_url: `https://api.github.com/repos/${repoFullName}`,
+          updated_at: issue.updated_at ?? "",
+          title: issue.title,
+          labels: issue.labels as Array<{ name?: string } | string>,
+        });
+      }
+
+      await sleep(INTER_QUERY_DELAY_MS);
+    } catch (error) {
+      debug(
+        MODULE,
+        `Error fetching issues from ${repoFullName}: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  return items;
+}
+
+/**
  * Search across chunked labels with deduplication.
  *
  * Splits labels into chunks that fit within GitHub's boolean operator budget,

--- a/packages/core/src/core/strategy-selection.test.ts
+++ b/packages/core/src/core/strategy-selection.test.ts
@@ -30,6 +30,7 @@ vi.mock("./search-phases.js", () => ({
   buildEffectiveLabels: vi.fn((_scopes: unknown, labels: string[]) => labels),
   interleaveArrays: vi.fn((arrays: unknown[][]) => arrays.flat()),
   cachedSearchIssues: vi.fn().mockResolvedValue({ total_count: 0, items: [] }),
+  fetchIssuesFromMaintainedRepos: vi.fn().mockResolvedValue([]),
   filterVetAndScore: vi.fn().mockResolvedValue({
     candidates: [],
     allVetFailed: false,


### PR DESCRIPTION
## Summary

- Phase 3 (`runPhase3`) now checks starred repos via REST API (`GET /repos/{owner}/{repo}` + `GET /repos/{owner}/{repo}/issues`) before falling back to the Search API
- New `fetchIssuesFromMaintainedRepos()` in `search-phases.ts` fetches issues from repos that are actively maintained (pushed within 30 days), above the star threshold, and not archived
- Filters out pull requests from the REST issues endpoint (which returns both issues and PRs)
- Falls back to the existing Search API query when REST doesn't yield enough candidates

## Test plan

- [x] `fetchIssuesFromMaintainedRepos` unit tests: active repos, stale repos skipped, low-star repos skipped, archived repos skipped, PR filtering, error handling, early termination
- [x] Phase 3 integration tests: REST-first path, fallback to Search API when REST yields nothing, fallback when no starred repos available
- [x] All 461 existing tests still pass
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] ESLint passes

Closes #54