### PR TITLE
feat: include open-PR repos in Phase 0 search (#65)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",
     "typescript-eslint": "^8.57.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "^8.0.5"
+    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,10 +65,11 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "esbuild": "^0.27.4",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.0"
+    "vite": "^8.0.5",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/core/src/core/bootstrap.test.ts
+++ b/packages/core/src/core/bootstrap.test.ts
@@ -223,6 +223,79 @@ describe("bootstrapScout", () => {
     ).toHaveBeenCalledTimes(4);
   });
 
+  it("reports open-PR fetch failures non-fatally and preserves prior counts", async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        yield {
+          data: [{ full_name: "org/repo-a" }],
+        };
+      })(),
+    );
+    mockOctokitInstance.search.issuesAndPullRequests = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { items: [makePRItem(1, "org/repo-a")] },
+      })
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockRejectedValueOnce(new Error("transient network error"));
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    const result = await bootstrapScout(scout, token);
+
+    expect(result.openPRCount).toBe(0);
+    expect(result.mergedPRCount).toBe(1);
+    expect(result.starredRepoCount).toBe(1);
+    expect(result.errors).toContain("open PR fetch failed");
+  });
+
+  it("propagates auth errors from open-PR fetch (does not silently degrade)", async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        yield { data: [] };
+      })(),
+    );
+    const authError = Object.assign(new Error("Bad credentials"), {
+      status: 401,
+    });
+    mockOctokitInstance.search.issuesAndPullRequests = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockRejectedValueOnce(authError);
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    await expect(bootstrapScout(scout, token)).rejects.toThrow(
+      "Bad credentials",
+    );
+  });
+
+  it("propagates rate-limit errors from open-PR fetch (does not silently degrade)", async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        yield { data: [] };
+      })(),
+    );
+    const rateLimitError = Object.assign(new Error("API rate limit exceeded"), {
+      status: 429,
+    });
+    mockOctokitInstance.search.issuesAndPullRequests = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockRejectedValueOnce(rateLimitError);
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    await expect(bootstrapScout(scout, token)).rejects.toThrow(
+      "API rate limit exceeded",
+    );
+  });
+
   it("queries open PRs with correct search qualifiers", async () => {
     mockRateLimit(30);
     mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(

--- a/packages/core/src/core/bootstrap.test.ts
+++ b/packages/core/src/core/bootstrap.test.ts
@@ -61,6 +61,7 @@ function makePRItem(n: number, repo: string) {
     html_url: `https://github.com/${repo}/pull/${n}`,
     title: `PR #${n}`,
     closed_at: "2026-01-15T00:00:00Z",
+    created_at: "2026-01-01T00:00:00Z",
   };
 }
 
@@ -83,6 +84,7 @@ describe("bootstrapScout", () => {
     expect(result.starredRepoCount).toBe(0);
     expect(result.mergedPRCount).toBe(0);
     expect(result.closedPRCount).toBe(0);
+    expect(result.openPRCount).toBe(0);
   });
 
   it("fetches starred repos and PRs", async () => {
@@ -103,6 +105,9 @@ describe("bootstrapScout", () => {
       })
       .mockResolvedValueOnce({
         data: { items: [makePRItem(3, "org/repo-c")] },
+      })
+      .mockResolvedValueOnce({
+        data: { items: [makePRItem(4, "org/repo-d")] },
       });
 
     const token = uniqueToken();
@@ -113,11 +118,14 @@ describe("bootstrapScout", () => {
     expect(result.starredRepoCount).toBe(2);
     expect(result.mergedPRCount).toBe(2);
     expect(result.closedPRCount).toBe(1);
+    expect(result.openPRCount).toBe(1);
     expect(result.reposScoredCount).toBeGreaterThanOrEqual(2);
     const state = scout.getState();
     expect(state.starredRepos).toEqual(["org/repo-a", "org/repo-b"]);
     expect(state.mergedPRs).toHaveLength(2);
     expect(state.closedPRs).toHaveLength(1);
+    expect(state.openPRs).toHaveLength(1);
+    expect(state.openPRs[0].url).toBe("https://github.com/org/repo-d/pull/4");
   });
 
   it("handles empty results", async () => {
@@ -130,6 +138,7 @@ describe("bootstrapScout", () => {
     mockOctokitInstance.search.issuesAndPullRequests = vi
       .fn()
       .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ data: { items: [] } })
       .mockResolvedValueOnce({ data: { items: [] } });
 
     const token = uniqueToken();
@@ -138,6 +147,7 @@ describe("bootstrapScout", () => {
     expect(result.starredRepoCount).toBe(0);
     expect(result.mergedPRCount).toBe(0);
     expect(result.closedPRCount).toBe(0);
+    expect(result.openPRCount).toBe(0);
     expect(result.reposScoredCount).toBe(0);
   });
 
@@ -175,6 +185,7 @@ describe("bootstrapScout", () => {
           items: [makePRItem(1, "org/repo-a"), makePRItem(2, "org/repo-a")],
         },
       })
+      .mockResolvedValueOnce({ data: { items: [] } })
       .mockResolvedValueOnce({ data: { items: [] } });
 
     const token = uniqueToken();
@@ -200,6 +211,7 @@ describe("bootstrapScout", () => {
       .mockResolvedValueOnce({
         data: { items: [makePRItem(101, "org/repo-a")] },
       })
+      .mockResolvedValueOnce({ data: { items: [] } })
       .mockResolvedValueOnce({ data: { items: [] } });
 
     const token = uniqueToken();
@@ -208,6 +220,38 @@ describe("bootstrapScout", () => {
     expect(result.mergedPRCount).toBe(101);
     expect(
       mockOctokitInstance.search.issuesAndPullRequests,
-    ).toHaveBeenCalledTimes(3);
+    ).toHaveBeenCalledTimes(4);
+  });
+
+  it("queries open PRs with correct search qualifiers", async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        yield { data: [] };
+      })(),
+    );
+    mockOctokitInstance.search.issuesAndPullRequests = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({
+        data: {
+          items: [
+            makePRItem(1, "org/open-repo"),
+            makePRItem(2, "org/open-repo"),
+          ],
+        },
+      });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    const result = await bootstrapScout(scout, token);
+    expect(result.openPRCount).toBe(2);
+    const state = scout.getState();
+    expect(state.openPRs).toHaveLength(2);
+    expect(scout.getReposWithOpenPRs()).toEqual(["org/open-repo"]);
+
+    const calls = mockOctokitInstance.search.issuesAndPullRequests.mock.calls;
+    expect(calls[2][0].q).toBe("is:pr is:open author:testuser");
   });
 });

