### PR TITLE
chore: add .prettierignore so format:check skips machine-generated files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+packages/*/dist/
+node_modules/
+pnpm-lock.yaml
+*.md


### PR DESCRIPTION
## Summary

Add a `.prettierignore` so `format:check` doesn't fail on auto-generated `CHANGELOG.md` files written by release-please, lockfiles, or built `dist/` output.

## Why

Every release-please PR fails CI because release-please writes `CHANGELOG.md` without running it through prettier — `format:check` then flags the formatting and the merge gate refuses to budge. Today required `--admin` to bypass.

This mirrors what oss-autopilot does: its root `.prettierignore` excludes `*.md`, `pnpm-lock.yaml`, `node_modules/`, and `dist/` for the same reason.

## Test plan

- [x] `prettier --check packages/` runs clean locally with this config
- [ ] Next release-please PR's CI run will skip `CHANGELOG.md` and pass `format:check`