### PR TITLE
feat: distinguish cause in degraded-mode bootstrap warning (#90)

### DIFF
--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -297,9 +297,88 @@ describe("GistStateStore", () => {
         const result = await store.bootstrap();
 
         expect(result.degraded).toBe(true);
+        expect(result.degradedReason).toBe("rate_limit");
         expect(result.state.preferences.githubUsername).toBe(
           "cached-during-ratelimit",
         );
+      });
+
+      it("classifies a 5xx server error as 'server'", async () => {
+        const serverErr = Object.assign(new Error("Bad gateway"), {
+          status: 502,
+        });
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(serverErr),
+        });
+        const store = new GistStateStore(octokit);
+        const result = await store.bootstrap();
+        expect(result.degraded).toBe(true);
+        expect(result.degradedReason).toBe("server");
+      });
+
+      it("classifies a 403+rate-limit-message as 'rate_limit'", async () => {
+        const abuseErr = Object.assign(
+          new Error("You have exceeded a secondary rate limit"),
+          { status: 403 },
+        );
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(abuseErr),
+        });
+        const store = new GistStateStore(octokit);
+        const result = await store.bootstrap();
+        expect(result.degradedReason).toBe("rate_limit");
+      });
+
+      it("classifies a 403+abuse-detection-message as 'rate_limit'", async () => {
+        // GitHub's older abuse-detection 403s use this phrasing without the
+        // "rate limit" substring — resolveErrorCode in errors.ts handles both;
+        // the classifier must too.
+        const abuseErr = Object.assign(
+          new Error("You have triggered an abuse detection mechanism"),
+          { status: 403 },
+        );
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(abuseErr),
+        });
+        const store = new GistStateStore(octokit);
+        const result = await store.bootstrap();
+        expect(result.degradedReason).toBe("rate_limit");
+      });
+
+      it("classifies a network error (ENOTFOUND) as 'network'", async () => {
+        const netErr = Object.assign(
+          new Error("getaddrinfo ENOTFOUND api.github.com"),
+          {
+            code: "ENOTFOUND",
+          },
+        );
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(netErr),
+        });
+        const store = new GistStateStore(octokit);
+        const result = await store.bootstrap();
+        expect(result.degradedReason).toBe("network");
+      });
+
+      it("classifies a Node fetch failure as 'network'", async () => {
+        // Node 18+ undici-backed fetch errors arrive as `Error: fetch failed`
+        // with no .status and no .code (cause is on err.cause).
+        const fetchErr = new Error("fetch failed");
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(fetchErr),
+        });
+        const store = new GistStateStore(octokit);
+        const result = await store.bootstrap();
+        expect(result.degradedReason).toBe("network");
+      });
+
+      it("classifies an unrecognized error as 'unknown'", async () => {
+        const octokit = makeOctokit({
+          list: vi.fn().mockRejectedValue(new Error("Something weird")),
+        });
+        const store = new GistStateStore(octokit);
+        const result = await store.bootstrap();
+        expect(result.degradedReason).toBe("unknown");
       });
     });
   });

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -52,11 +52,51 @@ export interface GistOctokitLike {
   };
 }
 
+/** Why bootstrap fell back to local-cache mode, when known. */
+export type DegradedReason = "rate_limit" | "network" | "server" | "unknown";
+
 export interface BootstrapResult {
   gistId: string;
   state: ScoutState;
   created: boolean;
   degraded?: boolean;
+  degradedReason?: DegradedReason;
+}
+
+/** Classify an unknown error into a DegradedReason for user-facing messaging. */
+function classifyDegradedReason(err: unknown): DegradedReason {
+  if (isRateLimitError(err)) return "rate_limit";
+  const status = getHttpStatusCode(err);
+  // GitHub's abuse-detection responses arrive as 403 with "abuse detection"
+  // in the message but no "rate limit" substring — match resolveErrorCode's
+  // logic in errors.ts so we don't misclassify as 'unknown'.
+  if (
+    status === 403 &&
+    errorMessage(err).toLowerCase().includes("abuse detection")
+  ) {
+    return "rate_limit";
+  }
+  if (status !== undefined && status >= 500 && status < 600) return "server";
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code: unknown }).code;
+    if (
+      code === "ECONNREFUSED" ||
+      code === "ENOTFOUND" ||
+      code === "ETIMEDOUT" ||
+      code === "ECONNRESET" ||
+      code === "EAI_AGAIN"
+    ) {
+      return "network";
+    }
+  }
+  // Node 18+ fetch errors arrive as `Error: fetch failed` with the cause set.
+  if (
+    err instanceof Error &&
+    err.message.toLowerCase().includes("fetch failed")
+  ) {
+    return "network";
+  }
+  return "unknown";
 }
 
 function getGistIdPath(): string {
@@ -85,7 +125,7 @@ export class GistStateStore {
       // keep working offline until the issue resolves.
       if (getHttpStatusCode(err) === 401) throw err;
       warn(MODULE, `API bootstrap failed: ${errorMessage(err)}`);
-      return this.bootstrapFromCache();
+      return this.bootstrapFromCache(classifyDegradedReason(err));
     }
   }
 
@@ -195,7 +235,7 @@ export class GistStateStore {
         MODULE,
         `Found existing gist ${foundId} but content failed validation. Using local cache to avoid data loss.`,
       );