--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -5,7 +5,12 @@
 
 import { getOctokit, checkRateLimit } from "./github.js";
 import { debug, warn } from "./logger.js";
-import { ConfigurationError, errorMessage } from "./errors.js";
+import {
+  ConfigurationError,
+  errorMessage,
+  getHttpStatusCode,
+  isRateLimitError,
+} from "./errors.js";
 import { extractRepoFromUrl } from "./utils.js";
 import type { OssScout } from "../scout.js";
 
@@ -110,6 +115,7 @@ export async function bootstrapScout(
     }
     debug(MODULE, `Imported ${mergedPRCount} merged PRs`);
   } catch (err) {
+    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
     warn(MODULE, `Failed to fetch merged PRs: ${errorMessage(err)}`);
     errors.push("merged PR fetch failed");
   }
@@ -141,6 +147,7 @@ export async function bootstrapScout(
     }
     debug(MODULE, `Imported ${closedPRCount} closed PRs`);
   } catch (err) {
+    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
     warn(MODULE, `Failed to fetch closed PRs: ${errorMessage(err)}`);
     errors.push("closed PR fetch failed");
   }
@@ -172,6 +179,7 @@ export async function bootstrapScout(
     }
     debug(MODULE, `Imported ${openPRCount} open PRs`);
   } catch (err) {
+    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
     warn(MODULE, `Failed to fetch open PRs: ${errorMessage(err)}`);
     errors.push("open PR fetch failed");
   }

