### PR TITLE
fix: propagate 401/429 in eligibility + repo-health helpers (#74)

### DIFF
--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -39,6 +39,15 @@ const mockPaginateAll = vi.mocked(paginateAll);
 
 // ── Helpers ────────────────────────────────────────────────────────
 
+function httpError(
+  status: number,
+  message: string,
+): Error & { status: number } {
+  const err = new Error(message) as Error & { status: number };
+  err.status = status;
+  return err;
+}
+
 function makeMockOctokit(overrides: Record<string, unknown> = {}): Octokit {
   return {
     issues: {
@@ -233,6 +242,24 @@ describe("checkNoExistingPR", () => {
     expect(result.linkedPR).toBeNull();
   });
 
+  it("propagates 401 auth errors instead of swallowing", async () => {
+    mockPaginateAll.mockRejectedValue(httpError(401, "Unauthorized"));
+    const octokit = makeMockOctokit();
+    await expect(
+      checkNoExistingPR(octokit, "owner", "repo", 1),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("propagates 429 rate-limit errors instead of swallowing", async () => {
+    mockPaginateAll.mockRejectedValue(
+      httpError(429, "API rate limit exceeded"),
+    );
+    const octokit = makeMockOctokit();
+    await expect(
+      checkNoExistingPR(octokit, "owner", "repo", 1),
+    ).rejects.toThrow("rate limit");
+  });
+
   it("returns passed:true when timeline is empty", async () => {
     mockPaginateAll.mockResolvedValue([]);
     const octokit = makeMockOctokit();
@@ -296,6 +323,26 @@ describe("checkNotClaimed", () => {
     expect(result.reason).toContain("Network error");
   });
 
+  it("propagates 401 auth errors instead of swallowing", async () => {
+    const octokit = makeMockOctokit({
+      paginate: vi.fn().mockRejectedValue(httpError(401, "Unauthorized")),
+    });
+    await expect(
+      checkNotClaimed(octokit, "owner", "repo", 1, 3),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("propagates 429 rate-limit errors instead of swallowing", async () => {
+    const octokit = makeMockOctokit({
+      paginate: vi
+        .fn()
+        .mockRejectedValue(httpError(429, "API rate limit exceeded")),
+    });
+    await expect(
+      checkNotClaimed(octokit, "owner", "repo", 1, 3),
+    ).rejects.toThrow("rate limit");
+  });
+
   it("returns passed:true when commentCount is zero (skips API)", async () => {
     const paginateFn = vi.fn();
     const octokit = makeMockOctokit({ paginate: paginateFn });
@@ -356,6 +403,32 @@ describe("checkUserMergedPRsInRepo", () => {
     });
     const result = await checkUserMergedPRsInRepo(octokit, "owner", "repo");
     expect(result).toBe(0);
+  });
+
+  it("propagates 401 auth errors instead of returning 0", async () => {
+    const octokit = makeMockOctokit({
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockRejectedValue(httpError(401, "Unauthorized")),
+      },
+    });
+    await expect(
+      checkUserMergedPRsInRepo(octokit, "owner", "repo"),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("propagates 429 rate-limit errors instead of returning 0", async () => {
+    const octokit = makeMockOctokit({
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockRejectedValue(httpError(429, "API rate limit exceeded")),
+      },
+    });
+    await expect(
+      checkUserMergedPRsInRepo(octokit, "owner", "repo"),
+    ).rejects.toThrow("rate limit");
   });
 });
 

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -8,7 +8,7 @@
 
 import { Octokit } from "@octokit/rest";
 import { paginateAll } from "./pagination.js";
-import { errorMessage } from "./errors.js";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache } from "./http-cache.js";
 import { getSearchBudgetTracker } from "./search-budget.js";
@@ -147,6 +147,9 @@ export async function checkNoExistingPR(
 
     return { passed: linkedPRCount === 0, linkedPR };
   } catch (error) {
+    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
+      throw error;
+    }
     const errMsg = errorMessage(error);
     warn(
       MODULE,
@@ -198,6 +201,9 @@ export async function checkUserMergedPRsInRepo(
       tracker.recordCall();
     }
   } catch (error) {
+    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
+      throw error;
+    }
     const errMsg = errorMessage(error);
     warn(
       MODULE,
@@ -245,6 +251,9 @@ export async function checkNotClaimed(
 
     return { passed: true };
   } catch (error) {
+    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
+      throw error;
+    }
     const errMsg = errorMessage(error);
     warn(
       MODULE,

--- a/packages/core/src/core/repo-health.test.ts
+++ b/packages/core/src/core/repo-health.test.ts
@@ -138,9 +138,11 @@ describe("fetchContributionGuidelines", () => {
   });
 
   it("returns undefined when no CONTRIBUTING.md found (404)", async () => {
+    const err = new Error("Not Found") as Error & { status: number };
+    err.status = 404;
     const octokit = {
       repos: {
-        getContent: vi.fn().mockRejectedValue(new Error("Not Found")),
+        getContent: vi.fn().mockRejectedValue(err),
       },
     } as unknown as Octokit;
 
@@ -150,5 +152,66 @@ describe("fetchContributionGuidelines", () => {
       "missing-repo",
     );
     expect(guidelines).toBeUndefined();
+  });
+
+  it("propagates 401 auth errors instead of swallowing", async () => {
+    const err = new Error("Unauthorized") as Error & { status: number };
+    err.status = 401;
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockRejectedValue(err),
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      fetchContributionGuidelines(octokit, "auth-org", "auth-repo"),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("propagates 429 rate-limit errors instead of swallowing", async () => {
+    const err = new Error("API rate limit exceeded") as Error & {
+      status: number;
+    };
+    err.status = 429;
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockRejectedValue(err),
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      fetchContributionGuidelines(octokit, "limited-org", "limited-repo"),
+    ).rejects.toThrow("rate limit");
+  });
+
+  it("propagates 401 even when a different probe path succeeded first", async () => {
+    // Path-restricted token: CONTRIBUTING.md returns content, but
+    // .github/CONTRIBUTING.md 401s. Auth misconfig must surface, not be hidden.
+    const authErr = new Error("Unauthorized") as Error & { status: number };
+    authErr.status = 401;
+    const content = "# Contributing\n\nUse conventional commits.";
+    const octokit = {
+      repos: {
+        getContent: vi.fn(({ path }: { path: string }) => {
+          if (path === "CONTRIBUTING.md") {
+            return Promise.resolve({
+              data: { content: Buffer.from(content).toString("base64") },
+            });
+          }
+          if (path === ".github/CONTRIBUTING.md") {
+            return Promise.reject(authErr);
+          }
+          const notFound = new Error("Not Found") as Error & {
+            status: number;
+          };
+          notFound.status = 404;
+          return Promise.reject(notFound);
+        }),
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      fetchContributionGuidelines(octokit, "mixed-org", "mixed-repo"),
+    ).rejects.toThrow("Unauthorized");
   });
 });

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -8,7 +8,7 @@
 import { Octokit } from "@octokit/rest";
 import { daysBetween } from "./utils.js";
 import { type ContributionGuidelines, type ProjectHealth } from "./types.js";
-import { errorMessage } from "./errors.js";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache, cachedRequest, cachedTimeBased } from "./http-cache.js";
 
@@ -179,6 +179,19 @@ export async function fetchContributionGuidelines(
     ),
   );
 
+  // Pre-scan: auth/rate-limit must propagate even if a faster probe succeeded —
+  // otherwise a path-restricted token that 401s on .github/CONTRIBUTING.md but
+  // wins on CONTRIBUTING.md would silently hide the auth misconfiguration.
+  for (const result of results) {
+    if (result.status !== "rejected") continue;
+    if (
+      getHttpStatusCode(result.reason) === 401 ||
+      isRateLimitError(result.reason)
+    ) {
+      throw result.reason;
+    }
+  }
+
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
     if (result.status === "fulfilled" && result.value) {
@@ -188,14 +201,11 @@ export async function fetchContributionGuidelines(
       return guidelines;
     }
     if (result.status === "rejected") {
-      const msg =
-        result.reason instanceof Error
-          ? result.reason.message
-          : String(result.reason);
-      if (!msg.includes("404") && !msg.includes("Not Found")) {
+      const status = getHttpStatusCode(result.reason);
+      if (status !== 404) {
         warn(
           MODULE,
-          `Unexpected error fetching ${filesToCheck[i]} from ${owner}/${repo}: ${msg}`,
+          `Unexpected error fetching ${filesToCheck[i]} from ${owner}/${repo}: ${errorMessage(result.reason)}`,
         );
       }
     }


### PR DESCRIPTION
Closes #74.

## Summary

Per the documented project error strategy in \`errors.ts\`, auth (401) and rate-limit (429, 403+rate-limit) errors must propagate so callers can classify the failure and degrade the user-facing recommendation appropriately. Four helpers swallowed everything, producing falsely-confident answers when the real truth was "we got rate-limited and don't know."

## What changed

- **\`checkNoExistingPR\`, \`checkNotClaimed\`, \`checkUserMergedPRsInRepo\`** in \`issue-eligibility.ts\`: throw on 401/rate-limit before the existing warn-and-degrade fallback. Same shape as \`anti-llm-policy.ts\`'s \`fetchFileText\`.
- **\`fetchContributionGuidelines\`** in \`repo-health.ts\`:
  - Replace substring \`\"404\"\`/\`\"Not Found\"\` matching with structured \`getHttpStatusCode\` classification.
  - Pre-scan rejected probes for 401/rate-limit so a path-restricted token that 401s on \`.github/CONTRIBUTING.md\` but wins on \`CONTRIBUTING.md\` surfaces the auth error rather than silently winning.

## Tests

- Update the pre-existing 404 test in \`repo-health.test.ts\` which used a raw \`Error(\"Not Found\")\` (no \`status\` property — worked only by accidental substring match) to use a proper \`httpError(404)\` shape.
- Add 401 + 429 propagation tests for all four helpers.
- Add a test for the new pre-scan behavior (401 propagates even when a faster probe succeeded).

## Out of scope (will file follow-ups)

The pr-review-toolkit surfaced four additional places that still swallow auth/rate-limit:
1. \`vetIssuesParallel\`'s per-item \`.catch\` in \`issue-vetting.ts\` re-swallows what these helpers now throw.
2. \`OssScout.vetList\` in \`scout.ts\` swallows 401 into per-row \`error\` records.
3. \`checkProjectHealth\` in \`repo-health.ts\` (issue body explicitly excluded it).
4. Three additional catches in \`bootstrap.ts\`, \`search-phases.ts\`, \`issue-discovery.ts\` (\`searchInRepoBatches\`, \`runPhase3\` Search-API fallback) that lack the 401-propagation guard their siblings have.

These need a separate scoped PR.

## Test plan

- [x] \`pnpm test\` — 543 core, 16 mcp-server passing
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`tsc --noEmit\` — clean