### PR TITLE
fix: propagate 401/rate-limit through vetIssuesParallel and vetList (#79)

### DIFF
--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -174,13 +174,62 @@ describe("vetList", () => {
     expect(result.summary.hasPR).toBe(1);
   });
 
+  it("propagates 401 auth errors instead of swallowing per-item", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [
+      makeSavedCandidate({ issueUrl: "https://github.com/a/b/issues/1" }),
+      makeSavedCandidate({ issueUrl: "https://github.com/a/b/issues/2" }),
+    ];
+    const scout = new OssScout("fake-token", state);
+
+    const authErr = Object.assign(new Error("Bad credentials"), {
+      status: 401,
+    });
+    vi.spyOn(scout, "vetIssue").mockRejectedValue(authErr);
+
+    await expect(scout.vetList()).rejects.toThrow("Bad credentials");
+  });
+
+  it("propagates rate-limit errors instead of producing N error rows", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [
+      makeSavedCandidate({ issueUrl: "https://github.com/a/b/issues/1" }),
+      makeSavedCandidate({ issueUrl: "https://github.com/a/b/issues/2" }),
+    ];
+    const scout = new OssScout("fake-token", state);
+
+    const rateErr = Object.assign(new Error("API rate limit exceeded"), {
+      status: 429,
+    });
+    vi.spyOn(scout, "vetIssue").mockRejectedValue(rateErr);
+
+    await expect(scout.vetList()).rejects.toThrow("rate limit");
+  });
+
+  it("classifies closed issues from 410 (gone) errors", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout("fake-token", state);
+
+    const gone = Object.assign(new Error("Gone"), { status: 410 });
+    vi.spyOn(scout, "vetIssue").mockRejectedValue(gone);
+
+    const result = await scout.vetList();
+    expect(result.results[0].status).toBe("closed");
+    expect(result.summary.closed).toBe(1);
+  });
+
   it("classifies closed issues from 404 errors", async () => {
     const { OssScout } = await import("../scout.js");
     const state = ScoutStateSchema.parse({ version: 1 });
     state.savedResults = [makeSavedCandidate()];
     const scout = new OssScout("fake-token", state);
 
-    vi.spyOn(scout, "vetIssue").mockRejectedValue(new Error("Not Found"));
+    const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+    vi.spyOn(scout, "vetIssue").mockRejectedValue(notFound);
 
     const result = await scout.vetList();
 
@@ -236,7 +285,9 @@ describe("vetList", () => {
       callCount++;
       if (callCount === 1) return makeIssueCandidate(); // still_available
       if (callCount === 2) return makeIssueCandidate({ notClaimed: false }); // claimed
-      if (callCount === 3) throw new Error("Not Found"); // closed
+      if (callCount === 3) {
+        throw Object.assign(new Error("Not Found"), { status: 404 }); // closed
+      }
       return makeIssueCandidate({ noExistingPR: false }); // has_pr
     });
 

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -35,6 +35,13 @@ vi.mock("./errors.js", () => ({
   errorMessage: vi.fn((e: unknown) =>
     e instanceof Error ? e.message : String(e),
   ),
+  getHttpStatusCode: vi.fn((e: unknown) => {
+    if (e && typeof e === "object" && "status" in e) {
+      const s = (e as { status: unknown }).status;
+      return typeof s === "number" ? s : undefined;
+    }
+    return undefined;
+  }),
   isRateLimitError: vi.fn(() => false),
 }));
 
@@ -531,6 +538,28 @@ describe("IssueVetter", () => {
         10,
       );
       expect(result.rateLimitHit).toBe(true);
+    });
+
+    it("propagates 401 auth errors instead of swallowing per-item", async () => {
+      const authErr = Object.assign(new Error("Bad credentials"), {
+        status: 401,
+      });
+      const octokit = {
+        issues: { get: vi.fn().mockRejectedValue(authErr) },
+      } as unknown as Octokit;
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      await expect(
+        vetter.vetIssuesParallel(
+          [
+            "https://github.com/owner/repo/issues/1",
+            "https://github.com/owner/repo/issues/2",
+            "https://github.com/owner/repo/issues/3",
+          ],
+          10,
+        ),
+      ).rejects.toThrow("Bad credentials");
     });
   });
 });

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -16,7 +16,12 @@ import {
   type IssueCandidate,
   type ProjectCategory,
 } from "./types.js";