--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -15,6 +15,7 @@ export interface BootstrapResult {
   starredRepoCount: number;
   mergedPRCount: number;
   closedPRCount: number;
+  openPRCount: number;
   reposScoredCount: number;
   skippedDueToRateLimit: boolean;
   errors: string[];
@@ -47,6 +48,7 @@ export async function bootstrapScout(
       starredRepoCount: 0,
       mergedPRCount: 0,
       closedPRCount: 0,
+      openPRCount: 0,
       reposScoredCount: 0,
       skippedDueToRateLimit: true,
       errors: [],
@@ -143,6 +145,37 @@ export async function bootstrapScout(
     errors.push("closed PR fetch failed");
   }
 
+  // 4. Fetch currently-open PRs via Search API
+  let openPRCount = 0;
+  try {
+    for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
+      const { data } = await octokit.search.issuesAndPullRequests({
+        q: `is:pr is:open author:${username}`,
+        per_page: PER_PAGE,
+        page,
+      });
+
+      for (const item of data.items) {
+        const repo = extractRepoFromUrl(item.html_url);
+        if (!repo) continue;
+
+        scout.recordOpenPR({
+          url: item.html_url,
+          title: item.title,
+          openedAt: item.created_at ?? new Date().toISOString(),
+          repo,
+        });
+        openPRCount++;
+      }
+
+      if (data.items.length < PER_PAGE) break;
+    }
+    debug(MODULE, `Imported ${openPRCount} open PRs`);
+  } catch (err) {
+    warn(MODULE, `Failed to fetch open PRs: ${errorMessage(err)}`);
+    errors.push("open PR fetch failed");
+  }
+
   const state = scout.getState();
   const reposScoredCount = Object.keys(state.repoScores).length;
 
@@ -150,6 +183,7 @@ export async function bootstrapScout(
     starredRepoCount: starredRepos.length,
     mergedPRCount,
     closedPRCount,
+    openPRCount,
     reposScoredCount,
     skippedDueToRateLimit: false,
     errors,

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -423,6 +423,67 @@ describe("mergeStates", () => {
     expect(merged.closedPRs).toHaveLength(2);
   });
 
+  it("unions openPRs by URL", () => {
+    const local = makeState({
+      openPRs: [
+        {
+          url: "https://github.com/a/b/pull/1",
+          title: "PR1",
+          openedAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          url: "https://github.com/a/b/pull/2",
+          title: "PR2",
+          openedAt: "2026-01-02T00:00:00Z",
+        },
+      ],
+    });
+    const remote = makeState({
+      openPRs: [
+        {
+          url: "https://github.com/a/b/pull/2",
+          title: "PR2",
+          openedAt: "2026-01-02T00:00:00Z",
+        },
+        {
+          url: "https://github.com/a/b/pull/3",
+          title: "PR3",
+          openedAt: "2026-01-03T00:00:00Z",
+        },
+      ],
+    });
+
+    const merged = mergeStates(local, remote);
+
+    expect(merged.openPRs).toHaveLength(3);
+    const urls = merged.openPRs.map((p) => p.url);
+    expect(urls).toContain("https://github.com/a/b/pull/1");
+    expect(urls).toContain("https://github.com/a/b/pull/2");
+    expect(urls).toContain("https://github.com/a/b/pull/3");
+  });
+
+  it("tolerates legacy state missing openPRs field", () => {
+    // Simulate a pre-feature state by stripping openPRs after parse.
+    const local = makeState({
+      openPRs: [
+        {
+          url: "https://github.com/a/b/pull/1",
+          title: "PR1",
+          openedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+    const remote = makeState();
+    // Cast because the current schema requires openPRs; we're simulating
+    // legacy persisted state that predates the field.
+    delete (remote as { openPRs?: unknown }).openPRs;
+
+    const merged = mergeStates(local, remote);
+
+    expect(merged.openPRs).toHaveLength(1);
+    expect(merged.openPRs[0].url).toBe("https://github.com/a/b/pull/1");
+  });
+
   it("keeps repo score with higher activity", () => {
     const local = makeState({
       repoScores: {

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -302,7 +302,7 @@ export class GistStateStore {
 /**
  * Merge two ScoutState objects with conflict resolution:
  * - repoScores: per-repo, keep the one with more total PR activity
- * - mergedPRs/closedPRs: union by URL
+ * - mergedPRs/closedPRs/openPRs: union by URL
  * - preferences: remote wins
  * - starredRepos: keep the list with the fresher timestamp
  * - savedResults: union by issueUrl, keep newer lastSeenAt
@@ -319,6 +319,7 @@ export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
     ),
     mergedPRs: unionByUrl(local.mergedPRs, remote.mergedPRs),
     closedPRs: unionByUrl(local.closedPRs, remote.closedPRs),
+    openPRs: unionByUrl(local.openPRs ?? [], remote.openPRs ?? []),
     savedResults: mergeSavedResults(
       local.savedResults ?? [],
       remote.savedResults ?? [],

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -188,6 +188,7 @@ function makeStateReader(
 ): ScoutStateReader {
   return {
     getReposWithMergedPRs: vi.fn(() => []),
+    getReposWithOpenPRs: vi.fn(() => []),
     getStarredRepos: vi.fn(() => []),
     getProjectCategories: vi.fn(() => []),
     getRepoScore: vi.fn(() => null),
@@ -277,6 +278,81 @@ describe("IssueDiscovery", () => {
         "merged_pr",
         expect.any(Function),
       );
+    });
+
+    it("Phase 0: unions merged-PR and open-PR repos, deduped, merged first", async () => {
+      const c = makeCandidate("org/merged-a", "merged_pr");
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [c],
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged-a", "org/shared"]),
+        getReposWithOpenPRs: vi.fn(() => ["org/shared", "org/open-only"]),
+      });
+
+      await discovery.searchIssues({ maxResults: 5 });
+
+      const phase0Call = mockFetchIssuesFromKnownRepos.mock.calls.find(
+        (call) => call[5] === "merged_pr",
+      );
+      expect(phase0Call).toBeDefined();
+      expect(phase0Call![2]).toEqual([
+        "org/merged-a",
+        "org/shared",
+        "org/open-only",
+      ]);
+    });
+
+    it("Phase 0: searches open-PR repos even when no merged PRs exist", async () => {
+      const c = makeCandidate("org/open-only", "merged_pr");
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [c],
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => []),
+        getReposWithOpenPRs: vi.fn(() => ["org/open-only"]),
+      });
+
+      await discovery.searchIssues({ maxResults: 5 });
+
+      const phase0Call = mockFetchIssuesFromKnownRepos.mock.calls.find(
+        (call) => call[5] === "merged_pr",
+      );
+      expect(phase0Call).toBeDefined();
+      expect(phase0Call![2]).toEqual(["org/open-only"]);
+    });
+
+    it("Phase 0: caps total repos at 10 across merged + open", async () => {
+      const c = makeCandidate("org/merged-0", "merged_pr");
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [c],
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+
+      const merged = Array.from({ length: 8 }, (_, i) => `org/merged-${i}`);
+      const open = Array.from({ length: 8 }, (_, i) => `org/open-${i}`);
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => merged),
+        getReposWithOpenPRs: vi.fn(() => open),
+      });
+
+      await discovery.searchIssues({ maxResults: 5 });
+
+      const phase0Call = mockFetchIssuesFromKnownRepos.mock.calls.find(
+        (call) => call[5] === "merged_pr",
+      );
+      expect(phase0Call).toBeDefined();
+      expect(phase0Call![2]).toHaveLength(10);
+      // Merged repos come first
+      expect(phase0Call![2].slice(0, 8)).toEqual(merged);
     });
 
     it("Phase 1: calls fetchIssuesFromKnownRepos with starred repos, priority starred", async () => {

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -355,6 +355,31 @@ describe("IssueDiscovery", () => {
       expect(phase0Call![2].slice(0, 8)).toEqual(merged);
     });
 
+    it("Phase 1: excludes starred repos that are already searched as open-PR repos in Phase 0", async () => {
+      const c = makeCandidate("org/shared", "merged_pr");
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [c],
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => []),
+        getReposWithOpenPRs: vi.fn(() => ["org/shared"]),
+        getStarredRepos: vi.fn(() => ["org/shared", "org/other"]),
+      });
+
+      await discovery.searchIssues({ maxResults: 5 });
+
+      const phase1Call = mockFetchIssuesFromKnownRepos.mock.calls.find(
+        (call) => call[5] === "starred",
+      );
+      expect(phase1Call).toBeDefined();
+      // "org/shared" was already searched in Phase 0 (as open-PR repo), so
+      // Phase 1 only gets the non-overlapping starred repo.
+      expect(phase1Call![2]).toEqual(["org/other"]);
+    });
+
     it("Phase 1: calls fetchIssuesFromKnownRepos with starred repos, priority starred", async () => {
       const c = makeCandidate("org/starred-repo", "starred");
       mockFetchIssuesFromKnownRepos.mockResolvedValue({

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -569,6 +569,7 @@ export class IssueDiscovery {
 
     // Derive search context
     const mergedPRRepos = this.stateReader.getReposWithMergedPRs();
+    const openPRRepos = this.stateReader.getReposWithOpenPRs();
     const starredRepos = this.getStarredRepos();
     const starredRepoSet = new Set(starredRepos);
     const lowScoringRepos = new Set(
@@ -605,8 +606,17 @@ export class IssueDiscovery {
       includeDocIssues: config.includeDocIssues ?? true,
     });
 
-    // Phase 0: Merged-PR repos
-    const phase0Repos = mergedPRRepos.slice(0, 10);
+    // Phase 0: Repos the user has engaged with — merged PRs first (strongest
+    // signal), then open PRs (active engagement even without a merge yet).
+    // Deduped and capped so REST cost stays bounded.
+    const seenPhase0 = new Set<string>();
+    const phase0Repos: string[] = [];
+    for (const repo of [...mergedPRRepos, ...openPRRepos]) {
+      if (seenPhase0.has(repo)) continue;
+      seenPhase0.add(repo);
+      phase0Repos.push(repo);
+      if (phase0Repos.length >= 10) break;
+    }
     const phase0RepoSet = new Set(phase0Repos);
 
     if (phase0Repos.length > 0 && enabledStrategies.has("merged")) {

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -102,6 +102,7 @@ function makeStubStateReader(
 ): ScoutStateReader {
   return {
     getReposWithMergedPRs: vi.fn(() => []),
+    getReposWithOpenPRs: vi.fn(() => []),
     getStarredRepos: vi.fn(() => []),
     getProjectCategories: vi.fn(() => []),
     getRepoScore: vi.fn(() => null),

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -50,6 +50,8 @@ const VETTING_CACHE_TTL_MS = 15 * 60 * 1000;
 export interface ScoutStateReader {
   /** Repos where the user has at least one merged PR. */
   getReposWithMergedPRs(): string[];
+  /** Repos where the user has at least one open PR. */
+  getReposWithOpenPRs(): string[];
   /** User's starred repos (from GitHub). */
   getStarredRepos(): string[];
   /** Preferred project categories from user preferences. */

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -79,6 +79,12 @@ export const StoredClosedPRSchema = z.object({
   closedAt: z.string(),
 });
 
+export const StoredOpenPRSchema = z.object({
+  url: z.string(),
+  title: z.string(),
+  openedAt: z.string(),
+});
+
 // ── Contribution schemas ────────────────────────────────────────────
 
 export const ContributionGuidelinesSchema = z.object({
@@ -191,6 +197,7 @@ export const ScoutStateSchema = z.object({
 
   mergedPRs: z.array(StoredMergedPRSchema).default([]),
   closedPRs: z.array(StoredClosedPRSchema).default([]),
+  openPRs: z.array(StoredOpenPRSchema).default([]),
 
   savedResults: z.array(SavedCandidateSchema).default([]),
   skippedIssues: z.array(SkippedIssueSchema).default([]),
@@ -210,6 +217,7 @@ export type RepoSignals = z.infer<typeof RepoSignalsSchema>;
 export type RepoScore = z.infer<typeof RepoScoreSchema>;
 export type StoredMergedPR = z.infer<typeof StoredMergedPRSchema>;
 export type StoredClosedPR = z.infer<typeof StoredClosedPRSchema>;
+export type StoredOpenPR = z.infer<typeof StoredOpenPRSchema>;
 export type ContributionGuidelines = z.infer<
   typeof ContributionGuidelinesSchema
 >;

--- a/packages/core/src/core/strategy-selection.test.ts
+++ b/packages/core/src/core/strategy-selection.test.ts
@@ -156,6 +156,7 @@ const basePreferences = {
 
 const baseStateReader = {
   getReposWithMergedPRs: () => [] as string[],
+  getReposWithOpenPRs: () => [] as string[],
   getStarredRepos: () => [] as string[],
   getProjectCategories: () => [] as string[],
   getRepoScore: () => null,

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -187,3 +187,11 @@ export interface ClosedPRRecord {
   closedAt: string;
   repo: string;
 }
+
+/** Record of an open PR for state contribution. */
+export interface OpenPRRecord {
+  url: string;
+  title: string;
+  openedAt: string;
+  repo: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   IssueCandidate,
   MergedPRRecord,
   ClosedPRRecord,
+  OpenPRRecord,
   RepoScoreUpdate,
   ProjectHealth,
   SearchPriority,
@@ -48,6 +49,7 @@ export type {
   ProjectCategory,
   StoredMergedPR,
   StoredClosedPR,
+  StoredOpenPR,
   SearchStrategy,
   SkippedIssue,
 } from "./core/schemas.js";

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -127,6 +127,45 @@ describe("OssScout", () => {
     });
   });
 
+  describe("recordOpenPR", () => {
+    it("adds PR to state and surfaces repo via getReposWithOpenPRs", () => {
+      const scout = makeScout();
+      scout.recordOpenPR({
+        url: "https://github.com/owner/repo/pull/1",
+        title: "Draft PR",
+        openedAt: "2026-01-01T00:00:00Z",
+        repo: "owner/repo",
+      });
+      expect(scout.getState().openPRs).toHaveLength(1);
+      expect(scout.getReposWithOpenPRs()).toEqual(["owner/repo"]);
+      expect(scout.isDirty()).toBe(true);
+    });
+
+    it("deduplicates by URL", () => {
+      const scout = makeScout();
+      const pr = {
+        url: "https://github.com/owner/repo/pull/1",
+        title: "Draft",
+        openedAt: "2026-01-01T00:00:00Z",
+        repo: "owner/repo",
+      };
+      scout.recordOpenPR(pr);
+      scout.recordOpenPR(pr);
+      expect(scout.getState().openPRs).toHaveLength(1);
+    });
+
+    it("does not update repo score (open PRs are not a merge signal)", () => {
+      const scout = makeScout();
+      scout.recordOpenPR({
+        url: "https://github.com/owner/repo/pull/1",
+        title: "Draft",
+        openedAt: "2026-01-01T00:00:00Z",
+        repo: "owner/repo",
+      });
+      expect(scout.getRepoScoreRecord("owner/repo")).toBeUndefined();
+    });
+  });
+
   describe("recordClosedPR", () => {
     it("adds PR to state and updates score", () => {
       const scout = makeScout();

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -22,6 +22,7 @@ import type {
   IssueCandidate,
   MergedPRRecord,
   ClosedPRRecord,
+  OpenPRRecord,
   RepoScoreUpdate,
   ProjectCategory,
   VetListOptions,
@@ -297,6 +298,19 @@ export class OssScout implements ScoutStateReader {
       .map(([repo]) => repo);
   }
 
+  getReposWithOpenPRs(): string[] {
+    const repoCounts = new Map<string, number>();
+    for (const pr of this.state.openPRs ?? []) {
+      const repo = extractRepoFromUrl(pr.url);
+      if (repo) {
+        repoCounts.set(repo, (repoCounts.get(repo) ?? 0) + 1);
+      }
+    }
+    return [...repoCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([repo]) => repo);
+  }
+
   getStarredRepos(): string[] {
     return this.state.starredRepos;
   }
@@ -351,6 +365,21 @@ export class OssScout implements ScoutStateReader {
       { url: pr.url, title: pr.title, closedAt: pr.closedAt },
     ];
     this.updateRepoScoreFromPRs(pr.repo);
+    this.dirty = true;
+  }
+
+  /**
+   * Record that a PR is currently open in this repo.
+   * Open PRs signal active engagement even when nothing is merged yet.
+   */
+  recordOpenPR(pr: OpenPRRecord): void {
+    const existing = this.state.openPRs ?? [];
+    if (existing.some((p) => p.url === pr.url)) return;
+
+    this.state.openPRs = [
+      ...existing,
+      { url: pr.url, title: pr.title, openedAt: pr.openedAt },
+    ];
     this.dirty = true;
   }
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -31,11 +31,12 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "esbuild": "^0.27.4",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "@vitest/coverage-v8": "^4.1.0",
-    "vitest": "^4.1.0"
+    "vite": "^8.0.5",
+    "vitest": "^4.1.4"
   },
   "keywords": [
     "mcp",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: ^8.0.5
+
 importers:
 
   .:
@@ -43,8 +46,8 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: ^4.1.0
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
@@ -54,9 +57,12 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^8.0.5
+        version: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.5.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
 
   packages/mcp-server:
     dependencies:
@@ -74,8 +80,8 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: ^4.1.0
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
@@ -85,9 +91,12 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^8.0.5
+        version: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.5.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
 
 packages:
 
@@ -112,14 +121,14 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -358,8 +367,11 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -419,100 +431,100 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.12':
-    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -597,43 +609,43 @@ packages:
     resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/coverage-v8@4.1.2':
-    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
-      '@vitest/browser': 4.1.2
-      vitest: 4.1.2
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^8.0.5
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1237,8 +1249,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1277,8 +1289,8 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  rolldown@1.0.0-rc.12:
-    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1343,8 +1355,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1353,12 +1365,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -1420,14 +1436,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@8.0.3:
-    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -1463,21 +1479,23 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^8.0.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1490,6 +1508,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -1544,18 +1566,18 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.9.2':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1718,10 +1740,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -1794,56 +1816,58 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oxc-project/types@0.122.0': {}
+  '@oxc-project/types@0.124.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.12': {}
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1960,58 +1984,58 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)))':
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.4
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
+      vitest: 4.1.4(@types/node@25.5.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.4':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.4': {}
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2596,7 +2620,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2630,26 +2654,26 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown@1.0.0-rc.12:
+  rolldown@1.0.0-rc.15:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
   router@2.2.0:
     dependencies:
@@ -2734,7 +2758,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.0.0: {}
+  std-env@4.1.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -2742,9 +2766,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.4: {}
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -2802,43 +2831,44 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0):
+  vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.12
-      tinyglobby: 0.2.15
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.5.0
       esbuild: 0.27.4
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@25.5.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary
- Phase 0 now unions repos where the user has merged PRs with repos where the user has open PRs (merged first, deduped, capped at 10 total). Previously it only searched merged-PR repos, missing active-but-unmerged relationships and closed-without-merge repos.
- Adds `openPRs` to persisted state with `recordOpenPR()` and `getReposWithOpenPRs()` on `OssScout`, mirroring the merged/closed PR pattern.
- Bootstrap fetches open PRs via `is:pr is:open author:{username}`; gist merge unions them.

## Why
Needed to replace oss-autopilot's independent Strategy A (open-PR search) so oss-scout can fully subsume that behavior. Open-PR repos signal active codebase familiarity and are valuable contribution targets.

## Test plan
- [x] `pnpm test` — 514 tests pass (3 new Phase 0 union tests, 1 new bootstrap query test, 3 new `recordOpenPR` tests)
- [x] `pnpm -r run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm run bundle`

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)