### PR TITLE
fix: use REST Issues API for Phase 0 and Phase 1 searches

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -83,6 +83,12 @@ const mockSearchInRepos = vi.fn().mockResolvedValue({
   rateLimitHit: false,
 });
 
+const mockFetchIssuesFromKnownRepos = vi.fn().mockResolvedValue({
+  candidates: [],
+  allReposFailed: false,
+  rateLimitHit: false,
+});
+
 const mockSearchWithChunkedLabels = vi.fn().mockResolvedValue([]);
 
 const mockFilterVetAndScore = vi.fn().mockResolvedValue({
@@ -102,6 +108,8 @@ vi.mock("./search-phases.js", () => ({
   ),
   interleaveArrays: vi.fn((arrays: unknown[][]) => arrays.flat()),
   searchInRepos: (...args: unknown[]) => mockSearchInRepos(...args),
+  fetchIssuesFromKnownRepos: (...args: unknown[]) =>
+    mockFetchIssuesFromKnownRepos(...args),
   searchWithChunkedLabels: (...args: unknown[]) =>
     mockSearchWithChunkedLabels(...args),
   filterVetAndScore: (...args: unknown[]) => mockFilterVetAndScore(...args),
@@ -227,6 +235,11 @@ describe("IssueDiscovery", () => {
       allBatchesFailed: false,
       rateLimitHit: false,
     });
+    mockFetchIssuesFromKnownRepos.mockResolvedValue({
+      candidates: [],
+      allReposFailed: false,
+      rateLimitHit: false,
+    });
     mockSearchWithChunkedLabels.mockResolvedValue([]);
     mockFilterVetAndScore.mockResolvedValue({
       candidates: [],
@@ -246,11 +259,11 @@ describe("IssueDiscovery", () => {
   });
 
   describe("searchIssues — phase execution", () => {
-    it("Phase 0: calls searchInRepos with merged-PR repos, priority merged_pr", async () => {
+    it("Phase 0: calls fetchIssuesFromKnownRepos with merged-PR repos, priority merged_pr", async () => {
       const c = makeCandidate("org/merged-repo", "merged_pr");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -260,11 +273,10 @@ describe("IssueDiscovery", () => {
 
       const { candidates } = await discovery.searchIssues({ maxResults: 5 });
       expect(candidates.length).toBeGreaterThanOrEqual(1);
-      expect(mockSearchInRepos).toHaveBeenCalledWith(
+      expect(mockFetchIssuesFromKnownRepos).toHaveBeenCalledWith(
         expect.anything(), // octokit
         expect.anything(), // vetter
         ["org/merged-repo"],
-        expect.stringContaining("is:issue"),
         [], // no labels for Phase 0
         expect.any(Number),
         "merged_pr",
@@ -272,11 +284,11 @@ describe("IssueDiscovery", () => {
       );
     });
 
-    it("Phase 1: calls searchInRepos with starred repos, priority starred", async () => {
+    it("Phase 1: calls fetchIssuesFromKnownRepos with starred repos, priority starred", async () => {
       const c = makeCandidate("org/starred-repo", "starred");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -285,9 +297,9 @@ describe("IssueDiscovery", () => {
       });
 
       await discovery.searchIssues({ maxResults: 5 });
-      // Phase 1 calls searchInRepos with "starred" priority
-      const phase1Call = mockSearchInRepos.mock.calls.find(
-        (call) => call[6] === "starred",
+      // Phase 1 calls fetchIssuesFromKnownRepos with "starred" priority
+      const phase1Call = mockFetchIssuesFromKnownRepos.mock.calls.find(
+        (call) => call[5] === "starred",
       );
       expect(phase1Call).toBeDefined();
       expect(phase1Call![2]).toEqual(["org/starred-repo"]);
@@ -342,9 +354,9 @@ describe("IssueDiscovery", () => {
   describe("searchIssues — strategy filtering", () => {
     it("strategies=[merged] runs only Phase 0", async () => {
       const c = makeCandidate("org/merged-repo", "merged_pr");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -366,9 +378,9 @@ describe("IssueDiscovery", () => {
 
     it("strategies=[starred,broad] runs only Phases 1 and 2", async () => {
       const c = makeCandidate("org/starred-repo", "starred");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -397,9 +409,9 @@ describe("IssueDiscovery", () => {
       });
 
       const c = makeCandidate("org/merged", "merged_pr");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -493,9 +505,9 @@ describe("IssueDiscovery", () => {
       });
 
       const c = makeCandidate("org/repo", "merged_pr");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -515,9 +527,9 @@ describe("IssueDiscovery", () => {
         makeCandidate("org/repo1", "normal"),
         makeCandidate("org/repo2", "normal"),
       ];
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates,
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -542,15 +554,15 @@ describe("IssueDiscovery", () => {
         rateLimitHit: false,
       });
       // Phase 0 returns merged
-      mockSearchInRepos.mockResolvedValueOnce({
+      mockFetchIssuesFromKnownRepos.mockResolvedValueOnce({
         candidates: [merged],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
       // Phase 1 returns starred
-      mockSearchInRepos.mockResolvedValueOnce({
+      mockFetchIssuesFromKnownRepos.mockResolvedValueOnce({
         candidates: [starred],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -596,9 +608,9 @@ describe("IssueDiscovery", () => {
     it("filterIssues excludes repos in aiPolicyBlocklist", async () => {
       // Provide a candidate so the search doesn't throw
       const c = makeCandidate("allowed/repo", "merged_pr");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -454,9 +454,9 @@ describe("IssueDiscovery", () => {
   describe("searchIssues — inter-phase delay", () => {
     it("uses interPhaseDelayMs preference for sleep between phases", async () => {
       const c = makeCandidate("org/starred-repo", "starred");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 
@@ -476,9 +476,9 @@ describe("IssueDiscovery", () => {
 
     it("skips sleep when interPhaseDelayMs is 0", async () => {
       const c = makeCandidate("org/starred-repo", "starred");
-      mockSearchInRepos.mockResolvedValue({
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
         candidates: [c],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
 

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -47,7 +47,7 @@ import {
   interleaveArrays,
   cachedSearchIssues,
   filterVetAndScore,
-  searchInRepos,
+  fetchIssuesFromKnownRepos,
   searchWithChunkedLabels,
 } from "./search-phases.js";
 
@@ -110,7 +110,6 @@ async function runPhase0(
   octokit: Octokit,
   vetter: IssueVetter,
   repos: string[],
-  baseQualifiers: string,
   maxResults: number,
   filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
 ): Promise<PhaseResult> {
@@ -119,22 +118,22 @@ async function runPhase0(
     `Phase 0: Searching issues in ${repos.length} merged-PR repos (no label filter)...`,
   );
 
-  const { candidates, allBatchesFailed, rateLimitHit } = await searchInRepos(
-    octokit,
-    vetter,
-    repos,
-    baseQualifiers,
-    [],
-    maxResults,
-    "merged_pr",
-    filterIssues,
-  );
+  const { candidates, allReposFailed, rateLimitHit } =
+    await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      repos,
+      [],
+      maxResults,
+      "merged_pr",
+      filterIssues,
+    );
 
   info(MODULE, `Found ${candidates.length} candidates from merged-PR repos`);
 
   return {
     candidates,
-    error: allBatchesFailed ? "All merged-PR repo batches failed" : null,
+    error: allReposFailed ? "All merged-PR repo fetches failed" : null,
     rateLimitHit,
   };
 }
@@ -144,32 +143,31 @@ async function runPhase1(
   octokit: Octokit,
   vetter: IssueVetter,
   repos: string[],
-  baseQualifiers: string,
   labels: string[],
   maxResults: number,
   filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
 ): Promise<PhaseResult> {
   info(MODULE, `Phase 1: Searching issues in ${repos.length} starred repos...`);
 
-  // Cap labels to reduce Search API calls: starred repos already signal user
-  // interest, so fewer labels suffice.
+  // Cap labels: starred repos already signal user interest, so fewer labels suffice.
   const phase1Labels = labels.slice(0, 3);
-  const { candidates, allBatchesFailed, rateLimitHit } = await searchInRepos(
-    octokit,
-    vetter,
-    repos.slice(0, 10),
-    baseQualifiers,
-    phase1Labels,
-    maxResults,
-    "starred",
-    filterIssues,
-  );
+  const reposToSearch = repos.slice(0, 10);
+  const { candidates, allReposFailed, rateLimitHit } =
+    await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      reposToSearch,
+      phase1Labels,
+      maxResults,
+      "starred",
+      filterIssues,
+    );
 
   info(MODULE, `Found ${candidates.length} candidates from starred repos`);
 
   return {
     candidates,
-    error: allBatchesFailed ? "All starred repo batches failed" : null,
+    error: allReposFailed ? "All starred repo fetches failed" : null,
     rateLimitHit,
   };
 }
@@ -557,7 +555,6 @@ export class IssueDiscovery {
           this.octokit,
           this.vetter,
           phase0Repos,
-          baseQualifiers,
           remaining,
           filterIssues,
         );
@@ -590,7 +587,6 @@ export class IssueDiscovery {
             this.octokit,
             this.vetter,
             reposToSearch,
-            baseQualifiers,
             labels,
             remaining,
             filterIssues,

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -616,8 +616,11 @@ describe("fetchIssuesFromKnownRepos", () => {
     expect(result.rateLimitHit).toBe(false);
     // Should call listForRepo for each repo
     expect(
-      (octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }).issues
-        .listForRepo,
+      (
+        octokit as unknown as {
+          issues: { listForRepo: ReturnType<typeof vi.fn> };
+        }
+      ).issues.listForRepo,
     ).toHaveBeenCalledTimes(2);
     // Vetter called once per repo
     expect(vetter.vetIssuesParallel).toHaveBeenCalledTimes(2);
@@ -657,9 +660,7 @@ describe("fetchIssuesFromKnownRepos", () => {
         issuesAndPullRequests: vi.fn(),
       },
     } as unknown as Octokit;
-    const candidates = [
-      makeCandidate("https://github.com/a/b/issues/1", 100),
-    ];
+    const candidates = [makeCandidate("https://github.com/a/b/issues/1", 100)];
     const vetter = makeMockVetter(candidates);
 
     const result = await fetchIssuesFromKnownRepos(
@@ -688,9 +689,7 @@ describe("fetchIssuesFromKnownRepos", () => {
         issuesAndPullRequests: vi.fn(),
       },
     } as unknown as Octokit;
-    const candidates = [
-      makeCandidate("https://github.com/a/b/issues/1", 100),
-    ];
+    const candidates = [makeCandidate("https://github.com/a/b/issues/1", 100)];
     const vetter = makeMockVetter(candidates);
 
     const result = await fetchIssuesFromKnownRepos(
@@ -706,8 +705,11 @@ describe("fetchIssuesFromKnownRepos", () => {
     expect(result.candidates).toHaveLength(1);
     // Should only call listForRepo once since maxResults was reached after first repo
     expect(
-      (octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }).issues
-        .listForRepo,
+      (
+        octokit as unknown as {
+          issues: { listForRepo: ReturnType<typeof vi.fn> };
+        }
+      ).issues.listForRepo,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -797,8 +799,11 @@ describe("fetchIssuesFromKnownRepos", () => {
     );
 
     expect(
-      (octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }).issues
-        .listForRepo,
+      (
+        octokit as unknown as {
+          issues: { listForRepo: ReturnType<typeof vi.fn> };
+        }
+      ).issues.listForRepo,
     ).toHaveBeenCalledWith(
       expect.objectContaining({
         owner: "owner",
@@ -824,7 +829,9 @@ describe("fetchIssuesFromKnownRepos", () => {
     );
 
     const call = (
-      octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }
+      octokit as unknown as {
+        issues: { listForRepo: ReturnType<typeof vi.fn> };
+      }
     ).issues.listForRepo.mock.calls[0][0];
     expect(call).not.toHaveProperty("labels");
   });

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -56,6 +56,7 @@ import {
   cachedSearchIssues,
   searchWithChunkedLabels,
   filterVetAndScore,
+  fetchIssuesFromKnownRepos,
   searchInRepos,
 } from "./search-phases.js";
 import { isRateLimitError } from "./errors.js";
@@ -539,6 +540,293 @@ describe("filterVetAndScore", () => {
     expect(result.candidates).toEqual([candidate]);
     expect(result.allVetFailed).toBe(false);
     expect(result.rateLimitHit).toBe(false);
+  });
+});
+
+function makeMockOctokitWithRest(
+  issues: Array<{
+    html_url: string;
+    updated_at: string;
+    title: string;
+    labels: Array<{ name?: string } | string>;
+  }> = [],
+) {
+  return {
+    issues: {
+      listForRepo: vi.fn().mockResolvedValue({ data: issues }),
+    },
+    search: {
+      issuesAndPullRequests: vi
+        .fn()
+        .mockResolvedValue({ data: { total_count: 0, items: [] } }),
+    },
+  } as unknown as Octokit;
+}
+
+function makeRestIssue(
+  repoFullName: string,
+  number: number,
+  opts?: { title?: string; labels?: Array<{ name?: string } | string> },
+) {
+  return {
+    html_url: `https://github.com/${repoFullName}/issues/${number}`,
+    updated_at: "2026-01-01T00:00:00Z",
+    title: opts?.title ?? `Issue ${number}`,
+    labels: opts?.labels ?? [],
+  };
+}
+
+describe("fetchIssuesFromKnownRepos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches issues from multiple repos", async () => {
+    const issues = [makeRestIssue("a/b", 1), makeRestIssue("a/b", 2)];
+    const octokit = makeMockOctokitWithRest(issues);
+    const candidate1 = makeCandidate("https://github.com/a/b/issues/1", 100);
+    const candidate2 = makeCandidate("https://github.com/c/d/issues/1", 100);
+    const vetter = {
+      vetIssuesParallel: vi
+        .fn()
+        .mockResolvedValueOnce({
+          candidates: [candidate1],
+          allFailed: false,
+          rateLimitHit: false,
+        })
+        .mockResolvedValueOnce({
+          candidates: [candidate2],
+          allFailed: false,
+          rateLimitHit: false,
+        }),
+    } as unknown as IssueVetter;
+
+    const result = await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["a/b", "c/d"],
+      [],
+      10,
+      "merged_pr",
+      (items) => items,
+    );
+
+    expect(result.candidates).toHaveLength(2);
+    expect(result.allReposFailed).toBe(false);
+    expect(result.rateLimitHit).toBe(false);
+    // Should call listForRepo for each repo
+    expect(
+      (octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }).issues
+        .listForRepo,
+    ).toHaveBeenCalledTimes(2);
+    // Vetter called once per repo
+    expect(vetter.vetIssuesParallel).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles empty results", async () => {
+    const octokit = makeMockOctokitWithRest([]);
+    const vetter = makeMockVetter([]);
+
+    const result = await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["a/b"],
+      [],
+      10,
+      "merged_pr",
+      (items) => items,
+    );
+
+    expect(result.candidates).toHaveLength(0);
+    expect(result.allReposFailed).toBe(false);
+    // Vetter should not be called when there are no issues
+    expect(vetter.vetIssuesParallel).not.toHaveBeenCalled();
+  });
+
+  it("handles per-repo errors gracefully", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi
+          .fn()
+          .mockResolvedValueOnce({
+            data: [makeRestIssue("a/b", 1)],
+          })
+          .mockRejectedValueOnce(new Error("404 Not Found")),
+      },
+      search: {
+        issuesAndPullRequests: vi.fn(),
+      },
+    } as unknown as Octokit;
+    const candidates = [
+      makeCandidate("https://github.com/a/b/issues/1", 100),
+    ];
+    const vetter = makeMockVetter(candidates);
+
+    const result = await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["a/b", "c/d"],
+      [],
+      10,
+      "merged_pr",
+      (items) => items,
+    );
+
+    // Should still return results from the repo that succeeded
+    expect(result.candidates).toHaveLength(1);
+    expect(result.allReposFailed).toBe(false);
+  });
+
+  it("stops when maxResults reached", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: [makeRestIssue("a/b", 1)],
+        }),
+      },
+      search: {
+        issuesAndPullRequests: vi.fn(),
+      },
+    } as unknown as Octokit;
+    const candidates = [
+      makeCandidate("https://github.com/a/b/issues/1", 100),
+    ];
+    const vetter = makeMockVetter(candidates);
+
+    const result = await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["a/b", "c/d", "e/f"],
+      [],
+      1, // maxResults = 1
+      "merged_pr",
+      (items) => items,
+    );
+
+    expect(result.candidates).toHaveLength(1);
+    // Should only call listForRepo once since maxResults was reached after first repo
+    expect(
+      (octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }).issues
+        .listForRepo,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies filter function", async () => {
+    const issues = [makeRestIssue("a/b", 1), makeRestIssue("a/b", 2)];
+    const octokit = makeMockOctokitWithRest(issues);
+    const vetter = makeMockVetter([]);
+
+    await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["a/b"],
+      [],
+      10,
+      "merged_pr",
+      // Filter that removes all items
+      () => [],
+    );
+
+    // Vetter should not be called because filter removed all items
+    expect(vetter.vetIssuesParallel).not.toHaveBeenCalled();
+  });
+
+  it("returns allReposFailed: true when all repos fail", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockRejectedValue(new Error("API error")),
+      },
+      search: {
+        issuesAndPullRequests: vi.fn(),
+      },
+    } as unknown as Octokit;
+    const vetter = makeMockVetter([]);
+
+    const result = await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["a/b", "c/d"],
+      [],
+      10,
+      "merged_pr",
+      (items) => items,
+    );
+
+    expect(result.allReposFailed).toBe(true);
+    expect(result.candidates).toHaveLength(0);
+  });
+
+  it("tracks rateLimitHit", async () => {
+    vi.mocked(isRateLimitError).mockReturnValue(true);
+
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockRejectedValue(new Error("rate limit")),
+      },
+      search: {
+        issuesAndPullRequests: vi.fn(),
+      },
+    } as unknown as Octokit;
+    const vetter = makeMockVetter([]);
+
+    const result = await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["a/b"],
+      [],
+      10,
+      "merged_pr",
+      (items) => items,
+    );
+
+    expect(result.rateLimitHit).toBe(true);
+  });
+
+  it("passes labels as comma-joined string to listForRepo", async () => {
+    const octokit = makeMockOctokitWithRest([]);
+    const vetter = makeMockVetter([]);
+
+    await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["owner/repo"],
+      ["good first issue", "help wanted"],
+      10,
+      "starred",
+      (items) => items,
+    );
+
+    expect(
+      (octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }).issues
+        .listForRepo,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "owner",
+        repo: "repo",
+        state: "open",
+        labels: "good first issue,help wanted",
+      }),
+    );
+  });
+
+  it("omits labels param when labels array is empty", async () => {
+    const octokit = makeMockOctokitWithRest([]);
+    const vetter = makeMockVetter([]);
+
+    await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["owner/repo"],
+      [],
+      10,
+      "merged_pr",
+      (items) => items,
+    );
+
+    const call = (
+      octokit as unknown as { issues: { listForRepo: ReturnType<typeof vi.fn> } }
+    ).issues.listForRepo.mock.calls[0][0];
+    expect(call).not.toHaveProperty("labels");
   });
 });
 

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -167,6 +167,101 @@ export async function cachedSearchIssues(
 // ── Search infrastructure ──
 
 /**
+ * Fetch open issues from known repos using REST API (no Search API quota).
+ * Used by Phase 0 (merged-PR repos) and Phase 1 (starred repos).
+ *
+ * Instead of the Search API (`octokit.search.issuesAndPullRequests`), this
+ * calls `GET /repos/{owner}/{repo}/issues` which counts against the much
+ * larger Core API rate limit and avoids consuming the scarce Search quota.
+ */
+export async function fetchIssuesFromKnownRepos(
+  octokit: Octokit,
+  vetter: IssueVetter,
+  repos: string[],
+  labels: string[],
+  maxResults: number,
+  priority: SearchPriority,
+  filterFn: (items: GitHubSearchItem[]) => GitHubSearchItem[],
+): Promise<{
+  candidates: IssueCandidate[];
+  allReposFailed: boolean;
+  rateLimitHit: boolean;
+}> {
+  const candidates: IssueCandidate[] = [];
+  let failedRepos = 0;
+  let rateLimitFailures = 0;
+
+  for (let i = 0; i < repos.length; i++) {
+    if (candidates.length >= maxResults) break;
+
+    // Delay between repos to avoid REST secondary rate limits
+    if (i > 0) await sleep(INTER_QUERY_DELAY_MS);
+
+    const repoFullName = repos[i];
+    const [owner, repo] = repoFullName.split("/");
+
+    try {
+      const response = await octokit.issues.listForRepo({
+        owner,
+        repo,
+        state: "open",
+        sort: "created",
+        direction: "desc",
+        per_page: 5,
+        ...(labels.length > 0 ? { labels: labels.join(",") } : {}),
+      });
+
+      const mapped: GitHubSearchItem[] = response.data.map((issue) => ({
+        html_url: issue.html_url,
+        repository_url: `https://api.github.com/repos/${repoFullName}`,
+        updated_at: issue.updated_at ?? "",
+        title: issue.title,
+        labels: issue.labels as Array<{ name?: string } | string>,
+      }));
+
+      if (mapped.length > 0) {
+        const filtered = filterFn(mapped);
+        if (filtered.length > 0) {
+          const remainingNeeded = maxResults - candidates.length;
+          const { candidates: vetted, rateLimitHit: vetRateLimitHit } =
+            await vetter.vetIssuesParallel(
+              filtered
+                .slice(0, remainingNeeded * 2)
+                .map((item) => item.html_url),
+              remainingNeeded,
+              priority,
+            );
+          candidates.push(...vetted);
+          if (vetRateLimitHit) rateLimitFailures++;
+        }
+      }
+    } catch (error) {
+      failedRepos++;
+      if (isRateLimitError(error)) {
+        rateLimitFailures++;
+      }
+      warn(
+        MODULE,
+        `Error fetching issues from ${repoFullName}:`,
+        errorMessage(error),
+      );
+    }
+  }
+
+  const allReposFailed = failedRepos === repos.length && repos.length > 0;
+  const rateLimitHit = rateLimitFailures > 0;
+  if (allReposFailed) {
+    warn(
+      MODULE,
+      `All ${repos.length} repo(s) failed for ${priority} phase. ` +
+        `This may indicate a systemic issue (rate limit, auth, network).`,
+    );
+  }
+
+  return { candidates, allReposFailed, rateLimitHit };
+}
+
+/**
  * Search across chunked labels with deduplication.
  *
  * Splits labels into chunks that fit within GitHub's boolean operator budget,

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -211,7 +211,12 @@ export async function fetchIssuesFromKnownRepos(
         ...(labels.length > 0 ? { labels: labels.join(",") } : {}),
       });
 
-      const mapped: GitHubSearchItem[] = response.data.map((issue) => ({
+      // Filter out pull requests (REST issues endpoint returns both) and assigned issues
+      const issuesOnly = response.data.filter(
+        (item) => !("pull_request" in item) && !item.assignee,
+      );
+
+      const mapped: GitHubSearchItem[] = issuesOnly.map((issue) => ({
         html_url: issue.html_url,
         repository_url: `https://api.github.com/repos/${repoFullName}`,
         updated_at: issue.updated_at ?? "",

--- a/packages/core/src/core/strategy-selection.test.ts
+++ b/packages/core/src/core/strategy-selection.test.ts
@@ -137,9 +137,8 @@ function makeFakeCandidate(repo: string, priority: string) {
 // ── Import after mocks ─────────────────────────────────────────────
 
 const { IssueDiscovery } = await import("./issue-discovery.js");
-const { searchInRepos, fetchIssuesFromKnownRepos } = await import(
-  "./search-phases.js"
-);
+const { searchInRepos, fetchIssuesFromKnownRepos } =
+  await import("./search-phases.js");
 
 const basePreferences = {
   githubUsername: "test",

--- a/packages/core/src/core/strategy-selection.test.ts
+++ b/packages/core/src/core/strategy-selection.test.ts
@@ -40,6 +40,11 @@ vi.mock("./search-phases.js", () => ({
     allBatchesFailed: false,
     rateLimitHit: false,
   }),
+  fetchIssuesFromKnownRepos: vi.fn().mockResolvedValue({
+    candidates: [],
+    allReposFailed: false,
+    rateLimitHit: false,
+  }),
   searchWithChunkedLabels: vi.fn().mockResolvedValue([]),
 }));
 
@@ -132,7 +137,9 @@ function makeFakeCandidate(repo: string, priority: string) {
 // ── Import after mocks ─────────────────────────────────────────────
 
 const { IssueDiscovery } = await import("./issue-discovery.js");
-const { searchInRepos } = await import("./search-phases.js");
+const { searchInRepos, fetchIssuesFromKnownRepos } = await import(
+  "./search-phases.js"
+);
 
 const basePreferences = {
   githubUsername: "test",
@@ -157,8 +164,13 @@ const baseStateReader = {
 describe("Strategy Selection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (searchInRepos as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (fetchIssuesFromKnownRepos as ReturnType<typeof vi.fn>).mockResolvedValue({
       candidates: [makeFakeCandidate("owner/merged-repo", "merged_pr")],
+      allReposFailed: false,
+      rateLimitHit: false,
+    });
+    (searchInRepos as ReturnType<typeof vi.fn>).mockResolvedValue({
+      candidates: [],
       allBatchesFailed: false,
       rateLimitHit: false,
     });
@@ -190,7 +202,7 @@ describe("Strategy Selection", () => {
     const discovery = new IssueDiscovery("token", basePreferences, stateReader);
     const result = await discovery.searchIssues({ strategies: ["merged"] });
     expect(result.strategiesUsed).toEqual(["merged"]);
-    expect(searchInRepos).toHaveBeenCalledTimes(1);
+    expect(fetchIssuesFromKnownRepos).toHaveBeenCalledTimes(1);
   });
 
   it("only runs starred strategy when specified", async () => {
@@ -198,15 +210,15 @@ describe("Strategy Selection", () => {
       ...baseStateReader,
       getStarredRepos: () => ["owner/starred"],
     };
-    (searchInRepos as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (fetchIssuesFromKnownRepos as ReturnType<typeof vi.fn>).mockResolvedValue({
       candidates: [makeFakeCandidate("owner/starred", "starred")],
-      allBatchesFailed: false,
+      allReposFailed: false,
       rateLimitHit: false,
     });
     const discovery = new IssueDiscovery("token", basePreferences, stateReader);
     const result = await discovery.searchIssues({ strategies: ["starred"] });
     expect(result.strategiesUsed).toEqual(["starred"]);
-    expect(searchInRepos).toHaveBeenCalledTimes(1);
+    expect(fetchIssuesFromKnownRepos).toHaveBeenCalledTimes(1);
   });
 
   it('runs all strategies when "all" is specified', async () => {
@@ -246,7 +258,7 @@ describe("Strategy Selection", () => {
     const discovery = new IssueDiscovery("token", prefs, stateReader);
     const result = await discovery.searchIssues({});
     expect(result.strategiesUsed).toEqual(["merged"]);
-    expect(searchInRepos).toHaveBeenCalledTimes(1);
+    expect(fetchIssuesFromKnownRepos).toHaveBeenCalledTimes(1);
   });
 
   it("can combine multiple strategies", async () => {
@@ -255,15 +267,15 @@ describe("Strategy Selection", () => {
       getReposWithMergedPRs: () => ["owner/repo"],
       getStarredRepos: () => ["owner/starred"],
     };
-    (searchInRepos as ReturnType<typeof vi.fn>)
+    (fetchIssuesFromKnownRepos as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce({
         candidates: [makeFakeCandidate("owner/repo", "merged_pr")],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       })
       .mockResolvedValueOnce({
         candidates: [makeFakeCandidate("owner/starred", "starred")],
-        allBatchesFailed: false,
+        allReposFailed: false,
         rateLimitHit: false,
       });
     const discovery = new IssueDiscovery("token", basePreferences, stateReader);
@@ -286,7 +298,7 @@ describe("Strategy Selection", () => {
     await expect(
       discovery.searchIssues({ strategies: ["merged"] }),
     ).rejects.toThrow(/No issue candidates found/);
-    expect(searchInRepos).not.toHaveBeenCalled();
+    expect(fetchIssuesFromKnownRepos).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Phase 0 (merged-PR repos) and Phase 1 (starred repos) now call `octokit.issues.listForRepo` (REST Core API) instead of `octokit.search.issuesAndPullRequests` (Search API)
- Adds `fetchIssuesFromKnownRepos()` to `search-phases.ts` that iterates known repos individually via the REST endpoint
- Since we already know the exact repo names for these phases, using the Search API was wasteful and consumed scarce Search quota (30 req/min)

## Test plan

- [x] All 461 existing tests pass
- [x] Added 9 new tests for `fetchIssuesFromKnownRepos`: multi-repo fetch, empty results, per-repo error handling, maxResults early stop, filter function application, allReposFailed tracking, rateLimitHit tracking, label passthrough, label omission
- [x] Updated Phase 0/Phase 1 assertions in `issue-discovery.test.ts` and `strategy-selection.test.ts`
- [x] Lint clean, typecheck clean

Closes #52