### PR TITLE
feat: add antiLLMPolicy scan on IssueCandidate (#70)

### DIFF
--- a/packages/core/src/core/anti-llm-policy.test.ts
+++ b/packages/core/src/core/anti-llm-policy.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("./errors.js", () => ({
+  errorMessage: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  ),
+  getHttpStatusCode: vi.fn((e: unknown) => {
+    if (e && typeof e === "object" && "status" in e) {
+      const s = (e as { status: unknown }).status;
+      return typeof s === "number" ? s : undefined;
+    }
+    return undefined;
+  }),
+  isRateLimitError: vi.fn((e: unknown) => {
+    if (e && typeof e === "object" && "status" in e) {
+      const s = (e as { status: unknown }).status;
+      if (s === 429) return true;
+      if (
+        s === 403 &&
+        e instanceof Error &&
+        e.message.toLowerCase().includes("rate limit")
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }),
+}));
+
+vi.mock("./http-cache.js", () => ({
+  getHttpCache: vi.fn(() => ({
+    getIfFresh: vi.fn(() => null),
+    set: vi.fn(),
+  })),
+}));
+
+import {
+  scanForAntiLLMPolicy,
+  fetchAndScanAntiLLMPolicy,
+  ANTI_LLM_KEYWORDS,
+} from "./anti-llm-policy.js";
+import type { Octokit } from "@octokit/rest";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** Helper: an HTTP-shaped error with a numeric status (Octokit RequestError shape). */
+function httpError(
+  status: number,
+  message: string,
+): Error & { status: number } {
+  const err = new Error(message) as Error & { status: number };
+  err.status = status;
+  return err;
+}
+
+/**
+ * Build an Octokit mock whose getContent returns base64-encoded text for
+ * matching paths and 404s for everything else.
+ */
+function makeMockOctokit(filesByPath: Record<string, string>): Octokit {
+  const getContent = vi.fn(({ path }: { path: string }) => {
+    if (path in filesByPath) {
+      return Promise.resolve({
+        data: {
+          content: Buffer.from(filesByPath[path] ?? "", "utf-8").toString(
+            "base64",
+          ),
+        },
+      });
+    }
+    return Promise.reject(httpError(404, "Not Found"));
+  });
+  return { repos: { getContent } } as unknown as Octokit;
+}
+
+// ── scanForAntiLLMPolicy (pure) ────────────────────────────────────
+
+describe("scanForAntiLLMPolicy", () => {
+  it("returns no match for empty input", () => {
+    expect(scanForAntiLLMPolicy("")).toEqual({
+      matched: false,
+      matchedKeywords: [],
+    });
+  });
+
+  it("returns no match for plain prose without anti-AI signals", () => {
+    const text =
+      "Please open an issue before sending a PR. We use ESLint and Prettier.";
+    expect(scanForAntiLLMPolicy(text)).toEqual({
+      matched: false,
+      matchedKeywords: [],
+    });
+  });
+
+  it("matches an obvious anti-LLM phrase (case-insensitive)", () => {
+    const text = "We do not accept No AI-generated code in this project.";
+    const result = scanForAntiLLMPolicy(text);
+    expect(result.matched).toBe(true);
+    expect(result.matchedKeywords).toContain("no ai-generated");
+  });
+
+  it("matches 'human-authored only'", () => {
+    const text = "Submissions must be human-authored only. No exceptions.";
+    expect(scanForAntiLLMPolicy(text).matched).toBe(true);
+  });
+
+  it("matches 'do not use copilot'", () => {
+    const text =
+      "Please do not use Copilot for any contributions to this repo.";
+    expect(scanForAntiLLMPolicy(text).matched).toBe(true);
+  });
+
+  it("returns multiple matched keywords when several appear", () => {
+    const text =
+      "We require human-authored only contributions and ban on ai-generated code.";
+    const result = scanForAntiLLMPolicy(text);
+    expect(result.matched).toBe(true);
+    expect(result.matchedKeywords.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does NOT false-positive on 'we use Copilot' style mentions", () => {
+    // Common pattern: a project that internally uses Copilot but has no policy
+    const text =
+      "Many of our maintainers use Copilot. Please run pnpm test before submitting.";
+    expect(scanForAntiLLMPolicy(text)).toEqual({
+      matched: false,
+      matchedKeywords: [],
+    });
+  });
+
+  it("does NOT false-positive on 'AI-generated documentation may be edited'", () => {
+    // Permissive phrasing that mentions AI-generated but isn't a ban
+    const text = "AI-generated documentation may be edited by maintainers.";
+    expect(scanForAntiLLMPolicy(text).matched).toBe(false);
+  });
+
+  it("keeps the keyword table non-empty", () => {
+    expect(ANTI_LLM_KEYWORDS.length).toBeGreaterThan(0);
+  });
+});
+
+// ── fetchAndScanAntiLLMPolicy (integration with Octokit) ───────────
+
+describe("fetchAndScanAntiLLMPolicy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns no-match when no policy files exist", async () => {
+    const octokit = makeMockOctokit({});
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result).toEqual({
+      matched: false,
+      matchedKeywords: [],
+      sourceFile: null,
+    });
+  });
+
+  it("returns no-match when policy files exist but contain no keywords", async () => {
+    const octokit = makeMockOctokit({
+      "CONTRIBUTING.md": "Run tests before submitting. Use ESLint.",
+      "README.md": "This is a friendly project.",
+    });
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result.matched).toBe(false);
+    expect(result.sourceFile).toBeNull();
+  });
+
+  it("matches a CONTRIBUTING.md anti-LLM policy and returns canonical sourceFile", async () => {
+    const octokit = makeMockOctokit({
+      "CONTRIBUTING.md":
+        "We require human-authored only PRs. Please do not use ChatGPT.",
+    });
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result.matched).toBe(true);
+    expect(result.sourceFile).toBe("CONTRIBUTING.md");
+    expect(result.matchedKeywords).toContain("human-authored only");
+  });
+
+  it("falls back to CODE_OF_CONDUCT when CONTRIBUTING is clean", async () => {
+    const octokit = makeMockOctokit({
+      "CONTRIBUTING.md": "Standard guidelines: open an issue first.",
+      "CODE_OF_CONDUCT.md":
+        "All contributions must be human-written only and respectful.",
+    });
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result.matched).toBe(true);
+    expect(result.sourceFile).toBe("CODE_OF_CONDUCT.md");
+  });
+
+  it("falls back to README when CONTRIBUTING and COC are clean", async () => {
+    const octokit = makeMockOctokit({
+      "README.md":
+        "About this project. Please do not submit ai-generated changes.",
+    });
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result.matched).toBe(true);
+    expect(result.sourceFile).toBe("README.md");
+  });
+
+  it("checks the .github/ variant when root file is missing", async () => {
+    const octokit = makeMockOctokit({
+      ".github/CONTRIBUTING.md":
+        "Submissions must be human-authored only. No exceptions.",
+    });
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result.matched).toBe(true);
+    expect(result.sourceFile).toBe("CONTRIBUTING.md");
+  });
+
+  it("returns no-match when getContent returns a non-content payload", async () => {
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    } as unknown as Octokit;
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result).toEqual({
+      matched: false,
+      matchedKeywords: [],
+      sourceFile: null,
+    });
+  });
+
+  it("propagates 401 auth errors instead of swallowing them", async () => {
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockRejectedValue(httpError(401, "Unauthorized")),
+      },
+    } as unknown as Octokit;
+    await expect(
+      fetchAndScanAntiLLMPolicy(octokit, "owner", "repo"),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("propagates 429 rate-limit errors instead of swallowing them", async () => {
+    const octokit = {
+      repos: {
+        getContent: vi
+          .fn()
+          .mockRejectedValue(httpError(429, "API rate limit exceeded")),
+      },
+    } as unknown as Octokit;
+    await expect(
+      fetchAndScanAntiLLMPolicy(octokit, "owner", "repo"),
+    ).rejects.toThrow("rate limit");
+  });
+
+  it("does NOT cache a no-match result when probes had transient failures", async () => {
+    // 5xx is "transient": the function returns NO_MATCH but skips the cache write.
+    const cacheSet = vi.fn();
+    const { getHttpCache } = await import("./http-cache.js");
+    vi.mocked(getHttpCache).mockReturnValue({
+      getIfFresh: vi.fn(() => null),
+      set: cacheSet,
+    } as unknown as ReturnType<typeof getHttpCache>);
+
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockRejectedValue(httpError(503, "Server error")),
+      },
+    } as unknown as Octokit;
+
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result).toEqual({
+      matched: false,
+      matchedKeywords: [],
+      sourceFile: null,
+    });
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("DOES cache a no-match result when all probes returned clean 404s", async () => {
+    const cacheSet = vi.fn();
+    const { getHttpCache } = await import("./http-cache.js");
+    vi.mocked(getHttpCache).mockReturnValue({
+      getIfFresh: vi.fn(() => null),
+      set: cacheSet,
+    } as unknown as ReturnType<typeof getHttpCache>);
+
+    const octokit = makeMockOctokit({}); // all 404s
+    await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(cacheSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the cached value when it passes shape validation", async () => {
+    const validCached = {
+      matched: true,
+      matchedKeywords: ["no ai-generated"],
+      sourceFile: "CONTRIBUTING.md",
+    };
+    const { getHttpCache } = await import("./http-cache.js");
+    vi.mocked(getHttpCache).mockReturnValue({
+      getIfFresh: vi.fn(() => validCached),
+      set: vi.fn(),
+    } as unknown as ReturnType<typeof getHttpCache>);
+
+    const octokit = makeMockOctokit({});
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result).toEqual(validCached);
+  });
+
+  it("ignores a malformed cache value and re-fetches", async () => {
+    // Missing matchedKeywords array — should fail the shape guard.
+    const malformed = { matched: true, sourceFile: "CONTRIBUTING.md" };
+    const { getHttpCache } = await import("./http-cache.js");
+    vi.mocked(getHttpCache).mockReturnValue({
+      getIfFresh: vi.fn(() => malformed),
+      set: vi.fn(),
+    } as unknown as ReturnType<typeof getHttpCache>);
+
+    const octokit = makeMockOctokit({}); // all 404s
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo");
+    expect(result.matched).toBe(false);
+    expect(result.sourceFile).toBeNull();
+  });
+});

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -1,0 +1,243 @@
+/**
+ * Anti-LLM Policy — scans repo policy docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md,
+ * README.md) for keywords that signal an anti-AI / anti-LLM contribution policy
+ * (e.g. "no AI-generated code", "human-authored only", "no Copilot contributions").
+ *
+ * The keyword table lives here as a single source of truth so consumers
+ * can rely on a structured `AntiLLMPolicyResult` rather than re-implementing
+ * the scan in agent prose.
+ */
+
+import { Octokit } from "@octokit/rest";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import { warn } from "./logger.js";
+import { getHttpCache } from "./http-cache.js";
+import type { AntiLLMPolicyResult, AntiLLMPolicySourceFile } from "./types.js";
+
+const MODULE = "anti-llm-policy";
+
+/** TTL for cached anti-LLM policy scan results (1 hour). Policy docs change rarely. */
+const POLICY_SCAN_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Conservative anti-LLM keyword phrases. Each entry is a lowercase substring
+ * that — when present in policy text — is a strong signal of an anti-AI policy.
+ * Phrases are deliberately narrow to avoid flagging "we use Copilot internally"
+ * style mentions; the table can grow as new patterns are observed.
+ */
+export const ANTI_LLM_KEYWORDS: readonly string[] = [
+  "no ai-generated",
+  "no ai generated",
+  "no ai-assisted",
+  "no ai assisted",
+  "no llm-generated",
+  "no llm generated",
+  "no copilot-generated",
+  "no chatgpt-generated",
+  "human-authored only",
+  "human authored only",
+  "human-written only",
+  "human written only",
+  "ai-free contributions",
+  "llm-free contributions",
+  "ai-generated code is not allowed",
+  "ai-generated code will not be accepted",
+  "do not submit ai-generated",
+  "do not submit llm-generated",
+  "do not use ai to",
+  "do not use llms",
+  "do not use copilot",
+  "do not use chatgpt",
+  "without ai assistance",
+  "without llm assistance",
+  "no use of generative ai",
+  "ban on ai-generated",
+  "prohibit ai-generated",
+  "prohibits ai-generated",
+] as const;
+
+/**
+ * Pure scan: does this text contain any anti-LLM keyword?
+ * Case-insensitive; returns the matched keywords (deduped, in table order).
+ */
+export function scanForAntiLLMPolicy(text: string): {
+  matched: boolean;
+  matchedKeywords: string[];
+} {
+  if (!text) return { matched: false, matchedKeywords: [] };
+  const haystack = text.toLowerCase();
+  const matchedKeywords = ANTI_LLM_KEYWORDS.filter((kw) =>
+    haystack.includes(kw),
+  );
+  return { matched: matchedKeywords.length > 0, matchedKeywords };
+}
+
+/** Source-file probe families, in priority order. First match wins. */
+const SOURCE_FILE_FAMILIES: ReadonlyArray<{
+  canonical: AntiLLMPolicySourceFile;
+  paths: readonly string[];
+}> = [
+  {
+    canonical: "CONTRIBUTING.md",
+    paths: [
+      "CONTRIBUTING.md",
+      ".github/CONTRIBUTING.md",
+      "docs/CONTRIBUTING.md",
+      "contributing.md",
+    ],
+  },
+  {
+    canonical: "CODE_OF_CONDUCT.md",
+    paths: [
+      "CODE_OF_CONDUCT.md",
+      ".github/CODE_OF_CONDUCT.md",
+      "docs/CODE_OF_CONDUCT.md",
+      "code_of_conduct.md",
+    ],
+  },
+  {
+    canonical: "README.md",
+    paths: ["README.md", "readme.md", "Readme.md"],
+  },
+];
+
+/**
+ * Fetch one path's raw text content. The `transient` flag distinguishes a
+ * clean miss (404 — file absent) from a degraded miss (5xx, network) so the
+ * caller can decide whether to cache "no policy" or retry. Throws on
+ * 401/auth and rate-limit per documented project error strategy.
+ */
+async function fetchFileText(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<{ text: string | null; transient: boolean }> {
+  try {
+    const { data } = await octokit.repos.getContent({ owner, repo, path });
+    if ("content" in data && typeof data.content === "string") {
+      return {
+        text: Buffer.from(data.content, "base64").toString("utf-8"),
+        transient: false,
+      };
+    }
+    return { text: null, transient: false };
+  } catch (error) {
+    const status = getHttpStatusCode(error);
+    if (status === 404) return { text: null, transient: false };
+    if (status === 401 || isRateLimitError(error)) throw error;
+    warn(
+      MODULE,
+      `Unexpected error fetching ${path} from ${owner}/${repo}: ${errorMessage(error)}`,
+    );
+    return { text: null, transient: true };
+  }
+}
+
+/**
+ * Result of probing one source-file family. `hadTransientFailure` lets the
+ * caller decide whether to skip caching a "no match" result that may have
+ * been incomplete due to a 5xx / network blip.
+ */
+interface FamilyFetchResult {
+  text: string | null;
+  hadTransientFailure: boolean;
+}
+
+/**
+ * Fetch the first available file from a family. Probes are issued in parallel,
+ * but auth/rate-limit rejections re-throw so the IssueVetter's existing
+ * rate-limit handling kicks in instead of silently caching a wrong answer.
+ */
+async function fetchFamilyText(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  paths: readonly string[],
+): Promise<FamilyFetchResult> {
+  const results = await Promise.allSettled(
+    paths.map((p) => fetchFileText(octokit, owner, repo, p)),
+  );
+  let hadTransientFailure = false;
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      if (result.value.transient) hadTransientFailure = true;
+      if (result.value.text)
+        return { text: result.value.text, hadTransientFailure };
+    } else {
+      // Re-throw so vetIssuesParallel's isRateLimitError classifier sees it.
+      if (
+        isRateLimitError(result.reason) ||
+        getHttpStatusCode(result.reason) === 401
+      ) {
+        throw result.reason;
+      }
+      hadTransientFailure = true;
+    }
+  }
+  return { text: null, hadTransientFailure };
+}
+
+/** Cached value passes runtime shape checks for AntiLLMPolicyResult. */
+function isAntiLLMPolicyResult(value: unknown): value is AntiLLMPolicyResult {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.matched !== "boolean") return false;
+  if (!Array.isArray(v.matchedKeywords)) return false;
+  if (v.sourceFile !== null && typeof v.sourceFile !== "string") return false;
+  return true;
+}
+
+/**
+ * Fetch CONTRIBUTING/CODE_OF_CONDUCT/README in priority order and return the
+ * first family whose text matches an anti-LLM keyword. Returns
+ * `{matched: false, matchedKeywords: [], sourceFile: null}` when no source
+ * file matches. Cached per-repo for POLICY_SCAN_CACHE_TTL_MS.
+ *
+ * Sequential by design: if CONTRIBUTING throws auth/rate-limit, we want to
+ * short-circuit rather than burn API budget on COC + README probes.
+ */
+export async function fetchAndScanAntiLLMPolicy(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<AntiLLMPolicyResult> {
+  const cache = getHttpCache();
+  const cacheKey = `anti-llm-policy:${owner}/${repo}`;
+  const cached = cache.getIfFresh(cacheKey, POLICY_SCAN_CACHE_TTL_MS);
+  if (isAntiLLMPolicyResult(cached)) return cached;
+
+  let anyTransientFailure = false;
+  for (const family of SOURCE_FILE_FAMILIES) {
+    const { text, hadTransientFailure } = await fetchFamilyText(
+      octokit,
+      owner,
+      repo,
+      family.paths,
+    );
+    if (hadTransientFailure) anyTransientFailure = true;
+    if (!text) continue;
+    const { matched, matchedKeywords } = scanForAntiLLMPolicy(text);
+    if (matched) {
+      const result: AntiLLMPolicyResult = {
+        matched: true,
+        matchedKeywords,
+        sourceFile: family.canonical,
+      };
+      cache.set(cacheKey, "", result);
+      return result;
+    }
+  }
+
+  const noMatch: AntiLLMPolicyResult = {
+    matched: false,
+    matchedKeywords: [],
+    sourceFile: null,
+  };
+  // Skip the cache write when probes failed transiently — otherwise a
+  // single 5xx pin "no policy" for an hour for a repo that may actually have one.
+  if (!anyTransientFailure) {
+    cache.set(cacheKey, "", noMatch);
+  }
+  return noMatch;
+}

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -74,6 +74,14 @@ vi.mock("./repo-health.js", () => ({
   }),
 }));
 
