### PR TITLE
chore: bump CI actions to v5/v6 and add hono/vite overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
         node-version: [20, 22, 24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,15 +35,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout tagged release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.core-tag }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
@@ -70,15 +70,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout tagged release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.mcp-tag }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "pnpm": {
     "overrides": {
-      "vite": "^8.0.5"
+      "vite": "^8.0.5",
+      "hono": ">=4.12.14",
+      "@hono/node-server": ">=1.19.13"
     }
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [0.5.0](https://github.com/costajohnt/oss-scout/compare/core-v0.4.0...core-v0.5.0) (2026-04-18)
 
-
 ### Features
 
-* include open-PR repos in Phase 0 search ([#65](https://github.com/costajohnt/oss-scout/issues/65)) ([#66](https://github.com/costajohnt/oss-scout/issues/66)) ([e5af4d2](https://github.com/costajohnt/oss-scout/commit/e5af4d2950bf243e6b77ba02344b4c2c4ad80045))
+- include open-PR repos in Phase 0 search ([#65](https://github.com/costajohnt/oss-scout/issues/65)) ([#66](https://github.com/costajohnt/oss-scout/issues/66)) ([e5af4d2](https://github.com/costajohnt/oss-scout/commit/e5af4d2950bf243e6b77ba02344b4c2c4ad80045))
 
 ## [0.4.0](https://github.com/costajohnt/oss-scout/compare/core-v0.3.0...core-v0.4.0) (2026-04-01)
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [0.5.0](https://github.com/costajohnt/oss-scout/compare/mcp-server-v0.4.0...mcp-server-v0.5.0) (2026-04-18)
 
-
 ### Features
 
-* include open-PR repos in Phase 0 search ([#65](https://github.com/costajohnt/oss-scout/issues/65)) ([#66](https://github.com/costajohnt/oss-scout/issues/66)) ([e5af4d2](https://github.com/costajohnt/oss-scout/commit/e5af4d2950bf243e6b77ba02344b4c2c4ad80045))
+- include open-PR repos in Phase 0 search ([#65](https://github.com/costajohnt/oss-scout/issues/65)) ([#66](https://github.com/costajohnt/oss-scout/issues/66)) ([e5af4d2](https://github.com/costajohnt/oss-scout/commit/e5af4d2950bf243e6b77ba02344b4c2c4ad80045))
 
 ## [0.4.0](https://github.com/costajohnt/oss-scout/compare/mcp-server-v0.3.0...mcp-server-v0.4.0) (2026-04-01)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   vite: ^8.0.5
+  hono: '>=4.12.14'
+  '@hono/node-server': '>=1.19.13'
 
 importers:
 
@@ -325,11 +327,11 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.14'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -972,8 +974,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -1694,9 +1696,9 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.11(hono@4.12.9)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
-      hono: 4.12.9
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1': {}
 
@@ -1720,7 +1722,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.9)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -1730,7 +1732,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.9
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2406,7 +2408,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.9: {}
+  hono@4.12.14: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4→v6, `actions/setup-node` v4→v6, `pnpm/action-setup` v4→v5 to silence the Node 20 deprecation warnings (forced to Node 24 starting June 2026).
- Expand `pnpm.overrides` to force `hono >=4.12.14` and `@hono/node-server >=1.19.13` — clears 7 moderate-severity advisories (all transitive via `@modelcontextprotocol/sdk`).

After this: `pnpm audit` reports **no known vulnerabilities** at any severity.

## Test plan
- [x] `pnpm test` — 520 tests pass
- [x] `pnpm -r run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm run bundle`
- [x] `pnpm audit` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)