### PR TITLE
fix: propagate 401/rate-limit in gist-state-store (#88)

### DIFF
--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -114,10 +114,11 @@ describe("GistStateStore", () => {
     it("falls back to search when cached gist ID is invalid", async () => {
       fs.writeFileSync(path.join(tempDir, "gist-id"), "stale-id\n");
       const state = makeState();
+      const notFound = Object.assign(new Error("Not Found"), { status: 404 });
       const octokit = makeOctokit({
         get: vi
           .fn()
-          .mockRejectedValueOnce(new Error("Not Found"))
+          .mockRejectedValueOnce(notFound)
           .mockResolvedValueOnce(gistResponse(state, "found-gist")),
         list: vi.fn().mockResolvedValue({
           data: [{ id: "found-gist", description: "oss-scout-state" }],
@@ -231,6 +232,75 @@ describe("GistStateStore", () => {
         expect(result.gistId).toBe("");
         expect(result.state.version).toBe(1);
       });
+
+      it("propagates 401 (does NOT fall back to cache silently)", async () => {
+        // Pre-seed a cache so we can verify it's NOT used as the fallback.
+        const sentinelCache = makeState({
+          preferences: { githubUsername: "should-not-be-used" },
+        });
+        fs.writeFileSync(
+          path.join(tempDir, "state-cache.json"),
+          JSON.stringify(sentinelCache),
+        );
+        const authErr = Object.assign(new Error("Bad credentials"), {
+          status: 401,
+        });
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(authErr),
+        });
+
+        const store = new GistStateStore(octokit);
+        await expect(store.bootstrap()).rejects.toThrow("Bad credentials");
+        // Verify cache was not consumed as a side-effect-of-throwing.
+        expect(store.getGistId()).toBeNull();
+      });
+
+      it("propagates 401 from cached-gist-ID fetch (not just the search path)", async () => {
+        // Steady-state regression: any user past their first run has a cached
+        // gist-id. A 401 on get-by-id must propagate, not silently fall through
+        // to search-and-create-a-new-empty-gist.
+        fs.writeFileSync(path.join(tempDir, "gist-id"), "stale-id\n");
+        const authErr = Object.assign(new Error("Bad credentials"), {
+          status: 401,
+        });
+        const create = vi.fn();
+        const octokit = makeOctokit({
+          get: vi.fn().mockRejectedValue(authErr),
+          list: vi.fn().mockResolvedValue({ data: [] }),
+          create,
+        });
+
+        const store = new GistStateStore(octokit);
+        await expect(store.bootstrap()).rejects.toThrow("Bad credentials");
+        // Critical: must NOT have created a new gist as a side effect of swallowing.
+        expect(create).not.toHaveBeenCalled();
+      });
+
+      it("falls back to cache on rate-limit (offline mode is desirable)", async () => {
+        // Rate-limit recovery deliberately stays as cache fallback so the
+        // user can keep working until the limit resets.
+        const cachedState = makeState({
+          preferences: { githubUsername: "cached-during-ratelimit" },
+        });
+        fs.writeFileSync(
+          path.join(tempDir, "state-cache.json"),
+          JSON.stringify(cachedState),
+        );
+        const rateErr = Object.assign(new Error("API rate limit exceeded"), {
+          status: 429,
+        });
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(rateErr),
+        });
+
+        const store = new GistStateStore(octokit);
+        const result = await store.bootstrap();
+
+        expect(result.degraded).toBe(true);
+        expect(result.state.preferences.githubUsername).toBe(
+          "cached-during-ratelimit",
+        );
+      });
     });
   });
 
@@ -282,6 +352,43 @@ describe("GistStateStore", () => {
       expect(ok).toBe(false);
       expect(fs.existsSync(path.join(tempDir, "state-cache.json"))).toBe(true);
     });
+
+    it("propagates 401 instead of returning false", async () => {
+      const authErr = Object.assign(new Error("Bad credentials"), {
+        status: 401,
+      });
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({ data: [] }),
+        create: vi.fn().mockResolvedValue({ data: { id: "gist-1" } }),
+        update: vi.fn().mockRejectedValue(authErr),
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      await expect(store.push(makeState())).rejects.toThrow("Bad credentials");
+    });
+
+    it("propagates rate-limit instead of returning false", async () => {
+      // Local cache is written before the API call, so the user's work is
+      // preserved even when push throws — they just get clear feedback that
+      // the gist sync failed (vs. a buried warn line).
+      const rateErr = Object.assign(new Error("API rate limit exceeded"), {
+        status: 429,
+      });
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({ data: [] }),
+        create: vi.fn().mockResolvedValue({ data: { id: "gist-1" } }),
+        update: vi.fn().mockRejectedValue(rateErr),
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      await expect(store.push(makeState())).rejects.toThrow("rate limit");
+      // Verify local cache write still happened (push writes cache before API call).
+      expect(fs.existsSync(path.join(tempDir, "state-cache.json"))).toBe(true);
+    });
   });
 
   describe("pull", () => {
@@ -324,6 +431,40 @@ describe("GistStateStore", () => {
       const result = await store.pull();
 
       expect(result).toBeNull();
+    });
+
+    it("propagates 401 instead of returning null", async () => {
+      const authErr = Object.assign(new Error("Bad credentials"), {
+        status: 401,
+      });
+      // Bootstrap creates a new gist (no get call needed); pull() then calls
+      // get which fails with 401.
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({ data: [] }),
+        create: vi.fn().mockResolvedValue({ data: { id: "gist-1" } }),
+        get: vi.fn().mockRejectedValue(authErr),
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      await expect(store.pull()).rejects.toThrow("Bad credentials");
+    });
+
+    it("propagates rate-limit instead of returning null", async () => {
+      const rateErr = Object.assign(new Error("API rate limit exceeded"), {
+        status: 429,
+      });
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({ data: [] }),
+        create: vi.fn().mockResolvedValue({ data: { id: "gist-1" } }),
+        get: vi.fn().mockRejectedValue(rateErr),
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      await expect(store.pull()).rejects.toThrow("rate limit");
     });
   });
 

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -16,7 +16,7 @@ import type {
 } from "./schemas.js";
 import { getDataDir } from "./utils.js";
 import { debug, warn } from "./logger.js";