-import { ValidationError, errorMessage, isRateLimitError } from "./errors.js";
+import {
+  ValidationError,
+  errorMessage,
+  getHttpStatusCode,
+  isRateLimitError,
+} from "./errors.js";
 import { debug, warn } from "./logger.js";
 import {
   calculateRepoQualityBonus,
@@ -383,9 +388,15 @@ export class IssueVetter {
     let failedVettingCount = 0;
     let rateLimitFailures = 0;
     let attemptedCount = 0;
+    // Capture the first 401 so we can re-throw after in-flight tasks settle.
+    // Per-item tolerance is right for transient failures, but a 401 means
+    // the token is invalid and no other issue will succeed either —
+    // continuing to log per-issue warnings buries the actual problem.
+    let firstAuthError: unknown = null;
 
     for (const url of urls) {
       if (candidates.length >= maxResults) break;
+      if (firstAuthError) break; // stop scheduling once auth has failed
       attemptedCount++;
 
       const task = this.vetIssue(url)
@@ -399,6 +410,10 @@ export class IssueVetter {
           }
         })
         .catch((error) => {
+          if (getHttpStatusCode(error) === 401) {
+            firstAuthError ??= error;
+            return;
+          }
           failedVettingCount++;
           if (isRateLimitError(error)) {
             rateLimitFailures++;
@@ -417,6 +432,16 @@ export class IssueVetter {
 
     // Wait for remaining
     await Promise.allSettled(pending.values());
+
+    if (firstAuthError) {
+      if (candidates.length > 0) {
+        warn(
+          MODULE,
+          `Auth failed mid-batch after ${candidates.length} successful vet(s) — discarding partial results`,
+        );
+      }
+      throw firstAuthError;
+    }
 
     const allFailed =
       failedVettingCount === attemptedCount && attemptedCount > 0;

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -36,6 +36,11 @@ import type { Octokit } from "@octokit/rest";
 import { loadLocalState } from "./core/local-state.js";
 import { warn } from "./core/logger.js";
 import { extractRepoFromUrl } from "./core/utils.js";
+import {
+  errorMessage,
+  getHttpStatusCode,
+  isRateLimitError,
+} from "./core/errors.js";
 
 /** Wrap a real Octokit instance as GistOctokitLike without unsafe double casts. */
 function toGistOctokit(octokit: Octokit): GistOctokitLike {
@@ -210,8 +215,15 @@ export class OssScout implements ScoutStateReader {
     const concurrency = options?.concurrency ?? 5;
     const results: VetListEntry[] = [];
     const pending = new Map<string, Promise<void>>();
+    // First 401 OR rate-limit short-circuits the whole batch. Unlike
+    // vetIssuesParallel (which has a batch-level rateLimitHit flag the
+    // search orchestrator surfaces via rateLimitWarning), vetList is the
+    // user-facing CLI entry point — N rows of "rate limit exceeded" is the
+    // exact silent-failure mode the documented strategy aims to prevent.
+    let firstHardError: unknown = null;
 
     for (const item of saved) {
+      if (firstHardError) break;
       const task = this.vetIssue(item.issueUrl)
         .then((candidate) => {
           results.push({
@@ -225,15 +237,19 @@ export class OssScout implements ScoutStateReader {
           });
         })
         .catch((error) => {
-          const msg = error instanceof Error ? error.message : String(error);
-          const isGone = msg.includes("Not Found") || msg.includes("410");
+          if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
+            firstHardError ??= error;
+            return;
+          }
+          const status = getHttpStatusCode(error);
+          const isGone = status === 404 || status === 410;
           results.push({
             issueUrl: item.issueUrl,
             repo: item.repo,
             number: item.number,
             title: item.title,
             status: isGone ? "closed" : "error",
-            errorMessage: msg,
+            errorMessage: errorMessage(error),
           });
         })
         .finally(() => {
@@ -246,6 +262,16 @@ export class OssScout implements ScoutStateReader {
       }
     }
     await Promise.allSettled(pending.values());
+
+    if (firstHardError) {
+      if (results.length > 0) {
+        warn(
+          "scout",
+          `vetList aborted mid-batch after ${results.length} result(s) — discarding partial results due to auth/rate-limit failure`,
+        );
+      }
+      throw firstHardError;
+    }
 
     const summary = {
       total: results.length,


### PR DESCRIPTION
Closes #79.

## Summary

Final follow-up to the auth-propagation series (#74, #80). Two batch handlers re-swallowed the 401 errors that helpers now correctly propagate. A revoked token mid-run silently turned into "no candidates found" (\`vetIssuesParallel\`) or "N error rows" (\`vetList\`) instead of the documented \`AUTH_REQUIRED\` failure mode.

## Pattern

Both handlers now use a closure-captured \`firstError\` that re-throws after \`Promise.allSettled\`, with the for-loop breaking early once the error is observed to stop scheduling new work.

## Asymmetry between the two (intentional)

| Handler | Propagates 401 | Propagates rate-limit |
|---|---|---|
| \`vetIssuesParallel\` | Yes | No (kept as existing per-batch \`rateLimitHit\` flag — surfaced by orchestrator via \`rateLimitWarning\`) |
| \`vetList\` | Yes | Yes (no aggregator above it; N rate-limit error rows is exactly the silent-failure mode the strategy aims to prevent) |

## vetList also fixes substring-matching anti-pattern

\`vetList\`'s "gone" detection used \`msg.includes("Not Found") || msg.includes("410")\` — the same pattern fixed for \`fetchContributionGuidelines\` in #74. Now uses \`getHttpStatusCode === 404 || === 410\`.

## Discarded in-flight successes

When the throw fires, in-flight \`vetIssue\` calls for other URLs may complete and push to \`candidates\` / \`results\` before being discarded. Both handlers now \`warn()\` with the count first so a debugger isn't left wondering whether the auth failure was the only problem.

## Test mock note

\`issue-vetting.test.ts\`'s \`errors.js\` mock was missing \`getHttpStatusCode\`. Without it, calling the function inside the new \`.catch\` silently throws \`TypeError\` (caught by the Promise chain), making the test "pass" with wrong values. Mock now includes \`getHttpStatusCode\`, following the pattern from \`anti-llm-policy.test.ts\`.

Two pre-existing 404 tests in \`vet-list.test.ts\` used raw \`new Error("Not Found")\` (no \`.status\`) — worked only by accidental substring match. Updated to proper HTTP-shaped errors.

## Out of scope

The pr-review-toolkit confirmed one remaining gap: \`gist-state-store.ts\`'s \`bootstrap()\`, \`push()\`, \`pull()\` swallow 401, masking expired-token scenarios behind generic "Gist sync unavailable" warnings. Will file a separate follow-up issue.

## Test plan

- [x] \`pnpm test\` — 570 core, 16 mcp-server passing
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`tsc --noEmit\` — clean
- [x] New tests cover: 401 from \`vetIssuesParallel\` rejects, 401 from \`vetList\` rejects, 429 from \`vetList\` rejects, 404 + 410 in \`vetList\` classify as \`closed\`