### PR TITLE
refactor: dedup CONTRIBUTING.md fetches between anti-llm and repo-health (#75)

### DIFF
--- a/packages/core/src/core/anti-llm-policy.test.ts
+++ b/packages/core/src/core/anti-llm-policy.test.ts
@@ -320,4 +320,109 @@ describe("fetchAndScanAntiLLMPolicy", () => {
     expect(result.matched).toBe(false);
     expect(result.sourceFile).toBeNull();
   });
+
+  // ── Caller-provided contributingText (deduplication) ────────────────
+
+  it("uses caller-provided contributingText without fetching CONTRIBUTING.md", async () => {
+    const getContent = vi.fn(() => {
+      const notFound = new Error("Not Found") as Error & { status: number };
+      notFound.status = 404;
+      return Promise.reject(notFound);
+    });
+    const octokit = { repos: { getContent } } as unknown as Octokit;
+
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo", {
+      contributingText:
+        "We require human-authored only contributions. No exceptions.",
+    });
+
+    expect(result).toEqual({
+      matched: true,
+      matchedKeywords: ["human-authored only"],
+      sourceFile: "CONTRIBUTING.md",
+    });
+    // No CONTRIBUTING family probe should have been issued.
+    const probedPaths = getContent.mock.calls.map(
+      (c) => (c[0] as { path: string }).path,
+    );
+    expect(probedPaths).not.toContain("CONTRIBUTING.md");
+    expect(probedPaths).not.toContain(".github/CONTRIBUTING.md");
+    expect(probedPaths).not.toContain("docs/CONTRIBUTING.md");
+    expect(probedPaths).not.toContain("contributing.md");
+  });
+
+  it("skips CONTRIBUTING family entirely when contributingText is null (known absent)", async () => {
+    const getContent = vi.fn(({ path }: { path: string }) => {
+      if (path === "CODE_OF_CONDUCT.md") {
+        return Promise.resolve({
+          data: {
+            content: Buffer.from(
+              "All contributions must be human-written only.",
+            ).toString("base64"),
+          },
+        });
+      }
+      const notFound = new Error("Not Found") as Error & { status: number };
+      notFound.status = 404;
+      return Promise.reject(notFound);
+    });
+    const octokit = { repos: { getContent } } as unknown as Octokit;
+
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo", {
+      contributingText: null,
+    });
+
+    expect(result.sourceFile).toBe("CODE_OF_CONDUCT.md");
+    const probedPaths = getContent.mock.calls.map(
+      (c) => (c[0] as { path: string }).path,
+    );
+    expect(probedPaths).not.toContain("CONTRIBUTING.md");
+    expect(probedPaths).not.toContain(".github/CONTRIBUTING.md");
+  });
+
+  it("falls through to COC when caller-provided contributingText has no match", async () => {
+    const octokit = makeMockOctokit({
+      "CODE_OF_CONDUCT.md":
+        "All contributions must be human-authored only. No AI tools.",
+    });
+
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo", {
+      contributingText: "Just a plain CONTRIBUTING with no keywords.",
+    });
+
+    expect(result.matched).toBe(true);
+    expect(result.sourceFile).toBe("CODE_OF_CONDUCT.md");
+  });
+
+  it("falls back to its own CONTRIBUTING fetch when contributingText is undefined", async () => {
+    // When the caller couldn't pre-fetch (e.g., contributionGuidelines was
+    // undefined due to a transient 5xx), passing contributingText: undefined
+    // must NOT short-circuit. We need the existing transient-failure tracking.
+    const getContent = vi.fn(({ path }: { path: string }) => {
+      if (path === "CONTRIBUTING.md") {
+        return Promise.resolve({
+          data: {
+            content: Buffer.from(
+              "We accept human-authored only contributions.",
+            ).toString("base64"),
+          },
+        });
+      }
+      const notFound = new Error("Not Found") as Error & { status: number };
+      notFound.status = 404;
+      return Promise.reject(notFound);
+    });
+    const octokit = { repos: { getContent } } as unknown as Octokit;
+
+    const result = await fetchAndScanAntiLLMPolicy(octokit, "owner", "repo", {
+      contributingText: undefined,
+    });
+
+    expect(result.matched).toBe(true);
+    expect(result.sourceFile).toBe("CONTRIBUTING.md");
+    const probedPaths = getContent.mock.calls.map(
+      (c) => (c[0] as { path: string }).path,
+    );
+    expect(probedPaths).toContain("CONTRIBUTING.md");
+  });
 });

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -189,6 +189,21 @@ function isAntiLLMPolicyResult(value: unknown): value is AntiLLMPolicyResult {
 }
 
 /**
+ * Optional caller hints to avoid duplicate fetches.
+ *
+ * `contributingText`:
+ *   - `string` — caller already fetched CONTRIBUTING; scan this text directly.
+ *   - `null`   — caller fetched and CONTRIBUTING is known absent; skip the family.
+ *   - `undefined` (omitted) — fetch as normal.
+ *
+ * Note: the per-repo result cache (1-hour TTL) is consulted before this hint.
+ * On a cache hit the cached result wins regardless of what is passed here.
+ */
+export interface AntiLLMPolicyOptions {
+  contributingText?: string | null;
+}
+
+/**
  * Fetch CONTRIBUTING/CODE_OF_CONDUCT/README in priority order and return the
  * first family whose text matches an anti-LLM keyword. Returns
  * `{matched: false, matchedKeywords: [], sourceFile: null}` when no source
@@ -201,6 +216,7 @@ export async function fetchAndScanAntiLLMPolicy(
   octokit: Octokit,
   owner: string,
   repo: string,
+  options?: AntiLLMPolicyOptions,
 ): Promise<AntiLLMPolicyResult> {
   const cache = getHttpCache();
   const cacheKey = `anti-llm-policy:${owner}/${repo}`;
@@ -209,12 +225,24 @@ export async function fetchAndScanAntiLLMPolicy(
 
   let anyTransientFailure = false;
   for (const family of SOURCE_FILE_FAMILIES) {
-    const { text, hadTransientFailure } = await fetchFamilyText(
-      octokit,
-      owner,
-      repo,
-      family.paths,
-    );
+    let text: string | null;
+    let hadTransientFailure = false;
+
+    if (
+      family.canonical === "CONTRIBUTING.md" &&
+      options?.contributingText !== undefined
+    ) {
+      // Use caller-provided text. null = known absent, string = use directly.
+      text = options.contributingText;
+    } else {
+      ({ text, hadTransientFailure } = await fetchFamilyText(
+        octokit,
+        owner,
+        repo,
+        family.paths,
+      ));
+    }
+
     if (hadTransientFailure) anyTransientFailure = true;
     if (!text) continue;
     const { matched, matchedKeywords } = scanForAntiLLMPolicy(text);

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -116,7 +116,6 @@ export class IssueVetter {
       projectHealth,
       contributionGuidelines,
       userMergedPRCount,
-      antiLLMPolicy,
     ] = await Promise.all([
       checkNoExistingPR(this.octokit, owner, repo, number),
       checkNotClaimed(this.octokit, owner, repo, number, ghIssue.comments),
@@ -125,8 +124,20 @@ export class IssueVetter {
       hasMergedPRsInRepo
         ? Promise.resolve(0)
         : checkUserMergedPRsInRepo(this.octokit, owner, repo),
-      fetchAndScanAntiLLMPolicy(this.octokit, owner, repo),
     ]);
+
+    // Anti-LLM scan reuses the CONTRIBUTING text just fetched above —
+    // dedup'd to avoid 4 redundant getContent calls on cold-cache repos.
+    // We deliberately pass undefined (not null) when guidelines is missing,
+    // because fetchContributionGuidelines returns undefined for BOTH a 404
+    // and a transient 5xx — collapsing them to null would bypass the
+    // anti-llm-policy transient-failure cache safeguard.
+    const antiLLMPolicy = await fetchAndScanAntiLLMPolicy(
+      this.octokit,
+      owner,
+      repo,
+      { contributingText: contributionGuidelines?.rawContent },
+    );
 
     const noExistingPR = existingPRCheck.passed;
     const notClaimed = claimCheck.passed;


### PR DESCRIPTION
Closes #75.

## Summary

Both \`fetchContributionGuidelines\` and \`fetchAndScanAntiLLMPolicy\` probed the same four CONTRIBUTING.md paths. On a cold-cache repo's first issue, that meant 8 \`getContent\` calls where 4 sufficed.

Took the **pass-through approach** (option 1 from the issue): anti-LLM accepts an optional \`contributingText\` hint and skips the CONTRIBUTING family probe when supplied. The dedup only matters for the first issue per repo (the per-repo anti-LLM cache short-circuits subsequent issues regardless).

## What changed

- New \`AntiLLMPolicyOptions { contributingText?: string | null }\` with three-state semantics:
  - \`string\` — use directly
  - \`null\` — known absent, skip
  - \`undefined\` — fetch as before
- \`vetIssue\` passes \`contributionGuidelines?.rawContent\` verbatim (NOT \`?? null\`).

## The undefined-vs-null subtlety

\`fetchContributionGuidelines\` returns \`undefined\` for both genuine 404s and transient 5xx failures (it warns and degrades). Collapsing both to \`null\` would mark CONTRIBUTING as authoritatively-absent and bypass the anti-LLM transient-failure cache safeguard built in #70 (PR #73). By keeping \`undefined\` for either case, anti-LLM falls back to its own fetch path with \`hadTransientFailure\` tracking intact when the caller couldn't reliably pre-fetch.

The trade-off: when the file genuinely 404s, anti-LLM still re-probes. But that case is the cheapest possible API result (4 quick 404s), and it's the price for not poisoning the cache on transient failures.

## Tests

- Three new tests in \`anti-llm-policy.test.ts\` covering all four hint shapes (string match, string no-match, null skip, undefined fallback).
- The \`undefined\` fallback test specifically verifies that anti-LLM still calls \`getContent\` for \`CONTRIBUTING.md\` when the hint is undefined — preserving the transient-failure path.

## Test plan

- [x] \`pnpm test\` — 549 core, 16 mcp-server passing
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`tsc --noEmit\` — clean