+vi.mock("./anti-llm-policy.js", () => ({
+  fetchAndScanAntiLLMPolicy: vi.fn().mockResolvedValue({
+    matched: false,
+    matchedKeywords: [],
+    sourceFile: null,
+  }),
+}));
+
 vi.mock("./http-cache.js", () => ({
   getHttpCache: vi.fn(() => ({
     getIfFresh: vi.fn(() => null),
@@ -92,6 +100,7 @@ import {
   checkProjectHealth,
   fetchContributionGuidelines,
 } from "./repo-health.js";
+import { fetchAndScanAntiLLMPolicy } from "./anti-llm-policy.js";
 import { repoBelongsToCategory } from "./category-mapping.js";
 import { isRateLimitError } from "./errors.js";
 import { getHttpCache } from "./http-cache.js";
@@ -169,6 +178,11 @@ describe("IssueVetter", () => {
     vi.mocked(fetchContributionGuidelines).mockResolvedValue({
       url: "https://github.com/owner/repo/blob/main/CONTRIBUTING.md",
       content: "Please read before contributing.",
+    });
+    vi.mocked(fetchAndScanAntiLLMPolicy).mockResolvedValue({
+      matched: false,
+      matchedKeywords: [],
+      sourceFile: null,
     });
     vi.mocked(repoBelongsToCategory).mockReturnValue(false);
     vi.mocked(isRateLimitError).mockReturnValue(false);
@@ -277,6 +291,31 @@ describe("IssueVetter", () => {
       expect(result.vettingResult.linkedPR).toBeNull();
     });
 
+    it("attaches antiLLMPolicy default (no match) when scan finds nothing", async () => {
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.antiLLMPolicy).toEqual({
+        matched: false,
+        matchedKeywords: [],
+        sourceFile: null,
+      });
+    });
+
+    it("attaches antiLLMPolicy match metadata when scan finds anti-LLM keywords", async () => {
+      vi.mocked(fetchAndScanAntiLLMPolicy).mockResolvedValueOnce({
+        matched: true,
+        matchedKeywords: ["no ai-generated", "human-authored only"],
+        sourceFile: "CONTRIBUTING.md",
+      });
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.antiLLMPolicy).toEqual({
+        matched: true,
+        matchedKeywords: ["no ai-generated", "human-authored only"],
+        sourceFile: "CONTRIBUTING.md",
+      });
+    });
+
     it("returns cached result within 15min TTL", async () => {
       const cachedResult: IssueCandidate = {
         issue: {
@@ -321,6 +360,11 @@ describe("IssueVetter", () => {
           avgIssueResponseDays: 1,
           ciStatus: "passing",
           isActive: true,
+        },
+        antiLLMPolicy: {
+          matched: false,
+          matchedKeywords: [],
+          sourceFile: null,
         },
         recommendation: "approve",
         reasonsToSkip: [],

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -33,6 +33,7 @@ import {
   checkProjectHealth,
   fetchContributionGuidelines,
 } from "./repo-health.js";
+import { fetchAndScanAntiLLMPolicy } from "./anti-llm-policy.js";
 import { getHttpCache } from "./http-cache.js";
 
 const MODULE = "issue-vetting";
@@ -115,6 +116,7 @@ export class IssueVetter {
       projectHealth,
       contributionGuidelines,
       userMergedPRCount,
+      antiLLMPolicy,
     ] = await Promise.all([
       checkNoExistingPR(this.octokit, owner, repo, number),
       checkNotClaimed(this.octokit, owner, repo, number, ghIssue.comments),
@@ -123,6 +125,7 @@ export class IssueVetter {
       hasMergedPRsInRepo
         ? Promise.resolve(0)
         : checkUserMergedPRsInRepo(this.octokit, owner, repo),
+      fetchAndScanAntiLLMPolicy(this.octokit, owner, repo),
     ]);
 
     const noExistingPR = existingPRCheck.passed;
@@ -307,6 +310,7 @@ export class IssueVetter {
       issue: trackedIssue,
       vettingResult,
       projectHealth,
+      antiLLMPolicy,
       recommendation,
       reasonsToSkip,
       reasonsToApprove,

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -50,11 +50,25 @@ export interface ProjectHealth {
 /** Priority tier for issue search results. */
 export type SearchPriority = "merged_pr" | "starred" | "normal";
 
+/** Source file the anti-LLM policy match came from, or null when no file matched. */
+export type AntiLLMPolicySourceFile =
+  | "CONTRIBUTING.md"
+  | "CODE_OF_CONDUCT.md"
+  | "README.md";
+
+/** Result of scanning a repo's policy docs for anti-LLM/AI keywords. */
+export interface AntiLLMPolicyResult {
+  matched: boolean;
+  matchedKeywords: string[];
+  sourceFile: AntiLLMPolicySourceFile | null;
+}
+
 /** A fully vetted issue candidate with scoring. */
 export interface IssueCandidate {
   issue: TrackedIssue;
   vettingResult: IssueVettingResult;
   projectHealth: ProjectHealth;
+  antiLLMPolicy: AntiLLMPolicyResult;
   recommendation: "approve" | "skip" | "needs_review";
   reasonsToSkip: string[];
   reasonsToApprove: string[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,8 @@ export type {
   ProjectHealth,
   SearchPriority,
   CheckResult,
+  AntiLLMPolicyResult,
+  AntiLLMPolicySourceFile,
   VetListOptions,
   VetListResult,
   VetListEntry,
@@ -72,3 +74,7 @@ export { requireGitHubToken, getGitHubToken } from "./core/utils.js";
 // Internal classes (for advanced use)
 export { IssueDiscovery } from "./core/issue-discovery.js";
 export { IssueVetter, type ScoutStateReader } from "./core/issue-vetting.js";
+export {
+  scanForAntiLLMPolicy,
+  ANTI_LLM_KEYWORDS,
+} from "./core/anti-llm-policy.js";


### PR DESCRIPTION
Closes #70.

## Summary

Adds a structured \`antiLLMPolicy\` field on \`IssueCandidate\`, produced by scanning a repo's CONTRIBUTING.md, CODE_OF_CONDUCT.md, and README.md for anti-AI/LLM policy keywords. Lets consumers replace agent-prose scanning with a tested pure function and a single source-of-truth keyword table.

## Shape

\`\`\`ts
antiLLMPolicy: {
  matched: boolean;
  matchedKeywords: string[];
  sourceFile: 'CONTRIBUTING.md' | 'CODE_OF_CONDUCT.md' | 'README.md' | null;
}
\`\`\`

Lives directly on \`IssueCandidate\` (ephemeral) per the issue spec.

## Design choices

- **Conservative keyword table** (~28 multi-word phrases) — narrow on purpose to avoid false-positives like \"we use Copilot internally\". Tests cover both true-positive and false-positive shapes.
- **Sequential across families, parallel within** — if CONTRIBUTING throws auth/rate-limit, short-circuit the COC + README probes to save API budget.
- **Auth and rate-limit propagate** per documented project error strategy. 5xx / network failures degrade to a 'transient' miss that is intentionally **not** cached, so a single blip cannot pin 'no policy' for an hour.
- **Runtime shape guard on cache hits** — a corrupted cache entry triggers a fresh fetch rather than a downstream crash.

## Follow-up (deferred)

There's overlap between \`fetchAndScanAntiLLMPolicy\` and \`fetchContributionGuidelines\` — both fetch the CONTRIBUTING.md family. The 1h per-repo cache amortizes cost after the first issue per repo, so this is a perf optimization rather than a correctness issue. Will file a follow-up.

## Test plan

- [x] \`pnpm test\` — 534 core tests, 16 mcp-server tests passing
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`tsc --noEmit\` — clean
- [x] New tests in \`anti-llm-policy.test.ts\` cover: pure scan (matches/no-matches/false-positives), priority ordering across families, .github/ fallback, 401 propagation, 429 propagation, transient (5xx) failure does not cache, clean 404s do cache, valid cache hit, malformed cache value triggers re-fetch
- [x] New tests in \`issue-vetting.test.ts\` cover: antiLLMPolicy default attached, antiLLMPolicy match propagated to IssueCandidate