### PR TITLE
fix: implement getSLMTriageConfig on OssScout so vetter can read prefs

### DIFF
--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -324,6 +324,17 @@ export class OssScout implements ScoutStateReader {
     return score ? score.score : null;
   }
 
+  /**
+   * Optional SLM pre-triage config read from preferences (oss-autopilot#1122).
+   * Empty `model` disables the call; the vetter treats it as a no-op.
+   */
+  getSLMTriageConfig(): { model: string; host: string } {
+    return {
+      model: this.state.preferences.slmTriageModel ?? "",
+      host: this.state.preferences.slmTriageHost ?? "",
+    };
+  }
+
   /** Get current preferences (read-only). */
   getPreferences(): Readonly<ScoutPreferences> {
     return this.state.preferences;


### PR DESCRIPTION
## Summary

The slmTriage feature added in #81 reads its config via the optional `getSLMTriageConfig()` method on `ScoutStateReader`. `OssScout` implements `ScoutStateReader` but the SLM method wasn't added in #81, so the SLM call silently no-ops in the standard `createScout()` flow.

This adds the trivial implementation that returns `{ model, host }` from `state.preferences`.

## Test plan

- [x] `pnpm test` — 576 tests pass
- [x] `pnpm run lint` clean
- [x] `pnpm build` clean

## Why this slipped through

The IssueVetter unit tests pass with a hand-rolled stateReader so they didn't catch the missing OssScout integration. Worth a follow-up integration test that asserts `createScout({...})` returns an instance whose `getSLMTriageConfig()` reads the right preferences.