-      return this.bootstrapFromCache();
+      return this.bootstrapFromCache("unknown");
     }
 
     // 3. Create new gist
@@ -208,7 +248,7 @@ export class GistStateStore {
     return { gistId: newId, state: freshState, created: true };
   }
 
-  private bootstrapFromCache(): BootstrapResult {
+  private bootstrapFromCache(reason: DegradedReason): BootstrapResult {
     const cached = this.readCache();
     if (cached) {
       debug(MODULE, "Bootstrapped from local cache (degraded mode)");
@@ -219,12 +259,19 @@ export class GistStateStore {
         state: cached,
         created: false,
         degraded: true,
+        degradedReason: reason,
       };
     }
 
     debug(MODULE, "No cache available, using fresh state (degraded mode)");
     const fresh = ScoutStateSchema.parse({ version: 1 });
-    return { gistId: "", state: fresh, created: false, degraded: true };
+    return {
+      gistId: "",
+      state: fresh,
+      created: false,
+      degraded: true,
+      degradedReason: reason,
+    };
   }
 
   // ── Gist API operations ──────────────────────────────────────────────

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -30,7 +30,10 @@ import type {
   VetListEntry,
 } from "./core/types.js";
 import { GistStateStore, mergeStates } from "./core/gist-state-store.js";
-import type { GistOctokitLike } from "./core/gist-state-store.js";
+import type {
+  DegradedReason,
+  GistOctokitLike,
+} from "./core/gist-state-store.js";
 import { getOctokit } from "./core/github.js";
 import type { Octokit } from "@octokit/rest";
 import { loadLocalState } from "./core/local-state.js";
@@ -41,6 +44,22 @@ import {
   getHttpStatusCode,
   isRateLimitError,
 } from "./core/errors.js";
+
+/** Cause-specific user-facing message for degraded (offline) mode. */
+function offlineModeMessage(reason: DegradedReason | undefined): string {
+  const tail = "Changes will only be saved locally.";
+  switch (reason) {
+    case "rate_limit":
+      return `Gist sync unavailable — GitHub API rate limit exceeded. ${tail} Try again after the rate limit resets.`;
+    case "network":
+      return `Gist sync unavailable — could not reach GitHub. ${tail} Check your network connection.`;
+    case "server":
+      return `Gist sync unavailable — GitHub returned a server error. ${tail} Try again later.`;
+    case "unknown":
+    case undefined:
+      return `Gist sync unavailable — running in offline mode. ${tail}`;
+  }
+}
 
 /** Wrap a real Octokit instance as GistOctokitLike without unsafe double casts. */
 function toGistOctokit(octokit: Octokit): GistOctokitLike {
@@ -118,10 +137,7 @@ export async function createScout(config: ScoutConfig): Promise<OssScout> {
     );
     const result = await gistStore.bootstrap();
     if (result.degraded) {
-      warn(
-        "scout",
-        "Gist sync unavailable — running in offline mode. Changes will only be saved locally.",
-      );
+      warn("scout", offlineModeMessage(result.degradedReason));
     }
     const localState = loadLocalState();
     state = mergeStates(localState, result.state);


### PR DESCRIPTION
Closes #90.

## Summary

After the auth-propagation series (#74, #80, #79, #88), the only remaining causes of degraded-mode bootstrap are network failure, 5xx, rate-limit, or 404-on-cached-id. Each demands a different user response, but \`createScout\` was emitting one generic warning for all four:

> Gist sync unavailable — running in offline mode. Changes will only be saved locally.

## What changed

| Cause | New message |
|---|---|
| rate_limit | "GitHub API rate limit exceeded ... Try again after the rate limit resets." |
| network | "could not reach GitHub ... Check your network connection." |
| server | "GitHub returned a server error ... Try again later." |
| unknown | (original generic message) |

- New \`DegradedReason\` type union on \`BootstrapResult\` (optional; \`undefined\` when not degraded).
- Private \`classifyDegradedReason(err)\` helper in \`gist-state-store.ts\` maps caught errors via \`isRateLimitError\`, \`getHttpStatusCode\` (5xx), error codes (\`ECONNREFUSED\`, \`ENOTFOUND\`, \`ETIMEDOUT\`, \`ECONNRESET\`, \`EAI_AGAIN\`), and the Node 18+ \`fetch failed\` message shape.
- Special-cases 403 with "abuse detection" message — GitHub's older abuse-detection phrasing doesn't include the "rate limit" substring that \`isRateLimitError\` checks. \`resolveErrorCode\` in \`errors.ts\` already handles both phrasings; the classifier now matches that contract.
- Private \`offlineModeMessage(reason)\` helper in \`scout.ts\` is a 4-case switch over the discriminator.

## Tests

Per-discriminator coverage in \`gist-state-store.test.ts\` (server, rate_limit secondary, rate_limit abuse-detection, network ENOTFOUND, network fetch-failed, unknown). \`offlineModeMessage\` is a trivial typed switch — discriminator coverage is sufficient; adding string-match tests would just mirror production code.

## Test plan

- [x] \`pnpm test\` — 583 core, 16 mcp-server passing
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`tsc --noEmit\` — clean