### PR TITLE
fix: harden error handling in REST search functions

### DIFF
--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -319,30 +319,39 @@ async function runPhase3(
     );
 
     if (restItems.length > 0) {
-      const {
-        candidates,
-        allVetFailed,
-        rateLimitHit: vetRateLimitHit,
-      } = await filterVetAndScore(
-        vetter,
-        restItems,
-        filterIssues,
-        [phase0RepoSet, seenRepos],
-        maxResults,
-        minStars,
-        "Phase 3 (REST)",
-      );
-
-      if (candidates.length > 0) {
-        info(
-          MODULE,
-          `Found ${candidates.length} candidates from maintained-repo REST search`,
-        );
-        return {
+      try {
+        const {
           candidates,
-          error: allVetFailed ? "all vetting failed" : null,
+          allVetFailed,
           rateLimitHit: vetRateLimitHit,
-        };
+        } = await filterVetAndScore(
+          vetter,
+          restItems,
+          filterIssues,
+          [phase0RepoSet, seenRepos],
+          maxResults,
+          minStars,
+          "Phase 3 (REST)",
+        );
+
+        if (candidates.length > 0) {
+          info(
+            MODULE,
+            `Found ${candidates.length} candidates from maintained-repo REST search`,
+          );
+          return {
+            candidates,
+            error: allVetFailed ? "all vetting failed" : null,
+            rateLimitHit: vetRateLimitHit,
+          };
+        }
+      } catch (error) {
+        if (getHttpStatusCode(error) === 401) throw error;
+        warn(
+          MODULE,
+          `Phase 3 REST vetting failed, falling back to Search API:`,
+          errorMessage(error),
+        );
       }
     }
   }

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -24,6 +24,7 @@ vi.mock("./errors.js", () => ({
     e instanceof Error ? e.message : String(e),
   ),
   isRateLimitError: vi.fn(() => false),
+  getHttpStatusCode: vi.fn(() => undefined),
 }));
 
 vi.mock("./search-budget.js", () => ({

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -12,7 +12,7 @@ import {
   type IssueScope,
   SCOPE_LABELS,
 } from "./types.js";
-import { errorMessage, isRateLimitError } from "./errors.js";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { debug, warn } from "./logger.js";
 import { getHttpCache } from "./http-cache.js";
 import {
@@ -190,6 +190,7 @@ export async function fetchIssuesFromMaintainedRepos(
     try {
       const { data: repoData } = await octokit.repos.get({ owner, repo });
 
+      if (!repoData.pushed_at) continue;
       const pushedAt = new Date(repoData.pushed_at);
       const thirtyDaysAgo = new Date();
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
@@ -206,8 +207,10 @@ export async function fetchIssuesFromMaintainedRepos(
         per_page: 5,
       });
 
+      // Filter out pull requests and assigned issues (REST endpoint returns both)
       const realIssues = issues.filter(
-        (i: { pull_request?: unknown }) => !i.pull_request,
+        (i: { pull_request?: unknown; assignee?: unknown }) =>
+          !i.pull_request && !i.assignee,
       );
 
       for (const issue of realIssues) {
@@ -222,9 +225,19 @@ export async function fetchIssuesFromMaintainedRepos(
 
       await sleep(INTER_QUERY_DELAY_MS);
     } catch (error) {
-      debug(
+      if (getHttpStatusCode(error) === 401) throw error;
+      if (isRateLimitError(error)) {
+        warn(
+          MODULE,
+          `Rate limit hit fetching issues from ${repoFullName}:`,
+          errorMessage(error),
+        );
+        break;
+      }
+      warn(
         MODULE,
-        `Error fetching issues from ${repoFullName}: ${errorMessage(error)}`,
+        `Error fetching issues from ${repoFullName}:`,
+        errorMessage(error),
       );
     }
   }
@@ -309,6 +322,7 @@ export async function fetchIssuesFromKnownRepos(
         }
       }
     } catch (error) {
+      if (getHttpStatusCode(error) === 401) throw error;
       failedRepos++;
       if (isRateLimitError(error)) {
         rateLimitFailures++;


### PR DESCRIPTION
## Summary

Post-merge review of PRs #58-#62 identified several error handling gaps in the new REST-based search functions:

- **fetchIssuesFromMaintainedRepos** silently swallowed all errors (including auth/rate limits) at debug level, violating the project's error strategy
- **fetchIssuesFromKnownRepos** didn't propagate 401 auth errors, causing confusing "all repo fetches failed" messages on expired tokens
- Phase 3 REST vetting exceptions bypassed the Search API fallback entirely
- **fetchIssuesFromMaintainedRepos** didn't filter assigned issues (inconsistent with fetchIssuesFromKnownRepos)

## Changes

- `fetchIssuesFromMaintainedRepos`: propagate 401, break on rate limits with warn logging, filter assigned issues, guard null `pushed_at`
- `fetchIssuesFromKnownRepos`: propagate 401 auth errors per project error strategy
- Phase 3 REST path: wrap `filterVetAndScore` in try-catch so Search API fallback runs on vetting failures
- Test mock: add `getHttpStatusCode` to errors mock

## Test plan

- [x] All 491 core tests pass
- [x] Lint clean
- [x] TypeScript compiles
- [x] Format check passes