### PR TITLE
feat: surface linked-PR metadata on IssueCandidate (#69)

### DIFF
--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -62,38 +62,165 @@ describe("checkNoExistingPR", () => {
     vi.clearAllMocks();
   });
 
-  it("returns passed:true when no PRs are linked", async () => {
+  it("returns passed:true and linkedPR:null when no PRs are linked", async () => {
     mockPaginateAll.mockResolvedValue([]);
     const octokit = makeMockOctokit();
     const result = await checkNoExistingPR(octokit, "owner", "repo", 1);
     expect(result.passed).toBe(true);
     expect(result.inconclusive).toBeUndefined();
+    expect(result.linkedPR).toBeNull();
   });
 
-  it("returns passed:false when an open PR is found via cross-reference", async () => {
+  it("returns passed:false and surfaces linkedPR metadata for an open linked PR", async () => {
     mockPaginateAll.mockResolvedValue([
       {
         event: "cross-referenced",
-        source: { issue: { pull_request: { url: "some-url" } } },
+        source: {
+          issue: {
+            number: 99,
+            state: "open",
+            html_url: "https://github.com/owner/repo/pull/99",
+            user: { login: "alice" },
+            pull_request: { url: "some-url", merged_at: null },
+          },
+        },
       },
     ]);
     const octokit = makeMockOctokit();
     const result = await checkNoExistingPR(octokit, "owner", "repo", 42);
     expect(result.passed).toBe(false);
+    expect(result.linkedPR).toEqual({
+      number: 99,
+      author: "alice",
+      state: "open",
+      merged: false,
+      url: "https://github.com/owner/repo/pull/99",
+    });
   });
 
-  it("returns passed:false when a merged PR is found via cross-reference", async () => {
+  it("returns passed:false and marks linkedPR.merged when a merged PR is found", async () => {
     mockPaginateAll.mockResolvedValue([
       {
         event: "cross-referenced",
         source: {
-          issue: { pull_request: { url: "some-url", merged_at: "2026-01-01" } },
+          issue: {
+            number: 12,
+            state: "closed",
+            html_url: "https://github.com/owner/repo/pull/12",
+            user: { login: "bob" },
+            pull_request: { url: "some-url", merged_at: "2026-01-01" },
+          },
         },
       },
     ]);
     const octokit = makeMockOctokit();
     const result = await checkNoExistingPR(octokit, "owner", "repo", 10);
     expect(result.passed).toBe(false);
+    expect(result.linkedPR).toEqual({
+      number: 12,
+      author: "bob",
+      state: "closed",
+      merged: true,
+      url: "https://github.com/owner/repo/pull/12",
+    });
+  });
+
+  it("classifies a closed-but-unmerged linked PR as state:closed merged:false", async () => {
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            number: 7,
+            state: "closed",
+            html_url: "https://github.com/owner/repo/pull/7",
+            user: { login: "carol" },
+            pull_request: { url: "some-url", merged_at: null },
+          },
+        },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 7);
+    expect(result.passed).toBe(false);
+    expect(result.linkedPR).toMatchObject({
+      number: 7,
+      author: "carol",
+      state: "closed",
+      merged: false,
+    });
+  });
+
+  it("returns the first linked PR when multiple exist", async () => {
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            number: 1,
+            state: "closed",
+            html_url: "https://github.com/owner/repo/pull/1",
+            user: { login: "first" },
+            pull_request: { url: "u1", merged_at: null },
+          },
+        },
+      },
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            number: 2,
+            state: "open",
+            html_url: "https://github.com/owner/repo/pull/2",
+            user: { login: "second" },
+            pull_request: { url: "u2", merged_at: null },
+          },
+        },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 5);
+    expect(result.linkedPR).toMatchObject({ number: 1, author: "first" });
+  });
+
+  it("returns linkedPR:null when timeline event is missing user.login", async () => {
+    // pull_request present (so the count still flips passed:false) but
+    // user.login is missing — defensive fallback should yield null metadata.
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            number: 99,
+            html_url: "https://github.com/owner/repo/pull/99",
+            pull_request: { url: "some-url" },
+          },
+        },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 8);
+    expect(result.passed).toBe(false);
+    expect(result.linkedPR).toBeNull();
+  });
+
+  it("returns linkedPR:null when timeline event is missing html_url", async () => {
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            number: 99,
+            user: { login: "alice" },
+            pull_request: { url: "some-url" },
+          },
+        },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 8);
+    expect(result.passed).toBe(false);
+    expect(result.linkedPR).toBeNull();
   });
 
   it("returns passed:true and inconclusive:true on API error", async () => {
@@ -103,6 +230,7 @@ describe("checkNoExistingPR", () => {
     expect(result.passed).toBe(true);
     expect(result.inconclusive).toBe(true);
     expect(result.reason).toContain("API timeout");
+    expect(result.linkedPR).toBeNull();
   });
 
   it("returns passed:true when timeline is empty", async () => {
@@ -110,6 +238,7 @@ describe("checkNoExistingPR", () => {
     const octokit = makeMockOctokit();
     const result = await checkNoExistingPR(octokit, "owner", "repo", 99);
     expect(result.passed).toBe(true);
+    expect(result.linkedPR).toBeNull();
   });
 });
 

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -12,7 +12,74 @@ import { errorMessage } from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache } from "./http-cache.js";
 import { getSearchBudgetTracker } from "./search-budget.js";
-import type { CheckResult } from "./types.js";
+import type { CheckResult, LinkedPR } from "./types.js";
+
+/** Result of the existing-PR check, including metadata for the first linked PR (if any). */
+export interface ExistingPRCheckResult extends CheckResult {
+  linkedPR: LinkedPR | null;
+}
+
+/** Shape of a cross-referenced PR event from the GitHub issue timeline API. */
+type CrossRefEvent = {
+  event?: string;
+  source?: {
+    issue?: {
+      number?: number;
+      state?: string;
+      html_url?: string;
+      user?: { login?: string };
+      pull_request?: { merged_at?: string | null };
+    };
+  };
+};
+
+function isLinkedPREvent(e: CrossRefEvent): boolean {
+  return e.event === "cross-referenced" && !!e.source?.issue?.pull_request;
+}
+
+/**
+ * Build a LinkedPR from a cross-referenced timeline event's source.issue.
+ * Returns null if required fields are missing — and warns, because callers
+ * only invoke this after asserting the event is a linked-PR event, so a
+ * null return signals API shape drift, not absent data.
+ */
+function buildLinkedPRFromTimelineEvent(
+  e: CrossRefEvent,
+  context: { owner: string; repo: string; issueNumber: number },
+): LinkedPR | null {
+  const issue = e.source?.issue;
+  const ctx = `${context.owner}/${context.repo}#${context.issueNumber}`;
+  if (!issue || typeof issue.number !== "number") {
+    warn(
+      MODULE,
+      `Cross-referenced timeline event for ${ctx} missing source.issue.number — possible API shape drift`,
+    );
+    return null;
+  }
+  const author = issue.user?.login;
+  if (!author) {
+    warn(
+      MODULE,
+      `Cross-referenced PR #${issue.number} for ${ctx} has no user.login (deleted user?) — skipping linkedPR metadata`,
+    );
+    return null;
+  }
+  const url = issue.html_url;
+  if (!url) {
+    warn(
+      MODULE,
+      `Cross-referenced PR #${issue.number} for ${ctx} missing html_url — skipping linkedPR metadata`,
+    );
+    return null;
+  }
+  return {
+    number: issue.number,
+    author,
+    state: issue.state === "closed" ? "closed" : "open",
+    merged: !!issue.pull_request?.merged_at,
+    url,
+  };
+}
 
 const MODULE = "issue-eligibility";
 
@@ -45,7 +112,7 @@ export async function checkNoExistingPR(
   owner: string,
   repo: string,
   issueNumber: number,
-): Promise<CheckResult> {
+): Promise<ExistingPRCheckResult> {
   try {
     // Use the timeline API (REST, not Search) to detect linked PRs.
     // This avoids consuming GitHub Search API quota (30 req/min limit).
@@ -62,22 +129,30 @@ export async function checkNoExistingPR(
       }),
     );
 
-    const linkedPRs = timeline.filter((event) => {
-      const e = event as {
-        event?: string;
-        source?: { issue?: { pull_request?: unknown } };
-      };
-      return e.event === "cross-referenced" && e.source?.issue?.pull_request;
-    });
+    // Single pass: count linked-PR events and capture metadata for the
+    // first valid one, so consumers can classify (own vs. competing,
+    // open vs. closed-unmerged) without a separate fetch.
+    let linkedPRCount = 0;
+    let linkedPR: LinkedPR | null = null;
+    for (const event of timeline) {
+      const e = event as CrossRefEvent;
+      if (!isLinkedPREvent(e)) continue;
+      linkedPRCount++;
+      linkedPR ??= buildLinkedPRFromTimelineEvent(e, {
+        owner,
+        repo,
+        issueNumber,
+      });
+    }
 
-    return { passed: linkedPRs.length === 0 };
+    return { passed: linkedPRCount === 0, linkedPR };
   } catch (error) {
     const errMsg = errorMessage(error);
     warn(
       MODULE,
       `Failed to check for existing PRs on ${owner}/${repo}#${issueNumber}: ${errMsg}. Assuming no existing PR.`,
     );
-    return { passed: true, inconclusive: true, reason: errMsg };
+    return { passed: true, inconclusive: true, reason: errMsg, linkedPR: null };
   }
 }
 

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -48,7 +48,9 @@ vi.mock("./category-mapping.js", () => ({
 }));
 
 vi.mock("./issue-eligibility.js", () => ({
-  checkNoExistingPR: vi.fn().mockResolvedValue({ passed: true, linkedPR: null }),
+  checkNoExistingPR: vi
+    .fn()
+    .mockResolvedValue({ passed: true, linkedPR: null }),
   checkNotClaimed: vi.fn().mockResolvedValue({ passed: true }),
   checkUserMergedPRsInRepo: vi.fn().mockResolvedValue(0),
   analyzeRequirements: vi.fn(() => true),
@@ -186,7 +188,10 @@ describe("IssueVetter", () => {
     });
 
     it("recommends skip when an existing PR is found", async () => {
-      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false, linkedPR: null });
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({
+        passed: false,
+        linkedPR: null,
+      });
       vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
       vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
       const vetter = makeVetter();
@@ -196,7 +201,10 @@ describe("IssueVetter", () => {
     });
 
     it("recommends skip when issue is claimed", async () => {
-      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false, linkedPR: null });
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({
+        passed: false,
+        linkedPR: null,
+      });
       vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
       vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
       const vetter = makeVetter();
@@ -206,7 +214,10 @@ describe("IssueVetter", () => {
     });
 
     it("recommends skip when 2+ skip reasons exist", async () => {
-      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false, linkedPR: null });
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({
+        passed: false,
+        linkedPR: null,
+      });
       vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
       vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
       const vetter = makeVetter();

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -48,7 +48,7 @@ vi.mock("./category-mapping.js", () => ({
 }));
 
 vi.mock("./issue-eligibility.js", () => ({
-  checkNoExistingPR: vi.fn().mockResolvedValue({ passed: true }),
+  checkNoExistingPR: vi.fn().mockResolvedValue({ passed: true, linkedPR: null }),
   checkNotClaimed: vi.fn().mockResolvedValue({ passed: true }),
   checkUserMergedPRsInRepo: vi.fn().mockResolvedValue(0),
   analyzeRequirements: vi.fn(() => true),
@@ -146,7 +146,10 @@ describe("IssueVetter", () => {
     vi.restoreAllMocks();
 
     // Re-establish default mock implementations after restoreAllMocks
-    vi.mocked(checkNoExistingPR).mockResolvedValue({ passed: true });
+    vi.mocked(checkNoExistingPR).mockResolvedValue({
+      passed: true,
+      linkedPR: null,
+    });
     vi.mocked(checkNotClaimed).mockResolvedValue({ passed: true });
     vi.mocked(checkUserMergedPRsInRepo).mockResolvedValue(0);
     vi.mocked(analyzeRequirements).mockReturnValue(true);
@@ -183,7 +186,7 @@ describe("IssueVetter", () => {
     });
 
     it("recommends skip when an existing PR is found", async () => {
-      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false });
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false, linkedPR: null });
       vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
       vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
       const vetter = makeVetter();
@@ -193,7 +196,7 @@ describe("IssueVetter", () => {
     });
 
     it("recommends skip when issue is claimed", async () => {
-      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false });
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false, linkedPR: null });
       vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
       vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
       const vetter = makeVetter();
@@ -203,7 +206,7 @@ describe("IssueVetter", () => {
     });
 
     it("recommends skip when 2+ skip reasons exist", async () => {
-      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false });
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({ passed: false, linkedPR: null });
       vi.mocked(checkNotClaimed).mockResolvedValueOnce({ passed: false });
       vi.mocked(analyzeRequirements).mockReturnValueOnce(false);
       const vetter = makeVetter();
@@ -218,6 +221,7 @@ describe("IssueVetter", () => {
         passed: true,
         inconclusive: true,
         reason: "API error",
+        linkedPR: null,
       });
       const vetter = makeVetter();
       const result = await vetter.vetIssue(VALID_ISSUE_URL);
@@ -232,6 +236,34 @@ describe("IssueVetter", () => {
       await expect(vetter.vetIssue("not-a-url")).rejects.toThrow(
         "Invalid issue URL",
       );
+    });
+
+    it("propagates linkedPR metadata from checkNoExistingPR onto vettingResult", async () => {
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({
+        passed: false,
+        linkedPR: {
+          number: 99,
+          author: "alice",
+          state: "open",
+          merged: false,
+          url: "https://github.com/owner/repo/pull/99",
+        },
+      });
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.vettingResult.linkedPR).toEqual({
+        number: 99,
+        author: "alice",
+        state: "open",
+        merged: false,
+        url: "https://github.com/owner/repo/pull/99",
+      });
+    });
+
+    it("sets vettingResult.linkedPR to null when no linked PR exists", async () => {
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.vettingResult.linkedPR).toBeNull();
     });
 
     it("returns cached result within 15min TTL", async () => {
@@ -361,7 +393,7 @@ describe("IssueVetter", () => {
         maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
         await new Promise((r) => setTimeout(r, 10));
         currentConcurrent--;
-        return { passed: true };
+        return { passed: true, linkedPR: null };
       });
 
       const stateReader = makeStubStateReader();

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -148,6 +148,7 @@ export class IssueVetter {
         contributionGuidelinesFound: !!contributionGuidelines,
       },
       contributionGuidelines,
+      linkedPR: existingPRCheck.linkedPR,
       notes: [],
     };
 

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -104,6 +104,14 @@ export const ContributionGuidelinesSchema = z.object({
   rawContent: z.string().optional(),
 });
 
+export const LinkedPRSchema = z.object({
+  number: z.number(),
+  author: z.string(),
+  state: z.enum(["open", "closed"]),
+  merged: z.boolean(),
+  url: z.string(),
+});
+
 export const IssueVettingResultSchema = z.object({
   passedAllChecks: z.boolean(),
   checks: z.object({
@@ -114,6 +122,7 @@ export const IssueVettingResultSchema = z.object({
     contributionGuidelinesFound: z.boolean(),
   }),
   contributionGuidelines: ContributionGuidelinesSchema.optional(),
+  linkedPR: LinkedPRSchema.nullable().optional(),
   notes: z.array(z.string()),
 });
 
@@ -221,6 +230,7 @@ export type StoredOpenPR = z.infer<typeof StoredOpenPRSchema>;
 export type ContributionGuidelines = z.infer<
   typeof ContributionGuidelinesSchema
 >;
+export type LinkedPR = z.infer<typeof LinkedPRSchema>;
 export type IssueVettingResult = z.infer<typeof IssueVettingResultSchema>;
 export type TrackedIssue = z.infer<typeof TrackedIssueSchema>;
 export type ScoutPreferences = z.infer<typeof ScoutPreferencesSchema>;

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -21,6 +21,7 @@ export type {
   StoredClosedPR,
   ContributionGuidelines,
   IssueVettingResult,
+  LinkedPR,
   TrackedIssue,
   ScoutPreferences,
   SavedCandidate,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export type {
   RepoScore,
   RepoSignals,
   IssueVettingResult,
+  LinkedPR,
   ContributionGuidelines,
   TrackedIssue,
   IssueScope,


### PR DESCRIPTION
Closes #69.

## Summary

Today `IssueCandidate.vettingResult.checks.noExistingPR` is a single boolean. Downstream consumers (oss-autopilot in particular) need to classify the linked PR — own/competing, open/closed-unmerged — but have no way to do so without a duplicate `gh pr list` round-trip.

This surfaces the structured metadata directly. The data was already fetched during `checkNoExistingPR` via the timeline API; this PR stops discarding it.

## Shape

```ts
linkedPR: {
  number: number;
  author: string;
  state: 'open' | 'closed';
  merged: boolean;
  url: string;
} | null
```

Lives on `vettingResult.linkedPR` (sibling to `contributionGuidelines`). Schema is `.nullable().optional()` so existing persisted state still parses.

## Why warns when extraction fails

The timeline filter has already asserted a cross-referenced PR event exists. If `buildLinkedPRFromTimelineEvent` then can't extract `number`, `user.login`, or `html_url`, that's API shape drift — not absent data. Each null branch logs via `warn()` per the documented project error strategy ("API data errors: degrade gracefully **with warn logging**").

## Test plan

- [x] `pnpm test` — 510 core tests, 16 mcp-server tests passing
- [x] `pnpm run lint` — clean
- [x] `tsc --noEmit` — clean
- [x] New tests in `issue-eligibility.test.ts` cover: no linked PR, open/merged/closed-unmerged metadata extraction, first-wins on multi-PR, missing user.login (warn + null), missing html_url (warn + null), inconclusive on API error
- [x] New tests in `issue-vetting.test.ts` cover: linkedPR propagates onto vettingResult, defaults to null when no linked PR