### PR TITLE
fix: MCP config parity, correct SKILL.md phase order, remove dead mocks

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -77,12 +77,6 @@ vi.mock("./errors.js", () => ({
   isRateLimitError: vi.fn(() => false),
 }));
 
-const mockSearchInRepos = vi.fn().mockResolvedValue({
-  candidates: [],
-  allReposFailed: false,
-  rateLimitHit: false,
-});
-
 const mockFetchIssuesFromKnownRepos = vi.fn().mockResolvedValue({
   candidates: [],
   allReposFailed: false,
@@ -111,7 +105,6 @@ vi.mock("./search-phases.js", () => ({
     labels.length > 0 ? labels : ["good first issue"],
   ),
   interleaveArrays: vi.fn((arrays: unknown[][]) => arrays.flat()),
-  searchInRepos: (...args: unknown[]) => mockSearchInRepos(...args),
   fetchIssuesFromKnownRepos: (...args: unknown[]) =>
     mockFetchIssuesFromKnownRepos(...args),
   searchWithChunkedLabels: (...args: unknown[]) =>
@@ -236,11 +229,6 @@ describe("IssueDiscovery", () => {
     vi.clearAllMocks();
 
     // Reset mocks to defaults
-    mockFetchIssuesFromKnownRepos.mockResolvedValue({
-      candidates: [],
-      allReposFailed: false,
-      rateLimitHit: false,
-    });
     mockFetchIssuesFromKnownRepos.mockResolvedValue({
       candidates: [],
       allReposFailed: false,
@@ -630,13 +618,6 @@ describe("IssueDiscovery", () => {
       const starred = makeCandidate("org/starred", "starred", "approve", 90);
       const normal = makeCandidate("org/normal", "normal", "approve", 95);
 
-      // Phase 2 (broad) runs first — returns normal
-      mockSearchWithChunkedLabels.mockResolvedValue([]);
-      mockFilterVetAndScore.mockResolvedValueOnce({
-        candidates: [normal],
-        allVetFailed: false,
-        rateLimitHit: false,
-      });
       // Phase 0 returns merged
       mockFetchIssuesFromKnownRepos.mockResolvedValueOnce({
         candidates: [merged],
@@ -647,6 +628,13 @@ describe("IssueDiscovery", () => {
       mockFetchIssuesFromKnownRepos.mockResolvedValueOnce({
         candidates: [starred],
         allReposFailed: false,
+        rateLimitHit: false,
+      });
+      // Phase 2 (broad) returns normal
+      mockSearchWithChunkedLabels.mockResolvedValue([]);
+      mockFilterVetAndScore.mockResolvedValueOnce({
+        candidates: [normal],
+        allVetFailed: false,
         rateLimitHit: false,
       });
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -227,6 +227,8 @@ export function registerTools(server: McpServer, scout: OssScout): void {
     "maxIssueAgeDays",
     "minRepoScoreThreshold",
     "interPhaseDelayMs",
+    "broadPhaseDelayMs",
+    "skipBroadWhenSufficientResults",
   ]);
   const BOOLEAN_KEYS = new Set(["includeDocIssues"]);
 

--- a/skills/oss-search/SKILL.md
+++ b/skills/oss-search/SKILL.md
@@ -62,7 +62,7 @@ oss-scout search --strategy merged,starred
 oss-scout config set defaultStrategy "merged,starred"
 ```
 
-The `all` strategy runs phases in order: broad (2) -> merged (0) -> starred (1) -> maintained (3). Broad search runs first to get the full Search API budget. Results are deduplicated and sorted by priority (merged_pr > starred > normal), then recommendation, then score. Rate-limit-aware: heavy phases (broad, maintained) are skipped when API budget is low.
+The `all` strategy runs phases in order: merged (0) -> starred (1) -> broad (2) -> maintained (3). Phases 0 and 1 use the REST Issues API (no search quota), so broad search gets the full Search API budget. Results are deduplicated and sorted by priority (merged_pr > starred > normal), then recommendation, then score. Rate-limit-aware: heavy phases (broad, maintained) are skipped when API budget is low.
 
 ## Viability Scoring (0-100)
 


### PR DESCRIPTION
## Summary

Post-merge review cleanup:

- Add `broadPhaseDelayMs` and `skipBroadWhenSufficientResults` to MCP `config-set` NUMBER_KEYS (they were unreachable via MCP)
- Fix SKILL.md phase order documentation (said broad runs first, actual order is merged→starred→broad→maintained)
- Remove dead `mockSearchInRepos` from issue-discovery.test.ts
- Remove duplicate mock reset in beforeEach
- Fix misleading test comment about phase execution order

## Test plan

- [x] All 491 core tests pass
- [x] Lint clean
- [x] Format check passes