-import { errorMessage } from "./errors.js";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 
 const MODULE = "gist-state";
 
@@ -80,6 +80,10 @@ export class GistStateStore {
     try {
       return await this.bootstrapFromApi();
     } catch (err) {
+      // 401 means the token is invalid — fail loudly so the user re-auths.
+      // Rate-limit / network / 5xx fall back to local cache so the user can
+      // keep working offline until the issue resolves.
+      if (getHttpStatusCode(err) === 401) throw err;
       warn(MODULE, `API bootstrap failed: ${errorMessage(err)}`);
       return this.bootstrapFromCache();
     }
@@ -115,6 +119,10 @@ export class GistStateStore {
       debug(MODULE, "State pushed to gist");
       return true;
     } catch (err) {
+      // Both auth and rate-limit propagate per documented strategy.
+      // Local cache write already happened above, so the user's work isn't
+      // lost — but they need clear feedback that the sync failed.
+      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
       warn(MODULE, `Failed to push: ${errorMessage(err)}`);
       return false;
     }
@@ -133,6 +141,7 @@ export class GistStateStore {
       }
       return state;
     } catch (err) {
+      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
       warn(MODULE, `Failed to pull: ${errorMessage(err)}`);
       return null;
     }
@@ -158,7 +167,13 @@ export class GistStateStore {
           return { gistId: cachedId, state, created: false };
         }
       } catch (err) {
-        debug(MODULE, `Cached gist ID invalid: ${errorMessage(err)}`);
+        // Only "the cached gist was deleted server-side" (404) justifies
+        // falling through to search. Auth/rate-limit/network must propagate
+        // so the outer bootstrap() catch can apply the documented strategy
+        // — otherwise a 401 here silently creates a brand-new empty gist
+        // for users with stale cached IDs.
+        if (getHttpStatusCode(err) !== 404) throw err;
+        debug(MODULE, `Cached gist gone (404): ${errorMessage(err)}`);
       }
       debug(MODULE, "Cached gist ID invalid, searching...");
     }


### PR DESCRIPTION
Closes #88. Final follow-up in the auth-propagation series (#74, #80, #79).

## Summary

Three methods in \`gist-state-store.ts\` swallowed 401 (and other) errors, masking expired-token scenarios behind generic "Gist sync unavailable" warnings. Both pr-review-toolkit reviewers flagged this in #80 and #79; deferred to keep those PRs scoped.

## What changed

| Method | Propagates 401 | Propagates rate-limit |
|---|---|---|
| \`bootstrap()\` | Yes | No (cache fallback for offline mode is desirable) |
| \`push()\` | Yes | Yes |
| \`pull()\` | Yes | Yes |

The asymmetry is intentional. \`bootstrap()\` runs once at startup; falling back to local cache during a rate-limit lets the user keep working until the limit resets. \`push()\` and \`pull()\` are per-operation; the local cache write in \`push()\` happens BEFORE the API call, so propagating doesn't lose user work — it just surfaces the sync failure clearly instead of burying it in a warn line.

## Bonus fix surfaced by review

The cached-gist-ID inner catch in \`bootstrapFromApi\` was swallowing ALL errors via debug-log-and-continue, including 401. A user with a stale cached gist ID and a now-invalid token would silently get a brand-new empty gist created (the inner catch ate the 401 before the outer guard could see it). The inner catch now only swallows 404 (the legitimate "stale cached ID" case); auth/rate-limit/network propagate to the outer guard.

## Tests

- Bootstrap: 401 propagates and cache is NOT consumed (asserts \`getGistId() === null\` after throw); 401 from cached-id fetch propagates and no new gist is created; rate-limit still falls back to cache.
- Push: 401 propagates; rate-limit propagates with local cache preserved.
- Pull: 401 propagates; rate-limit propagates.
- Pre-existing "falls back to search when cached gist ID is invalid" test used \`new Error("Not Found")\` with no \`.status\` (worked only by accidental substring match). Updated to a proper \`httpError\` shape.

## Out of scope (could be a small follow-up)

The "Gist sync unavailable — running in offline mode" warning in \`scout.ts\` doesn't distinguish cause (network vs. 5xx vs. rate-limit). Pre-existing UX gap; the user could pass the underlying error through \`bootstrapFromCache\` to surface a cause-specific message.

## Test plan

- [x] \`pnpm test\` — 577 core, 16 mcp-server passing
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`tsc --noEmit\` — clean