### PR TITLE
fix: add 401/rate-limit propagation guards to remaining core/ catches (#80)

### DIFF
--- a/packages/core/src/core/bootstrap.test.ts
+++ b/packages/core/src/core/bootstrap.test.ts
@@ -250,6 +250,44 @@ describe("bootstrapScout", () => {
     expect(result.errors).toContain("open PR fetch failed");
   });
 
+  it("propagates auth errors from starred-repos fetch (does not silently degrade)", async () => {
+    mockRateLimit(30);
+    const authError = Object.assign(new Error("Bad credentials"), {
+      status: 401,
+    });
+    // The starred-repos fetch goes through paginate.iterator. The error
+    // surfaces when the for-await loop pulls the first page.
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue({
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.reject(authError),
+      }),
+    });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    await expect(bootstrapScout(scout, token)).rejects.toThrow(
+      "Bad credentials",
+    );
+  });
+
+  it("propagates rate-limit errors from starred-repos fetch (does not silently degrade)", async () => {
+    mockRateLimit(30);
+    const rateLimitError = Object.assign(new Error("API rate limit exceeded"), {
+      status: 429,
+    });
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue({
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.reject(rateLimitError),
+      }),
+    });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    await expect(bootstrapScout(scout, token)).rejects.toThrow(
+      "API rate limit exceeded",
+    );
+  });
+
   it("propagates auth errors from open-PR fetch (does not silently degrade)", async () => {
     mockRateLimit(30);
     mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(

--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -84,6 +84,7 @@ export async function bootstrapScout(
     debug(MODULE, `Fetched ${starredRepos.length} starred repos`);
     scout.setStarredRepos(starredRepos);
   } catch (err) {
+    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
     warn(MODULE, `Failed to fetch starred repos: ${errorMessage(err)}`);
     errors.push("starred repos fetch failed");
   }

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -73,8 +73,27 @@ vi.mock("./errors.js", () => ({
   errorMessage: vi.fn((e: unknown) =>
     e instanceof Error ? e.message : String(e),
   ),
-  getHttpStatusCode: vi.fn(() => undefined),
-  isRateLimitError: vi.fn(() => false),
+  getHttpStatusCode: vi.fn((e: unknown) => {
+    if (e && typeof e === "object" && "status" in e) {
+      const s = (e as { status: unknown }).status;
+      return typeof s === "number" ? s : undefined;
+    }
+    return undefined;
+  }),
+  isRateLimitError: vi.fn((e: unknown) => {
+    if (e && typeof e === "object" && "status" in e) {
+      const s = (e as { status: unknown }).status;
+      if (s === 429) return true;
+      if (
+        s === 403 &&
+        e instanceof Error &&
+        e.message.toLowerCase().includes("rate limit")
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }),
 }));
 
 const mockFetchIssuesFromKnownRepos = vi.fn().mockResolvedValue({
@@ -488,6 +507,30 @@ describe("IssueDiscovery", () => {
 
       // Should fall back to Search API
       expect(mockCachedSearchIssues).toHaveBeenCalled();
+    });
+
+    it("Phase 3: propagates 401 from Search API fallback instead of swallowing", async () => {
+      // REST returns empty so Phase 3 falls back to Search API.
+      mockFetchIssuesFromMaintainedRepos.mockResolvedValue([]);
+
+      // The Search API call rejects with 401.
+      const authErr = Object.assign(new Error("Unauthorized"), { status: 401 });
+      mockCachedSearchIssues.mockRejectedValue(authErr);
+
+      // Phase 2 returns empty so we get to Phase 3.
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getStarredRepos: vi.fn(() => ["starred/repo"]),
+      });
+
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(
+        "Unauthorized",
+      );
     });
 
     it("Phase 3: falls back to Search API when no starred repos available", async () => {

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -408,6 +408,7 @@ async function runPhase3(
       rateLimitHit: vetRateLimitHit,
     };
   } catch (error) {
+    if (getHttpStatusCode(error) === 401) throw error;
     const errMsg = errorMessage(error);
     warn(MODULE, `Error in maintained-repo search: ${errMsg}`);
     return {

--- a/packages/core/src/core/repo-health.test.ts
+++ b/packages/core/src/core/repo-health.test.ts
@@ -110,6 +110,36 @@ describe("checkProjectHealth", () => {
     expect(health.failureReason).toBeDefined();
     expect(health.isActive).toBe(false);
   });
+
+  it("propagates 401 auth errors instead of swallowing", async () => {
+    const authErr = Object.assign(new Error("Unauthorized"), { status: 401 });
+    const octokit = {
+      repos: {
+        get: vi.fn().mockRejectedValue(authErr),
+        listCommits: vi.fn().mockRejectedValue(authErr),
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      checkProjectHealth(octokit, "auth-org", "auth-repo"),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("propagates 429 rate-limit errors instead of swallowing", async () => {
+    const rateErr = Object.assign(new Error("API rate limit exceeded"), {
+      status: 429,
+    });
+    const octokit = {
+      repos: {
+        get: vi.fn().mockRejectedValue(rateErr),
+        listCommits: vi.fn().mockRejectedValue(rateErr),
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      checkProjectHealth(octokit, "limited-org", "limited-repo"),
+    ).rejects.toThrow("rate limit");
+  });
 });
 
 // ── fetchContributionGuidelines ──

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -121,6 +121,9 @@ export async function checkProjectHealth(
       },
     );
   } catch (error) {
+    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
+      throw error;
+    }
     const errMsg = errorMessage(error);
     warn(
       MODULE,

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -23,8 +23,27 @@ vi.mock("./errors.js", () => ({
   errorMessage: vi.fn((e: unknown) =>
     e instanceof Error ? e.message : String(e),
   ),
-  isRateLimitError: vi.fn(() => false),
-  getHttpStatusCode: vi.fn(() => undefined),
+  isRateLimitError: vi.fn((e: unknown) => {
+    if (e && typeof e === "object" && "status" in e) {
+      const s = (e as { status: unknown }).status;
+      if (s === 429) return true;
+      if (
+        s === 403 &&
+        e instanceof Error &&
+        e.message.toLowerCase().includes("rate limit")
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }),
+  getHttpStatusCode: vi.fn((e: unknown) => {
+    if (e && typeof e === "object" && "status" in e) {
+      const s = (e as { status: unknown }).status;
+      return typeof s === "number" ? s : undefined;
+    }
+    return undefined;
+  }),
 }));
 
 vi.mock("./search-budget.js", () => ({
@@ -375,6 +394,32 @@ describe("searchInRepos", () => {
 
     expect(result.allBatchesFailed).toBe(true);
     expect(result.candidates).toHaveLength(0);
+  });
+
+  it("propagates 401 auth errors instead of swallowing per-batch", async () => {
+    const authErr = Object.assign(new Error("Unauthorized"), { status: 401 });
+    const octokit = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockRejectedValue(authErr),
+      },
+    } as unknown as Octokit;
+
+    const vetter = makeMockVetter([]);
+
+    // Use unique repo names so we don't hit the cache from earlier tests in
+    // the file (cachedSearchIssues keys include the query, which includes repos).
+    await expect(
+      searchInRepos(
+        octokit,
+        vetter,
+        ["auth-test/r1", "auth-test/r2", "auth-test/r3"],
+        "is:issue is:open",
+        ["unique-401-label"],
+        10,
+        "normal",
+        (items) => items,
+      ),
+    ).rejects.toThrow("Unauthorized");
   });
 
   it("returns partial results when some batches succeed", async () => {

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -534,6 +534,7 @@ export async function searchInRepos(
         if (vetRateLimitHit) rateLimitFailures++;
       }
     } catch (error) {
+      if (getHttpStatusCode(error) === 401) throw error;
       failedBatches++;
       if (isRateLimitError(error)) {
         rateLimitFailures++;


### PR DESCRIPTION
Closes #80.

## Summary

Follow-up to #74. Four \`try/catch\` sites in \`core/\` still swallowed auth/rate-limit errors, contradicting the documented strategy in \`errors.ts\`. Each gets the same \`getHttpStatusCode + isRateLimitError\` guard adopted in #74.

## What changed

| Site | Propagates |
|---|---|
| \`checkProjectHealth\` outer catch (\`repo-health.ts\`) | 401 + rate-limit |
| \`bootstrap.ts\` starred-repos catch | 401 + rate-limit |
| \`searchInRepos\` per-batch catch (\`search-phases.ts\`) | 401 only |
| \`runPhase3\` outer catch (\`issue-discovery.ts\`) | 401 only |

The asymmetry is intentional. Sites 1-2 are leaf fetchers where a rate-limited fetch is genuinely fatal to the operation. Sites 3-4 are batch-level handlers with an existing per-batch \`rateLimitHit\` signal that the orchestrator already surfaces via the \`rateLimitWarning\` string — propagating rate-limit there would bypass the documented signal.

## Tests

- 401 + 429 propagation tests for each touched site.
- Two test files' \`errors.js\` mocks were updated from "always return undefined/false" to read the \`.status\` property like the real implementation, bringing them in line with \`anti-llm-policy.test.ts\` and including the 403+rate-limit fallback branch.

## Out of scope (will file follow-up)

The pr-review-toolkit surfaced one additional gap not in #80's scope: \`gist-state-store.ts\`'s \`bootstrap()\`, \`push()\`, and \`pull()\` methods all swallow 401, masking expired-token scenarios behind generic "Gist sync unavailable" warnings. Will file a separate issue.

The other gap surfaced (\`vetIssuesParallel\`'s per-item \`.catch\` swallows 401) is already in scope of the next batch issue (#79).

## Test plan

- [x] \`pnpm test\` — 553 core, 16 mcp-server passing
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`tsc --noEmit\` — clean