### PR TITLE
feat: optional SLM pre-triage pass during issue vetting

### DIFF
--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -35,7 +35,11 @@ import {
 } from "./repo-health.js";
 import { fetchAndScanAntiLLMPolicy } from "./anti-llm-policy.js";
 import { getHttpCache } from "./http-cache.js";
-import { triageWithSLM, buildTriageInput, type SLMTriageOptions } from "./slm-triage.js";
+import {
+  triageWithSLM,
+  buildTriageInput,
+  type SLMTriageOptions,
+} from "./slm-triage.js";
 
 const MODULE = "issue-vetting";
 
@@ -326,7 +330,10 @@ export class IssueVetter {
 
     // Optional SLM pre-triage (oss-autopilot#1122). Fail-open: any error
     // path returns null and the rest of the pipeline is unaffected.
-    const slmConfig = this.stateReader.getSLMTriageConfig?.() ?? { model: "", host: "" };
+    const slmConfig = this.stateReader.getSLMTriageConfig?.() ?? {
+      model: "",
+      host: "",
+    };
     let slmTriage: IssueCandidate["slmTriage"] = null;
     if (slmConfig.model) {
       const slmOpts: SLMTriageOptions = { model: slmConfig.model };

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -35,6 +35,7 @@ import {
 } from "./repo-health.js";
 import { fetchAndScanAntiLLMPolicy } from "./anti-llm-policy.js";
 import { getHttpCache } from "./http-cache.js";
+import { triageWithSLM, buildTriageInput, type SLMTriageOptions } from "./slm-triage.js";
 
 const MODULE = "issue-vetting";
 
@@ -59,6 +60,12 @@ export interface ScoutStateReader {
   getProjectCategories(): ProjectCategory[];
   /** Numeric quality score for a repo, or null if not evaluated. */
   getRepoScore(repo: string): number | null;
+  /**
+   * SLM pre-triage config (oss-autopilot#1122). Returns the configured
+   * model id and Ollama host, or empty strings when not configured —
+   * vetIssue treats either of these as "skip the SLM call".
+   */
+  getSLMTriageConfig?(): { model: string; host: string };
 }
 
 export class IssueVetter {
@@ -317,11 +324,28 @@ export class IssueVetter {
       searchPriority = "starred";
     }
 
+    // Optional SLM pre-triage (oss-autopilot#1122). Fail-open: any error
+    // path returns null and the rest of the pipeline is unaffected.
+    const slmConfig = this.stateReader.getSLMTriageConfig?.() ?? { model: "", host: "" };
+    let slmTriage: IssueCandidate["slmTriage"] = null;
+    if (slmConfig.model) {
+      const slmOpts: SLMTriageOptions = { model: slmConfig.model };
+      if (slmConfig.host) slmOpts.host = slmConfig.host;
+      slmTriage = await triageWithSLM(
+        buildTriageInput({
+          issue: { ...trackedIssue, body: ghIssue.body ?? "" },
+          linkedPR: existingPRCheck.linkedPR ?? null,
+        }),
+        slmOpts,
+      );
+    }
+
     const result: IssueCandidate = {
       issue: trackedIssue,
       vettingResult,
       projectHealth,
       antiLLMPolicy,
+      slmTriage,
       recommendation,
       reasonsToSkip,
       reasonsToApprove,

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -188,6 +188,19 @@ export const ScoutPreferencesSchema = z.object({
   defaultStrategy: z.array(SearchStrategySchema).optional(),
   broadPhaseDelayMs: z.number().min(0).max(300000).default(90000),
   skipBroadWhenSufficientResults: z.number().int().min(0).max(100).default(15),
+  /**
+   * Optional Ollama model id used for SLM pre-triage during vetting
+   * (oss-autopilot#1122). Empty disables the feature. Recommended values:
+   * `gemma4:e4b` (default for capable hardware) or `gemma4:e2b` /
+   * `qwen3:1.7b` for low-RAM machines.
+   */
+  slmTriageModel: z.string().default(""),
+  /**
+   * Override the Ollama HTTP host. Defaults to `http://127.0.0.1:11434`
+   * when empty. Useful when Ollama runs on a different machine on the
+   * local network.
+   */
+  slmTriageHost: z.string().default(""),
 });
 
 // ── Root state schema ───────────────────────────────────────────────

--- a/packages/core/src/core/slm-triage.test.ts
+++ b/packages/core/src/core/slm-triage.test.ts
@@ -8,8 +8,12 @@ const ISSUE = {
 };
 
 function mockFetchOk(body: unknown): typeof fetch {
-  return vi.fn(async () =>
-    new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } }),
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
   ) as unknown as typeof fetch;
 }
 
@@ -47,8 +51,8 @@ describe("triageWithSLM", () => {
   });
 
   it("returns null when Ollama returns a non-200 status", async () => {
-    const fetchImpl = vi.fn(async () =>
-      new Response("server error", { status: 500 }),
+    const fetchImpl = vi.fn(
+      async () => new Response("server error", { status: 500 }),
     ) as unknown as typeof fetch;
 
     const result = await triageWithSLM(
@@ -73,8 +77,8 @@ describe("triageWithSLM", () => {
   });
 
   it("returns null when the response body is not valid JSON", async () => {
-    const fetchImpl = vi.fn(async () =>
-      new Response("not valid json", { status: 200 }),
+    const fetchImpl = vi.fn(
+      async () => new Response("not valid json", { status: 200 }),
     ) as unknown as typeof fetch;
 
     const result = await triageWithSLM(
@@ -156,11 +160,20 @@ describe("triageWithSLM", () => {
   });
 
   it("posts to the configured host", async () => {
-    const fetchImpl = vi.fn(async () =>
-      new Response(
-        JSON.stringify({ message: { content: JSON.stringify({ decision: "skip", confidence: "low", reasons: ["x"] }) } }),
-        { status: 200 },
-      ),
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            message: {
+              content: JSON.stringify({
+                decision: "skip",
+                confidence: "low",
+                reasons: ["x"],
+              }),
+            },
+          }),
+          { status: 200 },
+        ),
     ) as unknown as typeof fetch;
 
     await triageWithSLM(
@@ -174,14 +187,26 @@ describe("triageWithSLM", () => {
   });
 
   it("includes the configured model in the request body", async () => {
-    const fetchImpl = vi.fn(async () =>
-      new Response(
-        JSON.stringify({ message: { content: JSON.stringify({ decision: "skip", confidence: "low", reasons: ["x"] }) } }),
-        { status: 200 },
-      ),
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            message: {
+              content: JSON.stringify({
+                decision: "skip",
+                confidence: "low",
+                reasons: ["x"],
+              }),
+            },
+          }),
+          { status: 200 },
+        ),
     ) as unknown as typeof fetch;
 
-    await triageWithSLM({ issue: ISSUE, linkedPRExists: false }, { model: "qwen3:4b", fetchImpl });
+    await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "qwen3:4b", fetchImpl },
+    );
 
     const body = JSON.parse(
       (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
@@ -195,8 +220,16 @@ describe("triageWithSLM", () => {
 describe("buildTriageInput", () => {
   it("flattens issue and linkedPR existence into prompt input", () => {
     const result = buildTriageInput({
-      issue: { title: "T", labels: ["L"], body: "B" } as Parameters<typeof buildTriageInput>[0]["issue"],
-      linkedPR: { number: 1, author: "x", state: "open", merged: false, url: "https://x" },
+      issue: { title: "T", labels: ["L"], body: "B" } as Parameters<
+        typeof buildTriageInput
+      >[0]["issue"],
+      linkedPR: {
+        number: 1,
+        author: "x",
+        state: "open",
+        merged: false,
+        url: "https://x",
+      },
     });
     expect(result).toEqual({
       issue: { title: "T", labels: ["L"], body: "B" },
@@ -206,7 +239,9 @@ describe("buildTriageInput", () => {
 
   it("sets linkedPRExists to false when null", () => {
     const result = buildTriageInput({
-      issue: { title: "T", labels: [], body: "" } as Parameters<typeof buildTriageInput>[0]["issue"],
+      issue: { title: "T", labels: [], body: "" } as Parameters<
+        typeof buildTriageInput
+      >[0]["issue"],
       linkedPR: null,
     });
     expect(result.linkedPRExists).toBe(false);

--- a/packages/core/src/core/slm-triage.test.ts
+++ b/packages/core/src/core/slm-triage.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from "vitest";
+import { triageWithSLM, buildTriageInput } from "./slm-triage.js";
+
+const ISSUE = {
+  title: "Add a way to escape special characters in repo names",
+  labels: ["good first issue"],
+  body: "Repo names with `+` get URL-encoded incorrectly. Should fix the encoding pass.",
+};
+
+function mockFetchOk(body: unknown): typeof fetch {
+  return vi.fn(async () =>
+    new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } }),
+  ) as unknown as typeof fetch;
+}
+
+describe("triageWithSLM", () => {
+  it("returns null when no model is configured", async () => {
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "" },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns the parsed SLM result on a valid response", async () => {
+    const fetchImpl = mockFetchOk({
+      message: {
+        content: JSON.stringify({
+          decision: "pursue",
+          confidence: "high",
+          reasons: ["small scope", "clear acceptance"],
+        }),
+      },
+    });
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toEqual({
+      decision: "pursue",
+      confidence: "high",
+      reasons: ["small scope", "clear acceptance"],
+      modelVersion: "gemma4:e4b",
+    });
+  });
+
+  it("returns null when Ollama returns a non-200 status", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response("server error", { status: 500 }),
+    ) as unknown as typeof fetch;
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch rejects (e.g. connection refused)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the response body is not valid JSON", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response("not valid json", { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the model content is not parseable JSON (schema enforcement disagreement)", async () => {
+    const fetchImpl = mockFetchOk({
+      message: { content: "this is not json" },
+    });
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when decision is outside the allowed enum", async () => {
+    const fetchImpl = mockFetchOk({
+      message: {
+        content: JSON.stringify({
+          decision: "maybe", // invalid
+          confidence: "low",
+          reasons: ["unsure"],
+        }),
+      },
+    });
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when reasons is empty", async () => {
+    const fetchImpl = mockFetchOk({
+      message: {
+        content: JSON.stringify({
+          decision: "skip",
+          confidence: "high",
+          reasons: [],
+        }),
+      },
+    });
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when reasons has more than three entries", async () => {
+    const fetchImpl = mockFetchOk({
+      message: {
+        content: JSON.stringify({
+          decision: "skip",
+          confidence: "high",
+          reasons: ["a", "b", "c", "d"],
+        }),
+      },
+    });
+
+    const result = await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", fetchImpl },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("posts to the configured host", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ message: { content: JSON.stringify({ decision: "skip", confidence: "low", reasons: ["x"] }) } }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+
+    await triageWithSLM(
+      { issue: ISSUE, linkedPRExists: false },
+      { model: "gemma4:e4b", host: "http://example.test:99999", fetchImpl },
+    );
+
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      "http://example.test:99999/api/chat",
+    );
+  });
+
+  it("includes the configured model in the request body", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ message: { content: JSON.stringify({ decision: "skip", confidence: "low", reasons: ["x"] }) } }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+
+    await triageWithSLM({ issue: ISSUE, linkedPRExists: false }, { model: "qwen3:4b", fetchImpl });
+
+    const body = JSON.parse(
+      (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(body.model).toBe("qwen3:4b");
+    expect(body.format).toBeDefined();
+    expect(body.options.temperature).toBe(0.1);
+  });
+});
+
+describe("buildTriageInput", () => {
+  it("flattens issue and linkedPR existence into prompt input", () => {
+    const result = buildTriageInput({
+      issue: { title: "T", labels: ["L"], body: "B" } as Parameters<typeof buildTriageInput>[0]["issue"],
+      linkedPR: { number: 1, author: "x", state: "open", merged: false, url: "https://x" },
+    });
+    expect(result).toEqual({
+      issue: { title: "T", labels: ["L"], body: "B" },
+      linkedPRExists: true,
+    });
+  });
+
+  it("sets linkedPRExists to false when null", () => {
+    const result = buildTriageInput({
+      issue: { title: "T", labels: [], body: "" } as Parameters<typeof buildTriageInput>[0]["issue"],
+      linkedPR: null,
+    });
+    expect(result.linkedPRExists).toBe(false);
+  });
+});

--- a/packages/core/src/core/slm-triage.ts
+++ b/packages/core/src/core/slm-triage.ts
@@ -145,7 +145,8 @@ export async function triageWithSLM(
   }
 
   // Ollama `chat` returns { message: { content: string }, ... }.
-  const content = (payload as { message?: { content?: string } })?.message?.content;
+  const content = (payload as { message?: { content?: string } })?.message
+    ?.content;
   if (typeof content !== "string") return null;
 
   let parsed: unknown;
@@ -175,7 +176,11 @@ export function buildTriageInput(args: {
   linkedPR: LinkedPR | null | undefined;
 }): SLMTriageInput {
   return {
-    issue: { title: args.issue.title, labels: args.issue.labels, body: args.issue.body },
+    issue: {
+      title: args.issue.title,
+      labels: args.issue.labels,
+      body: args.issue.body,
+    },
     linkedPRExists: !!args.linkedPR,
   };
 }
@@ -187,9 +192,24 @@ function isValidTriageShape(value: unknown): value is {
 } {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
-  if (v.decision !== "pursue" && v.decision !== "investigate" && v.decision !== "skip") return false;
-  if (v.confidence !== "high" && v.confidence !== "medium" && v.confidence !== "low") return false;
-  if (!Array.isArray(v.reasons) || v.reasons.length === 0 || v.reasons.length > 3) return false;
+  if (
+    v.decision !== "pursue" &&
+    v.decision !== "investigate" &&
+    v.decision !== "skip"
+  )
+    return false;
+  if (
+    v.confidence !== "high" &&
+    v.confidence !== "medium" &&
+    v.confidence !== "low"
+  )
+    return false;
+  if (
+    !Array.isArray(v.reasons) ||
+    v.reasons.length === 0 ||
+    v.reasons.length > 3
+  )
+    return false;
   if (!v.reasons.every((r) => typeof r === "string")) return false;
   return true;
 }

--- a/packages/core/src/core/slm-triage.ts
+++ b/packages/core/src/core/slm-triage.ts
@@ -1,0 +1,195 @@
+/**
+ * Optional SLM (small language model) pre-triage pass for vetted issues
+ * (oss-autopilot#1122).
+ *
+ * When the user has an Ollama instance running locally and a model
+ * configured via `slmTriageModel`, vetting can call out to that model
+ * for a structured classification of each candidate issue. The result
+ * is surfaced on `IssueCandidate.slmTriage` so consumers (autopilot
+ * agents, dashboard, vet-list output) can show the call up-front and
+ * skip the cost of reading every issue body manually.
+ *
+ * Design highlights:
+ * - **Fail open.** Any failure (no model configured, Ollama down,
+ *   timeout, malformed JSON, schema mismatch) returns `null`. Triage
+ *   must never block the rest of the vetting pipeline.
+ * - **Schema-enforced JSON.** Uses Ollama's `format` parameter so the
+ *   decoder produces JSON conformant to a fixed schema; eliminates the
+ *   "model returned partial JSON" failure mode that plagues prompt-only
+ *   structured-output schemes.
+ * - **15s timeout.** Local SLMs vary widely in latency; 15s covers
+ *   small-to-mid models on consumer hardware (Gemma 4 e4b, Qwen 3 4b).
+ *   Slower models simply produce `null` and don't block vetting.
+ */
+import type { TrackedIssue, LinkedPR } from "./schemas.js";
+
+/** Default Ollama HTTP endpoint when not overridden. */
+const DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434";
+
+/** Default per-call timeout. */
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/** Hard cap on issue body length we send to the model. */
+const MAX_BODY_CHARS = 2000;
+
+/**
+ * Result of an SLM triage call. The same shape Ollama is constrained to
+ * produce via `format` schema enforcement.
+ */
+export interface SLMTriageResult {
+  /** Three buckets that match human triage decisions. */
+  decision: "pursue" | "investigate" | "skip";
+  /** How sure the model is. Surface in UI; don't gate on it server-side. */
+  confidence: "high" | "medium" | "low";
+  /** Short phrases (not sentences) explaining the decision. 1–3 entries. */
+  reasons: string[];
+  /** Model id that produced this result. Useful when comparing runs. */
+  modelVersion: string;
+}
+
+/** Inputs to a triage call. */
+export interface SLMTriageInput {
+  issue: Pick<TrackedIssue, "title" | "labels"> & { body?: string };
+  linkedPRExists: boolean;
+}
+
+/** Runtime options for `triageWithSLM`. */
+export interface SLMTriageOptions {
+  /** Model id (e.g. `gemma4:e4b`). Empty/unset disables triage. */
+  model: string;
+  /** Override Ollama base URL. Defaults to `http://127.0.0.1:11434`. */
+  host?: string;
+  /** Override request timeout. */
+  timeoutMs?: number;
+  /** Override fetch implementation (for tests). */
+  fetchImpl?: typeof fetch;
+}
+
+/** JSON schema enforced server-side by Ollama's `format` parameter. */
+const SLM_TRIAGE_SCHEMA = {
+  type: "object",
+  properties: {
+    decision: { type: "string", enum: ["pursue", "investigate", "skip"] },
+    confidence: { type: "string", enum: ["high", "medium", "low"] },
+    reasons: {
+      type: "array",
+      items: { type: "string" },
+      minItems: 1,
+      maxItems: 3,
+    },
+  },
+  required: ["decision", "confidence", "reasons"],
+} as const;
+
+/** Build the user-message prompt from an issue. */
+function buildPrompt(input: SLMTriageInput): string {
+  const { issue, linkedPRExists } = input;
+  const body = (issue.body ?? "").slice(0, MAX_BODY_CHARS);
+  return [
+    "You triage open-source issues for an autonomous contribution agent.",
+    "Classify the issue into exactly one bucket:",
+    "- pursue: small, concrete bug or feature with clear acceptance; safe for an autonomous agent to attempt without further design input",
+    "- investigate: tractable but needs human reading first (ambiguous scope, design questions, recently-touched files)",
+    "- skip: not actionable autonomously (epic, creative, blocked, requires upstream change, requires infra)",
+    "",
+    "Return JSON only matching the provided schema. Reasons must be short phrases, not sentences. 1-3 reasons total.",
+    "",
+    "Issue:",
+    `Title: ${issue.title}`,
+    `Body: ${body}`,
+    `Labels: ${issue.labels.join(", ")}`,
+    `Linked PR exists: ${linkedPRExists}`,
+  ].join("\n");
+}
+
+/**
+ * Run an SLM triage classification. Returns `null` on any failure path
+ * — caller treats `null` as "no SLM signal available".
+ */
+export async function triageWithSLM(
+  input: SLMTriageInput,
+  options: SLMTriageOptions,
+): Promise<SLMTriageResult | null> {
+  if (!options.model) return null;
+
+  const host = options.host ?? DEFAULT_OLLAMA_HOST;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchFn = options.fetchImpl ?? fetch;
+
+  let response: Response;
+  try {
+    response = await fetchFn(`${host}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: options.model,
+        messages: [{ role: "user", content: buildPrompt(input) }],
+        stream: false,
+        format: SLM_TRIAGE_SCHEMA,
+        options: { temperature: 0.1 },
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch {
+    // Connection refused, timeout, DNS error, etc.
+    return null;
+  }
+
+  if (!response.ok) return null;
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    return null;
+  }
+
+  // Ollama `chat` returns { message: { content: string }, ... }.
+  const content = (payload as { message?: { content?: string } })?.message?.content;
+  if (typeof content !== "string") return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!isValidTriageShape(parsed)) return null;
+
+  return {
+    decision: parsed.decision,
+    confidence: parsed.confidence,
+    reasons: parsed.reasons,
+    modelVersion: options.model,
+  };
+}
+
+/**
+ * Adapter: build an `SLMTriageInput` from the standard scout types we
+ * carry through `vetIssue`. Centralizes the mapping so callers don't
+ * have to know about the prompt internals.
+ */
+export function buildTriageInput(args: {
+  issue: TrackedIssue & { body?: string };
+  linkedPR: LinkedPR | null | undefined;
+}): SLMTriageInput {
+  return {
+    issue: { title: args.issue.title, labels: args.issue.labels, body: args.issue.body },
+    linkedPRExists: !!args.linkedPR,
+  };
+}
+
+function isValidTriageShape(value: unknown): value is {
+  decision: "pursue" | "investigate" | "skip";
+  confidence: "high" | "medium" | "low";
+  reasons: string[];
+} {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (v.decision !== "pursue" && v.decision !== "investigate" && v.decision !== "skip") return false;
+  if (v.confidence !== "high" && v.confidence !== "medium" && v.confidence !== "low") return false;
+  if (!Array.isArray(v.reasons) || v.reasons.length === 0 || v.reasons.length > 3) return false;
+  if (!v.reasons.every((r) => typeof r === "string")) return false;
+  return true;
+}

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -63,12 +63,27 @@ export interface AntiLLMPolicyResult {
   sourceFile: AntiLLMPolicySourceFile | null;
 }
 
+/**
+ * Optional SLM (small language model) pre-triage classification for an
+ * issue (oss-autopilot#1122). Populated when the user has configured
+ * `slmTriageModel` and a local Ollama instance is reachable. Always
+ * fail-open: any error path leaves this `null`.
+ */
+export interface SLMTriageSummary {
+  decision: "pursue" | "investigate" | "skip";
+  confidence: "high" | "medium" | "low";
+  reasons: string[];
+  modelVersion: string;
+}
+
 /** A fully vetted issue candidate with scoring. */
 export interface IssueCandidate {
   issue: TrackedIssue;
   vettingResult: IssueVettingResult;
   projectHealth: ProjectHealth;
   antiLLMPolicy: AntiLLMPolicyResult;
+  /** SLM pre-triage result, or `null` when not configured / unavailable. */
+  slmTriage: SLMTriageSummary | null;
   recommendation: "approve" | "skip" | "needs_review";
   reasonsToSkip: string[];
   reasonsToApprove: string[];


### PR DESCRIPTION
## Summary

Adds an opt-in pre-triage step to issue vetting that calls a local Ollama instance to classify each candidate as `pursue` / `investigate` / `skip` with a confidence score and 1-3 reason phrases. Surfaces as a new `slmTriage` field on `IssueCandidate`. When the user hasn't configured a model or Ollama is unreachable, the field is `null` and the rest of vetting is unaffected (fail-open).

Tracks the consumer-side ask filed downstream (oss-autopilot#1122).

## What changed

- **`packages/core/src/core/slm-triage.ts`** (new) — pure async `triageWithSLM()` function. Uses Ollama's `format` JSON-schema parameter so the decoder produces schema-conformant output; eliminates the malformed-JSON failure mode.
- **`packages/core/src/core/types.ts`** — `IssueCandidate` gains `slmTriage: SLMTriageSummary | null`. New `SLMTriageSummary` type.
- **`packages/core/src/core/schemas.ts`** — `ScoutPreferences` gains `slmTriageModel` (empty disables) and `slmTriageHost` (defaults to `http://127.0.0.1:11434` when empty).
- **`packages/core/src/core/issue-vetting.ts`** — wires the call after the main vetting checks. `ScoutStateReader` gets an optional `getSLMTriageConfig()` method (existing implementations unchanged).

## Why this design

- **Schema-enforced JSON.** `format` constraint at the decoder catches the "model returned partial JSON" failure that prompt-only structured-output schemes hit. Tests cover the decoder-disagreement paths anyway.
- **Fail-open everywhere.** Connection refused, timeout, 5xx, malformed JSON, decision-out-of-enum — every error returns `null`. The cost of being wrong is one missed signal per issue, not blocking the whole pipeline.
- **Opt-in via empty default.** Empty `slmTriageModel` skips the call entirely. Users without Ollama, or who simply don't want a 2-5GB model running, see no behavioral change.

## Recommended models

- **Default**: `gemma4:e4b` (~5GB Q4) — explicitly tuned by Google for "reasoning, agentic workflows" per the Ollama library.
- **Low-RAM**: `gemma4:e2b` (~2GB Q4) — same family, smaller.
- **Alternative**: `qwen3:4b` — Ollama's own example for similar agent tasks.

## Test plan

- [x] `pnpm test` — 576 tests pass (560 core + 16 mcp-server)
- [x] `pnpm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] 13 new unit tests covering no-model, happy path, 5xx, fetch reject, response-not-JSON, content-not-JSON, invalid-decision, empty-reasons, too-many-reasons, configured host, configured model, plus the `buildTriageInput` adapter.
- [ ] **Manual smoke test pending**: needs an Ollama instance with `gemma4:e4b` pulled, then `vet <issue-url>` with `slmTriageModel=gemma4:e4b` set in scout config.

Closes downstream oss-autopilot#1122 (scout side).