### PR TITLE
feat: add scout features subcommand (#92)

### DIFF
--- a/docs/superpowers/plans/2026-05-08-scout-features.md
+++ b/docs/superpowers/plans/2026-05-08-scout-features.md
@@ -1,0 +1,1669 @@
+# `scout features` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `scout features` subcommand that surfaces feature-scoped contribution opportunities in repos where the user has 3+ merged PRs, ranked into separate "quick wins" and "bigger bets" buckets.
+
+**Architecture:** New CLI command + new core orchestrator (`feature-discovery.ts`) sharing the existing scoring, vetting, cache, and rate-limit infrastructure. Feature-mode signals (reactions, comments, milestone) plumb through `calculateViabilityScore` as an optional `featureSignals` parameter and through `IssueVetter.vetIssue` as an optional option. No `if (mode === ...)` checks anywhere — mode is expressed as data.
+
+**Tech Stack:** TypeScript (strict mode, ESM, NodeNext), Vitest, Commander, Octokit, Zod, MCP SDK.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-scout-features-design.md`
+
+---
+
+## File map
+
+**Create:**
+- `packages/core/src/core/feature-discovery.ts` — orchestrator + pure helpers (anchor resolver, horizon classifier, bucket splitter)
+- `packages/core/src/core/feature-discovery.test.ts`
+- `packages/core/src/commands/features.ts` — CLI command runner
+- `packages/core/src/commands/features.test.ts`
+
+**Modify:**
+- `packages/core/src/core/schemas.ts` — add `HorizonSchema`, optional `horizon` on `SavedCandidate`
+- `packages/core/src/core/issue-scoring.ts` — extend `calculateViabilityScore` with optional `featureSignals` param
+- `packages/core/src/core/issue-scoring.test.ts` — add cases for feature signals
+- `packages/core/src/core/issue-vetting.ts` — thread optional `featureSignals` through `vetIssue`
+- `packages/core/src/scout.ts` — add `OssScout.features()` API
+- `packages/core/src/cli.ts` — register `features` subcommand
+- `packages/core/src/index.ts` — export `Horizon`, `FeatureSearchResult`, `FeatureSignals`
+- `packages/mcp-server/src/tools.ts` — register `scout-features` tool
+- `packages/mcp-server/src/tools.test.ts` — add tool registration test
+
+---
+
+## Branch & convention
+
+Branch already exists: `feat/92-scout-features-design`. Use it for the implementation as well, or cut a new `feat/92-scout-features-impl` from main if you prefer to keep the spec PR separate. The plan below assumes the same branch (single PR for spec + impl); adjust if splitting.
+
+---
+
+### Task 1: Add `HorizonSchema` and optional `horizon` field on `SavedCandidate`
+
+**Files:**
+- Modify: `packages/core/src/core/schemas.ts`
+
+Existing `SavedCandidateSchema` is at the lines defining `savedResults` storage shape. We need to add a new enum and extend the candidate schema. The change must be backwards-compatible (existing saved results in user gists must still validate).
+
+- [ ] **Step 1: Read current schema location**
+
+Run: `grep -n "SavedCandidateSchema" packages/core/src/core/schemas.ts`
+Note the line range; plan to insert `HorizonSchema` immediately above it.
+
+- [ ] **Step 2: Add `HorizonSchema` and field**
+
+Edit `packages/core/src/core/schemas.ts`. Add immediately above `export const SavedCandidateSchema`:
+
+```ts
+export const HorizonSchema = z.enum(["quick-win", "bigger-bet"]);
+```
+
+Inside `SavedCandidateSchema = z.object({ ... })`, add `horizon: HorizonSchema.optional(),` as a new field (alongside the existing fields like `viabilityScore`, `searchPriority`).
+
+At the bottom of the file with the other type exports, add:
+
+```ts
+export type Horizon = z.infer<typeof HorizonSchema>;
+```
+
+- [ ] **Step 3: Run schema tests**
+
+Run: `pnpm --filter @oss-scout/core test schemas`
+Expected: PASS. Existing tests cover `SavedCandidateSchema.parse({...})` without `horizon`; the optional field must not break them.
+
+- [ ] **Step 4: Add test for new field**
+
+`packages/core/src/core/schemas.test.ts` already exists. Append the two `describe` blocks below to it:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { SavedCandidateSchema, HorizonSchema } from "./schemas.js";
+
+describe("HorizonSchema", () => {
+  it("accepts quick-win and bigger-bet", () => {
+    expect(HorizonSchema.parse("quick-win")).toBe("quick-win");
+    expect(HorizonSchema.parse("bigger-bet")).toBe("bigger-bet");
+  });
+  it("rejects unknown values", () => {
+    expect(() => HorizonSchema.parse("medium")).toThrow();
+  });
+});
+
+describe("SavedCandidateSchema horizon field", () => {
+  const base = {
+    issueUrl: "https://github.com/foo/bar/issues/1",
+    repo: "foo/bar",
+    number: 1,
+    title: "t",
+    labels: [],
+    recommendation: "approve" as const,
+    viabilityScore: 80,
+    searchPriority: "merged_pr" as const,
+    firstSeenAt: "2026-05-08T00:00:00Z",
+    lastSeenAt: "2026-05-08T00:00:00Z",
+    lastScore: 80,
+  };
+  it("validates without horizon (backwards compat)", () => {
+    expect(() => SavedCandidateSchema.parse(base)).not.toThrow();
+  });
+  it("validates with horizon set", () => {
+    expect(() =>
+      SavedCandidateSchema.parse({ ...base, horizon: "quick-win" }),
+    ).not.toThrow();
+  });
+});
+```
+
+If `schemas.test.ts` already exists, append the two `describe` blocks to it.
+
+- [ ] **Step 5: Run new tests**
+
+Run: `pnpm --filter @oss-scout/core test schemas`
+Expected: PASS, new tests included.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/core/schemas.ts packages/core/src/core/schemas.test.ts
+git commit -m "feat(core): add Horizon schema + optional horizon field on SavedCandidate (#92)"
+```
+
+---
+
+### Task 2: Extend `calculateViabilityScore` with optional `featureSignals`
+
+**Files:**
+- Modify: `packages/core/src/core/issue-scoring.ts`
+- Modify: `packages/core/src/core/issue-scoring.test.ts`
+
+The scoring function gains an optional input. When absent, behavior is identical to today. When present, applies +reactions/2 (capped at 10), +5 if comments >= 5, +5 if hasMilestone.
+
+- [ ] **Step 1: Write failing tests for feature signals**
+
+Append to `packages/core/src/core/issue-scoring.test.ts`:
+
+```ts
+describe("calculateViabilityScore feature signals", () => {
+  const baseFeature: ViabilityScoreParams = {
+    repoScore: null,
+    hasExistingPR: false,
+    isClaimed: false,
+    clearRequirements: false,
+    hasContributionGuidelines: false,
+    issueUpdatedAt: new Date().toISOString(),
+    closedWithoutMergeCount: 0,
+    mergedPRCount: 0,
+    orgHasMergedPRs: false,
+  };
+  it("adds nothing when featureSignals is absent", () => {
+    const score = calculateViabilityScore(baseFeature);
+    // base 50 + freshness 15 = 65
+    expect(score).toBe(65);
+  });
+  it("adds reactions/2 capped at 10", () => {
+    const score = calculateViabilityScore({
+      ...baseFeature,
+      featureSignals: { reactions: 4, comments: 0, hasMilestone: false },
+    });
+    expect(score).toBe(65 + 2); // 4/2 = 2
+  });
+  it("caps reactions bonus at 10", () => {
+    const score = calculateViabilityScore({
+      ...baseFeature,
+      featureSignals: { reactions: 100, comments: 0, hasMilestone: false },
+    });
+    expect(score).toBe(65 + 10);
+  });
+  it("adds +5 when comments >= 5", () => {
+    const score = calculateViabilityScore({
+      ...baseFeature,
+      featureSignals: { reactions: 0, comments: 5, hasMilestone: false },
+    });
+    expect(score).toBe(65 + 5);
+  });
+  it("adds nothing when comments < 5", () => {
+    const score = calculateViabilityScore({
+      ...baseFeature,
+      featureSignals: { reactions: 0, comments: 4, hasMilestone: false },
+    });
+    expect(score).toBe(65);
+  });
+  it("adds +5 when hasMilestone is true", () => {
+    const score = calculateViabilityScore({
+      ...baseFeature,
+      featureSignals: { reactions: 0, comments: 0, hasMilestone: true },
+    });
+    expect(score).toBe(65 + 5);
+  });
+  it("combines all feature bonuses", () => {
+    const score = calculateViabilityScore({
+      ...baseFeature,
+      featureSignals: { reactions: 20, comments: 10, hasMilestone: true },
+    });
+    expect(score).toBe(65 + 10 + 5 + 5);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `pnpm --filter @oss-scout/core test issue-scoring`
+Expected: FAIL with `Property 'featureSignals' does not exist on type 'ViabilityScoreParams'` or runtime errors.
+
+- [ ] **Step 3: Implement feature signals in scoring**
+
+Edit `packages/core/src/core/issue-scoring.ts`. Add to `ViabilityScoreParams` interface (after `matchesPreferredCategory?:`):
+
+```ts
+  /**
+   * Optional feature-mode signals. When present, applies reaction (cap +10),
+   * comment-depth (+5 if >=5), and milestone (+5) bonuses. When absent,
+   * scoring behavior is unchanged.
+   */
+  featureSignals?: {
+    reactions: number;
+    comments: number;
+    hasMilestone: boolean;
+  };
+```
+
+Inside `calculateViabilityScore`, immediately before the final clamp (`return Math.max(0, Math.min(100, score));`), add:
+
+```ts
+  if (params.featureSignals) {
+    const fs = params.featureSignals;
+    score += Math.min(Math.floor(fs.reactions / 2), 10);
+    if (fs.comments >= 5) score += 5;
+    if (fs.hasMilestone) score += 5;
+  }
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pnpm --filter @oss-scout/core test issue-scoring`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/issue-scoring.ts packages/core/src/core/issue-scoring.test.ts
+git commit -m "feat(core): add featureSignals to calculateViabilityScore (#92)"
+```
+
+---
+
+### Task 3: Thread `featureSignals` through `IssueVetter.vetIssue`
+
+**Files:**
+- Modify: `packages/core/src/core/issue-vetting.ts`
+- Modify: `packages/core/src/core/issue-vetting.test.ts`
+
+`vetIssue(url)` becomes `vetIssue(url, opts?: { featureSignals?: FeatureSignals })`. The signals plumb directly into the `calculateViabilityScore` call inside vetter. The vetter does NOT extract signals from the fetched issue — the caller (feature-discovery) extracts them from the search-result item and passes them in. This keeps the vetter mode-agnostic.
+
+- [ ] **Step 1: Read current `vetIssue` signature and scoring call**
+
+Run: `grep -n "calculateViabilityScore\|async vetIssue" packages/core/src/core/issue-vetting.ts`
+Note line numbers for the signature and the scoring call site.
+
+- [ ] **Step 2: Write failing test**
+
+Append to `packages/core/src/core/issue-vetting.test.ts`:
+
+```ts
+describe("IssueVetter feature signals", () => {
+  it("plumbs featureSignals through to scoring", async () => {
+    // Build a vetter mock that returns a fixed candidate URL with no PR/no claim,
+    // so the only score difference comes from featureSignals.
+    const baselineUrl = "https://github.com/foo/bar/issues/100";
+    const { vetter, scoreOf } = buildVetterUnderTest(); // helper defined in this file
+    const baseline = await vetter.vetIssue(baselineUrl);
+    const boosted = await vetter.vetIssue(baselineUrl, {
+      featureSignals: { reactions: 20, comments: 10, hasMilestone: true },
+    });
+    // 10 (reactions cap) + 5 (comments) + 5 (milestone) = 20
+    expect(scoreOf(boosted)).toBe(scoreOf(baseline) + 20);
+  });
+});
+```
+
+If `buildVetterUnderTest` does not exist in the test file, write one matching the existing test patterns in this file. Otherwise reuse it. To match the project's test style, look at the existing top of the file:
+
+Run: `head -60 packages/core/src/core/issue-vetting.test.ts`
+
+Inline-copy the existing setup pattern (likely `vi.mock("./issue-eligibility")`, `vi.mock("./repo-health")`, etc.) and produce a vetter you can call twice on the same URL. Cache in vetter is 15 minutes — to avoid the cache returning the first result on the second call, clear it between calls. Use:
+
+```ts
+import { getHttpCache } from "./http-cache.js";
+beforeEach(() => getHttpCache().clear());
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/core test issue-vetting`
+Expected: FAIL — vetIssue does not accept the second argument or signals do not affect score.
+
+- [ ] **Step 4: Implement plumbing**
+
+Edit `packages/core/src/core/issue-vetting.ts`. Add a type export at the top (near other type imports):
+
+```ts
+export type FeatureSignals = {
+  reactions: number;
+  comments: number;
+  hasMilestone: boolean;
+};
+```
+
+Change `vetIssue` signature from `async vetIssue(issueUrl: string): Promise<IssueCandidate>` to:
+
+```ts
+async vetIssue(
+  issueUrl: string,
+  opts?: { featureSignals?: FeatureSignals },
+): Promise<IssueCandidate>
+```
+
+In the body, find the call to `calculateViabilityScore({...})` and add `featureSignals: opts?.featureSignals,` to the params object (alongside the existing fields like `repoScore`, `hasExistingPR`, etc.).
+
+The vetting cache key currently is `vet:${issueUrl}`. Because feature signals affect the score, change it to include them:
+
+```ts
+const sigKey = opts?.featureSignals
+  ? `:r${opts.featureSignals.reactions}c${opts.featureSignals.comments}m${opts.featureSignals.hasMilestone ? 1 : 0}`
+  : "";
+const cacheKey = `vet:${issueUrl}${sigKey}`;
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `pnpm --filter @oss-scout/core test issue-vetting`
+Expected: PASS, including the new test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/core/issue-vetting.ts packages/core/src/core/issue-vetting.test.ts
+git commit -m "feat(core): thread featureSignals through IssueVetter.vetIssue (#92)"
+```
+
+---
+
+### Task 4: Pure helper — `resolveAnchorRepos`
+
+**Files:**
+- Create: `packages/core/src/core/feature-discovery.ts`
+- Create: `packages/core/src/core/feature-discovery.test.ts`
+
+Pure function that filters `RepoScore[]` by `mergedPRCount >= threshold` and returns the repo full-names sorted by mergedPRCount desc.
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/core/src/core/feature-discovery.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import type { RepoScore } from "./schemas.js";
+import { resolveAnchorRepos, ANCHOR_THRESHOLD } from "./feature-discovery.js";
+
+const mkScore = (repo: string, mergedPRCount: number): RepoScore => ({
+  repo,
+  score: 5,
+  mergedPRCount,
+  closedWithoutMergeCount: 0,
+  avgResponseDays: null,
+  lastEvaluatedAt: "2026-05-08T00:00:00Z",
+  signals: {
+    hasActiveMaintainers: true,
+    isResponsive: true,
+    hasHostileComments: false,
+  },
+});
+
+const mkScores = (...entries: Array<[string, number]>): Record<string, RepoScore> =>
+  Object.fromEntries(entries.map(([repo, count]) => [repo, mkScore(repo, count)]));
+
+describe("resolveAnchorRepos", () => {
+  it("returns empty array when no scores meet threshold", () => {
+    const out = resolveAnchorRepos(mkScores(["a/b", 1], ["c/d", 2]));
+    expect(out).toEqual([]);
+  });
+  it("filters by ANCHOR_THRESHOLD (3)", () => {
+    expect(ANCHOR_THRESHOLD).toBe(3);
+    const out = resolveAnchorRepos(
+      mkScores(["a/b", 2], ["c/d", 3], ["e/f", 5]),
+    );
+    expect(out).toEqual(["e/f", "c/d"]);
+  });
+  it("sorts by mergedPRCount desc", () => {
+    const out = resolveAnchorRepos(
+      mkScores(["a/b", 4], ["c/d", 10], ["e/f", 7]),
+    );
+    expect(out).toEqual(["c/d", "e/f", "a/b"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: FAIL with module not found.
+
+- [ ] **Step 3: Create `feature-discovery.ts` with pure helper**
+
+Create `packages/core/src/core/feature-discovery.ts`:
+
+```ts
+/**
+ * Feature Discovery — orchestrates `scout features` mode: surfaces
+ * feature-scoped contribution opportunities in repos where the user has
+ * 3+ merged PRs, ranked into separate "quick wins" and "bigger bets" buckets.
+ *
+ * Reuses existing infrastructure:
+ * - issue-vetting.ts    — per-issue vetting + scoring (with featureSignals)
+ * - issue-scoring.ts    — viability score (existing weights + feature bonuses)
+ * - http-cache.ts       — response cache
+ * - errors.ts           — auth/rate-limit propagation
+ *
+ * No state singletons — anchor repos are resolved from RepoScore[] passed in.
+ */
+
+import type { RepoScore } from "./schemas.js";
+
+/** Minimum merged-PR count for a repo to qualify as an anchor. */
+export const ANCHOR_THRESHOLD = 3;
+
+/**
+ * Resolve anchor repos: those with mergedPRCount >= ANCHOR_THRESHOLD,
+ * sorted by mergedPRCount descending. ScoutState stores repoScores as a
+ * Record<string, RepoScore>, so we read its values.
+ */
+export function resolveAnchorRepos(
+  repoScores: Record<string, RepoScore>,
+): string[] {
+  return Object.values(repoScores)
+    .filter((rs) => rs.mergedPRCount >= ANCHOR_THRESHOLD)
+    .sort((a, b) => b.mergedPRCount - a.mergedPRCount)
+    .map((rs) => rs.repo);
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/feature-discovery.ts packages/core/src/core/feature-discovery.test.ts
+git commit -m "feat(core): add resolveAnchorRepos pure helper (#92)"
+```
+
+---
+
+### Task 5: Pure helper — `classifyHorizon`
+
+**Files:**
+- Modify: `packages/core/src/core/feature-discovery.ts`
+- Modify: `packages/core/src/core/feature-discovery.test.ts`
+
+Pure function: bigger-bet if `hasMilestone` OR labels contain any of `roadmap`, `accepted-rfc`, `proposal`. Otherwise quick-win.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `packages/core/src/core/feature-discovery.test.ts`:
+
+```ts
+import { classifyHorizon } from "./feature-discovery.js";
+
+describe("classifyHorizon", () => {
+  it("returns bigger-bet when issue has a milestone", () => {
+    expect(classifyHorizon({ hasMilestone: true, labels: [] })).toBe(
+      "bigger-bet",
+    );
+  });
+  it("returns bigger-bet for roadmap label", () => {
+    expect(
+      classifyHorizon({ hasMilestone: false, labels: ["roadmap"] }),
+    ).toBe("bigger-bet");
+  });
+  it("returns bigger-bet for accepted-rfc label", () => {
+    expect(
+      classifyHorizon({ hasMilestone: false, labels: ["accepted-rfc"] }),
+    ).toBe("bigger-bet");
+  });
+  it("returns bigger-bet for proposal label", () => {
+    expect(
+      classifyHorizon({ hasMilestone: false, labels: ["proposal"] }),
+    ).toBe("bigger-bet");
+  });
+  it("returns quick-win for plain enhancement label", () => {
+    expect(
+      classifyHorizon({ hasMilestone: false, labels: ["enhancement"] }),
+    ).toBe("quick-win");
+  });
+  it("returns quick-win when no signals fire", () => {
+    expect(classifyHorizon({ hasMilestone: false, labels: [] })).toBe(
+      "quick-win",
+    );
+  });
+  it("is case-insensitive on label matching", () => {
+    expect(
+      classifyHorizon({ hasMilestone: false, labels: ["Roadmap"] }),
+    ).toBe("bigger-bet");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: FAIL — `classifyHorizon` not exported.
+
+- [ ] **Step 3: Implement `classifyHorizon`**
+
+Append to `packages/core/src/core/feature-discovery.ts`:
+
+```ts
+import type { Horizon } from "./schemas.js";
+
+/** Labels that promote an issue to the "bigger-bet" bucket. */
+export const BIGGER_BET_LABELS = new Set(["roadmap", "accepted-rfc", "proposal"]);
+
+/**
+ * Classify an issue into "quick-win" or "bigger-bet" based on
+ * maintainer-commitment signals (milestone presence + label set).
+ */
+export function classifyHorizon(input: {
+  hasMilestone: boolean;
+  labels: string[];
+}): Horizon {
+  if (input.hasMilestone) return "bigger-bet";
+  for (const label of input.labels) {
+    if (BIGGER_BET_LABELS.has(label.toLowerCase())) return "bigger-bet";
+  }
+  return "quick-win";
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/feature-discovery.ts packages/core/src/core/feature-discovery.test.ts
+git commit -m "feat(core): add classifyHorizon pure helper (#92)"
+```
+
+---
+
+### Task 6: Pure helper — `splitByHorizon` (60/40 with underfill rule)
+
+**Files:**
+- Modify: `packages/core/src/core/feature-discovery.ts`
+- Modify: `packages/core/src/core/feature-discovery.test.ts`
+
+Takes scored candidates already classified into horizons, target `count`, and produces `{ quickWins, biggerBets }` honoring the 60/40 split with deficit-redirect.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `packages/core/src/core/feature-discovery.test.ts`:
+
+```ts
+import { splitByHorizon } from "./feature-discovery.js";
+import type { IssueCandidate } from "./types.js";
+
+const mkCand = (
+  url: string,
+  score: number,
+  horizon: "quick-win" | "bigger-bet",
+): IssueCandidate & { horizon: "quick-win" | "bigger-bet" } =>
+  ({
+    issue: {
+      url,
+      repo: "x/y",
+      number: 1,
+      title: url,
+      labels: [],
+      updatedAt: "2026-05-08",
+    },
+    vettingResult: {} as never,
+    projectHealth: {} as never,
+    antiLLMPolicy: {} as never,
+    slmTriage: null,
+    recommendation: "approve",
+    reasonsToApprove: [],
+    reasonsToSkip: [],
+    viabilityScore: score,
+    searchPriority: "merged_pr",
+    horizon,
+  }) as never;
+
+describe("splitByHorizon 60/40 split", () => {
+  const quickWinPool = [
+    mkCand("q1", 90, "quick-win"),
+    mkCand("q2", 88, "quick-win"),
+    mkCand("q3", 85, "quick-win"),
+    mkCand("q4", 82, "quick-win"),
+    mkCand("q5", 80, "quick-win"),
+    mkCand("q6", 78, "quick-win"),
+    mkCand("q7", 75, "quick-win"),
+    mkCand("q8", 72, "quick-win"),
+  ];
+  const biggerBetPool = [
+    mkCand("b1", 95, "bigger-bet"),
+    mkCand("b2", 92, "bigger-bet"),
+    mkCand("b3", 88, "bigger-bet"),
+    mkCand("b4", 85, "bigger-bet"),
+    mkCand("b5", 80, "bigger-bet"),
+  ];
+
+  it("returns 6 quick + 4 bigger when count=10 and both abundant", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 10);
+    expect(out.quickWins).toHaveLength(6);
+    expect(out.biggerBets).toHaveLength(4);
+  });
+  it("returns 3 quick + 2 bigger when count=5", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 5);
+    expect(out.quickWins).toHaveLength(3);
+    expect(out.biggerBets).toHaveLength(2);
+  });
+  it("redirects deficit to other bucket when one is short", () => {
+    const out = splitByHorizon([...quickWinPool, biggerBetPool[0], biggerBetPool[1]], 10);
+    // target 6+4, but only 2 bigger bets exist → fill quick to 8.
+    expect(out.quickWins).toHaveLength(8);
+    expect(out.biggerBets).toHaveLength(2);
+  });
+  it("returns all of one bucket when other is empty", () => {
+    const out = splitByHorizon([...quickWinPool], 10);
+    expect(out.quickWins).toHaveLength(8);
+    expect(out.biggerBets).toHaveLength(0);
+  });
+  it("sorts each bucket by score desc", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 10);
+    expect(out.quickWins.map((c) => c.viabilityScore)).toEqual([
+      90, 88, 85, 82, 80, 78,
+    ]);
+    expect(out.biggerBets.map((c) => c.viabilityScore)).toEqual([
+      95, 92, 88, 85,
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: FAIL — `splitByHorizon` not exported.
+
+- [ ] **Step 3: Implement `splitByHorizon`**
+
+Append to `packages/core/src/core/feature-discovery.ts`:
+
+```ts
+import type { IssueCandidate } from "./types.js";
+
+/** A vetted issue candidate stamped with its horizon classification. */
+export type FeatureCandidate = IssueCandidate & { horizon: Horizon };
+
+/**
+ * Split feature candidates into two buckets respecting a 60/40 target.
+ * If either bucket is short, redirect the deficit to the other bucket.
+ * Each bucket is sorted by viabilityScore descending.
+ */
+export function splitByHorizon(
+  candidates: FeatureCandidate[],
+  count: number,
+): { quickWins: FeatureCandidate[]; biggerBets: FeatureCandidate[] } {
+  const allQuick = candidates
+    .filter((c) => c.horizon === "quick-win")
+    .sort((a, b) => b.viabilityScore - a.viabilityScore);
+  const allBigger = candidates
+    .filter((c) => c.horizon === "bigger-bet")
+    .sort((a, b) => b.viabilityScore - a.viabilityScore);
+
+  const targetQuick = Math.round(count * 0.6);
+  const targetBigger = count - targetQuick;
+
+  const quickTaken = Math.min(allQuick.length, targetQuick);
+  const biggerTaken = Math.min(allBigger.length, targetBigger);
+
+  // Redirect deficits.
+  let quickFinal = quickTaken;
+  let biggerFinal = biggerTaken;
+  const quickDeficit = targetQuick - quickTaken;
+  const biggerDeficit = targetBigger - biggerTaken;
+  if (quickDeficit > 0) {
+    biggerFinal = Math.min(allBigger.length, biggerFinal + quickDeficit);
+  }
+  if (biggerDeficit > 0) {
+    quickFinal = Math.min(allQuick.length, quickFinal + biggerDeficit);
+  }
+
+  return {
+    quickWins: allQuick.slice(0, quickFinal),
+    biggerBets: allBigger.slice(0, biggerFinal),
+  };
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/feature-discovery.ts packages/core/src/core/feature-discovery.test.ts
+git commit -m "feat(core): add splitByHorizon helper with deficit-redirect (#92)"
+```
+
+---
+
+### Task 7: Build `discoverFeatures` orchestrator
+
+**Files:**
+- Modify: `packages/core/src/core/feature-discovery.ts`
+- Modify: `packages/core/src/core/feature-discovery.test.ts`
+
+The orchestrator wires anchor resolution → per-repo issue listing → feature-signal extraction → vetting → classification → bucket split. Reuses `IssueVetter` (already extended with featureSignals) and the throttled `octokit` from `github.ts`.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `packages/core/src/core/feature-discovery.test.ts`:
+
+```ts
+import { vi } from "vitest";
+import { discoverFeatures } from "./feature-discovery.js";
+
+describe("discoverFeatures orchestrator", () => {
+  it("returns no-anchors message when repoScores has no qualifying repos", async () => {
+    const octokit = { issues: { listForRepo: vi.fn() } } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 1]),
+      count: 10,
+    });
+    expect(result.anchorRepos).toEqual([]);
+    expect(result.quickWins).toEqual([]);
+    expect(result.biggerBets).toEqual([]);
+    expect(result.message).toContain("No anchor repos yet");
+    expect(octokit.issues.listForRepo).not.toHaveBeenCalled();
+  });
+
+  it("returns no-results message when anchors exist but no feature issues found", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 10,
+    });
+    expect(result.anchorRepos).toEqual(["a/b"]);
+    expect(result.quickWins).toEqual([]);
+    expect(result.biggerBets).toEqual([]);
+    expect(result.message).toContain("No open feature opportunities");
+  });
+
+  it("classifies, vets, and splits issues into horizons", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: [
+            {
+              html_url: "https://github.com/a/b/issues/1",
+              title: "small enhancement",
+              labels: [{ name: "enhancement" }],
+              updated_at: "2026-05-01",
+              comments: 2,
+              reactions: { total_count: 4 },
+              milestone: null,
+              pull_request: undefined,
+              assignee: null,
+            },
+            {
+              html_url: "https://github.com/a/b/issues/2",
+              title: "big proposal",
+              labels: [{ name: "proposal" }],
+              updated_at: "2026-05-01",
+              comments: 30,
+              reactions: { total_count: 50 },
+              milestone: { number: 1 },
+              pull_request: undefined,
+              assignee: null,
+            },
+          ],
+        }),
+      },
+    } as never;
+    const vetter = {
+      vetIssue: vi.fn().mockImplementation(async (url: string) => ({
+        issue: { url, repo: "a/b", number: 1, title: "t", labels: [], updatedAt: "2026-05-01" },
+        vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+        projectHealth: {},
+        antiLLMPolicy: { matched: false, matchedKeywords: [], sourceFile: null },
+        slmTriage: null,
+        recommendation: "approve",
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        viabilityScore: 80,
+        searchPriority: "merged_pr",
+      })),
+    } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 10,
+    });
+    expect(result.anchorRepos).toEqual(["a/b"]);
+    expect(result.quickWins).toHaveLength(1);
+    expect(result.biggerBets).toHaveLength(1);
+    expect(result.quickWins[0].horizon).toBe("quick-win");
+    expect(result.biggerBets[0].horizon).toBe("bigger-bet");
+    expect(result.message).toBeNull();
+    // Confirm vetter received feature signals
+    expect(vetter.vetIssue).toHaveBeenCalledWith(
+      "https://github.com/a/b/issues/1",
+      { featureSignals: { reactions: 4, comments: 2, hasMilestone: false } },
+    );
+    expect(vetter.vetIssue).toHaveBeenCalledWith(
+      "https://github.com/a/b/issues/2",
+      { featureSignals: { reactions: 50, comments: 30, hasMilestone: true } },
+    );
+  });
+
+  it("propagates auth and rate-limit errors", async () => {
+    const error = Object.assign(new Error("401"), { status: 401 });
+    const octokit = {
+      issues: { listForRepo: vi.fn().mockRejectedValue(error) },
+    } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    await expect(
+      discoverFeatures({
+        octokit,
+        vetter,
+        repoScores: mkScores(["a/b", 4]),
+        count: 10,
+      }),
+    ).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: FAIL — `discoverFeatures` not exported.
+
+- [ ] **Step 3: Implement orchestrator**
+
+Append to `packages/core/src/core/feature-discovery.ts`:
+
+```ts
+import type { Octokit } from "@octokit/rest";
+import type { IssueVetter } from "./issue-vetting.js";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import { warn } from "./logger.js";
+import { sleep } from "./utils.js";
+
+const MODULE = "feature-discovery";
+
+/** Delay between per-repo issue lists, mirroring search-phases.INTER_QUERY_DELAY_MS. */
+const INTER_REPO_DELAY_MS = 2000;
+
+/** Feature labels used to filter issues. Any-of match. */
+export const FEATURE_LABELS = [
+  "enhancement",
+  "feature",
+  "feature-request",
+  "proposal",
+  "roadmap",
+  "accepted-rfc",
+] as const;
+
+/** Labels excluded from feature-mode results (overlap with `scout` territory). */
+export const FEATURE_EXCLUSION_LABELS = new Set([
+  "good first issue",
+  "bug",
+  "documentation",
+]);
+
+export const NO_ANCHORS_MESSAGE =
+  "No anchor repos yet (need 3+ merged PRs in a repo). Try `scout search` to build relationships first.";
+
+export const NO_RESULTS_MESSAGE =
+  "No open feature opportunities in your anchor repos right now. Check back next week, or try `scout search` for fix-mode work.";
+
+export interface FeatureSearchResult {
+  quickWins: FeatureCandidate[];
+  biggerBets: FeatureCandidate[];
+  anchorRepos: string[];
+  message: string | null;
+}
+
+export interface DiscoverFeaturesOptions {
+  octokit: Octokit;
+  vetter: IssueVetter;
+  repoScores: Record<string, RepoScore>;
+  count: number;
+}
+
+interface RawIssueItem {
+  html_url: string;
+  title?: string;
+  labels?: Array<{ name?: string } | string>;
+  comments?: number;
+  reactions?: { total_count?: number } | null;
+  milestone?: { number?: number } | null;
+  pull_request?: unknown;
+  assignee?: unknown;
+}
+
+function extractLabels(item: RawIssueItem): string[] {
+  if (!Array.isArray(item.labels)) return [];
+  return item.labels
+    .map((l) => (typeof l === "string" ? l : l?.name))
+    .filter((s): s is string => typeof s === "string");
+}
+
+function isFeatureIssue(item: RawIssueItem): boolean {
+  const labels = extractLabels(item).map((l) => l.toLowerCase());
+  if (labels.length === 0) return false;
+  if (labels.some((l) => FEATURE_EXCLUSION_LABELS.has(l))) return false;
+  return labels.some((l) => (FEATURE_LABELS as readonly string[]).includes(l));
+}
+
+export async function discoverFeatures(
+  opts: DiscoverFeaturesOptions,
+): Promise<FeatureSearchResult> {
+  const anchorRepos = resolveAnchorRepos(opts.repoScores);
+  if (anchorRepos.length === 0) {
+    return {
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: NO_ANCHORS_MESSAGE,
+    };
+  }
+
+  const candidates: FeatureCandidate[] = [];
+
+  for (let i = 0; i < anchorRepos.length; i++) {
+    if (i > 0) await sleep(INTER_REPO_DELAY_MS);
+    const [owner, repo] = anchorRepos[i].split("/");
+    let response;
+    try {
+      response = await opts.octokit.issues.listForRepo({
+        owner,
+        repo,
+        state: "open",
+        sort: "updated",
+        direction: "desc",
+        per_page: 20,
+      });
+    } catch (err: unknown) {
+      // Auth and rate-limit errors propagate; other errors degrade with a warn.
+      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      warn(
+        MODULE,
+        `failed to list issues for ${anchorRepos[i]}: ${errorMessage(err)}`,
+      );
+      continue;
+    }
+
+    const items = (response.data as RawIssueItem[]).filter(
+      (it) => !it.pull_request && !it.assignee && isFeatureIssue(it),
+    );
+
+    for (const item of items) {
+      const labels = extractLabels(item);
+      const hasMilestone = !!item.milestone;
+      const reactions = item.reactions?.total_count ?? 0;
+      const comments = item.comments ?? 0;
+      let candidate;
+      try {
+        candidate = await opts.vetter.vetIssue(item.html_url, {
+          featureSignals: { reactions, comments, hasMilestone },
+        });
+      } catch (err: unknown) {
+        if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+        warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
+        continue;
+      }
+      const horizon = classifyHorizon({ hasMilestone, labels });
+      candidates.push({ ...candidate, horizon });
+    }
+  }
+
+  // Drop low-viability results — same threshold as scout search.
+  const passing = candidates.filter((c) => c.viabilityScore >= 40);
+
+  const split = splitByHorizon(passing, opts.count);
+  const total = split.quickWins.length + split.biggerBets.length;
+  return {
+    ...split,
+    anchorRepos,
+    message: total === 0 ? NO_RESULTS_MESSAGE : null,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm --filter @oss-scout/core test feature-discovery`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/feature-discovery.ts packages/core/src/core/feature-discovery.test.ts
+git commit -m "feat(core): add discoverFeatures orchestrator (#92)"
+```
+
+---
+
+### Task 8: Add `OssScout.features()` API method
+
+**Files:**
+- Modify: `packages/core/src/scout.ts`
+- Modify: `packages/core/src/scout.test.ts`
+
+Public API mirroring `OssScout.search()`. Builds the discoverFeatures call and persists results.
+
+**Important:** `state.repoScores` is `Record<string, RepoScore>`, not an array. The test data and the `OssScout.features()` body both pass it through unchanged to `discoverFeatures`. The existing `scout.test.ts` builds state via `ScoutStateSchema.parse({ version: 1, ...overrides })` — use that pattern for the test setup.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `packages/core/src/scout.test.ts`. Stub `discoverFeatures` so the test does not exercise network/octokit calls:
+
+```ts
+import { vi } from "vitest";
+
+vi.mock("./core/feature-discovery.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./core/feature-discovery.js")>();
+  return {
+    ...actual,
+    discoverFeatures: vi.fn(),
+  };
+});
+
+import { discoverFeatures } from "./core/feature-discovery.js";
+
+describe("OssScout.features", () => {
+  it("delegates to discoverFeatures and persists results with horizon stamped", async () => {
+    const fakeQuick = {
+      issue: {
+        url: "https://github.com/foo/bar/issues/1",
+        repo: "foo/bar",
+        number: 1,
+        title: "qw",
+        labels: ["enhancement"],
+        updatedAt: "2026-05-08",
+      },
+      vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+      projectHealth: {},
+      antiLLMPolicy: { matched: false, matchedKeywords: [], sourceFile: null },
+      slmTriage: null,
+      recommendation: "approve",
+      reasonsToApprove: [],
+      reasonsToSkip: [],
+      viabilityScore: 80,
+      searchPriority: "merged_pr",
+      horizon: "quick-win" as const,
+    };
+    const fakeBigger = { ...fakeQuick, issue: { ...fakeQuick.issue, url: "https://github.com/foo/bar/issues/2", number: 2 }, horizon: "bigger-bet" as const };
+    vi.mocked(discoverFeatures).mockResolvedValue({
+      quickWins: [fakeQuick],
+      biggerBets: [fakeBigger],
+      anchorRepos: ["foo/bar"],
+      message: null,
+    } as never);
+
+    const state = ScoutStateSchema.parse({
+      version: 1,
+      repoScores: {
+        "foo/bar": {
+          repo: "foo/bar",
+          score: 5,
+          mergedPRCount: 4,
+          closedWithoutMergeCount: 0,
+          avgResponseDays: null,
+          lastEvaluatedAt: "2026-05-08T00:00:00Z",
+          signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
+        },
+      },
+    });
+    const scout = new OssScout("test-token", state);
+    const result = await scout.features({ count: 10 });
+    expect(result.quickWins).toHaveLength(1);
+    expect(result.biggerBets).toHaveLength(1);
+    expect(scout.getSavedResults().find((r) => r.number === 1)?.horizon).toBe("quick-win");
+    expect(scout.getSavedResults().find((r) => r.number === 2)?.horizon).toBe("bigger-bet");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/core test scout`
+Expected: FAIL — `OssScout.features` not implemented.
+
+- [ ] **Step 3: Implement `OssScout.features()`**
+
+Edit `packages/core/src/scout.ts`. Add an import:
+
+```ts
+import {
+  discoverFeatures,
+  type FeatureSearchResult,
+} from "./core/feature-discovery.js";
+import { IssueVetter } from "./core/issue-vetting.js";
+import { getOctokit } from "./core/github.js";
+```
+
+Inside the `OssScout` class, after the `search` method, add:
+
+```ts
+/**
+ * `scout features` — surfaces feature-scoped contribution opportunities
+ * in repos where the user has 3+ merged PRs, ranked into separate
+ * "quick wins" and "bigger bets" buckets.
+ */
+async features(options?: {
+  count?: number;
+}): Promise<FeatureSearchResult> {
+  const count = options?.count ?? 10;
+  const octokit = getOctokit(this.githubToken);
+  const vetter = new IssueVetter(octokit, this);
+  const result = await discoverFeatures({
+    octokit,
+    vetter,
+    repoScores: this.state.repoScores ?? {},
+    count,
+  });
+
+  // Persist with horizon stamped on each saved candidate.
+  this.saveResults([
+    ...result.quickWins.map((c) => ({ ...c, horizon: c.horizon as const })),
+    ...result.biggerBets.map((c) => ({ ...c, horizon: c.horizon as const })),
+  ]);
+  this.state.lastSearchAt = new Date().toISOString();
+  this.dirty = true;
+
+  return result;
+}
+```
+
+To make `saveResults` honor the new optional `horizon` field, update its body. Find:
+
+```ts
+saveResults(candidates: IssueCandidate[]): void {
+  ...
+  for (const c of candidates) {
+    ...
+    existing.set(c.issue.url, {
+      ...
+      lastScore: c.viabilityScore,
+    });
+  }
+}
+```
+
+Change the parameter type to accept either `IssueCandidate` or `FeatureCandidate`:
+
+```ts
+saveResults(
+  candidates: Array<IssueCandidate | (IssueCandidate & { horizon?: Horizon })>,
+): void {
+```
+
+And inside the existing.set call, append `horizon: ("horizon" in c ? c.horizon : undefined),`.
+
+Also import `Horizon` at the top of `scout.ts` from schemas.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm --filter @oss-scout/core test scout`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/scout.ts packages/core/src/scout.test.ts
+git commit -m "feat(core): expose OssScout.features() API (#92)"
+```
+
+---
+
+### Task 9: CLI command `scout features`
+
+**Files:**
+- Create: `packages/core/src/commands/features.ts`
+- Create: `packages/core/src/commands/features.test.ts`
+- Modify: `packages/core/src/cli.ts`
+
+CLI entry mirrors `commands/search.ts`. Validates count, loads state, delegates to `OssScout.features()`, prints terminal or JSON output.
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/core/src/commands/features.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { runFeatures } from "./features.js";
+
+vi.mock("../scout.js", () => ({
+  createScout: vi.fn().mockResolvedValue({
+    features: vi.fn().mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: "No anchor repos yet",
+    }),
+    getState: () => ({}),
+    saveResults: vi.fn(),
+    checkpoint: vi.fn().mockResolvedValue(true),
+    getRepoScoreRecord: vi.fn().mockReturnValue(undefined),
+  }),
+}));
+
+vi.mock("../core/utils.js", () => ({
+  requireGitHubToken: () => "test-token",
+}));
+
+vi.mock("../core/local-state.js", () => ({
+  saveLocalState: vi.fn(),
+}));
+
+describe("runFeatures", () => {
+  it("returns the features result envelope", async () => {
+    const out = await runFeatures({ maxResults: 10 });
+    expect(out.quickWins).toEqual([]);
+    expect(out.biggerBets).toEqual([]);
+    expect(out.message).toBe("No anchor repos yet");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/core test commands/features`
+Expected: FAIL — `runFeatures` not exported.
+
+- [ ] **Step 3: Implement `runFeatures`**
+
+Create `packages/core/src/commands/features.ts`:
+
+```ts
+/**
+ * Features command — surfaces feature opportunities in anchor repos.
+ */
+
+import { createScout } from "../scout.js";
+import { requireGitHubToken } from "../core/utils.js";
+import { saveLocalState } from "../core/local-state.js";
+import type { ScoutState } from "../core/schemas.js";
+
+export interface FeaturesOutput {
+  quickWins: Array<{
+    issue: { repo: string; number: number; title: string; url: string; labels: string[] };
+    recommendation: "approve" | "skip" | "needs_review";
+    viabilityScore: number;
+    horizon: "quick-win";
+  }>;
+  biggerBets: Array<{
+    issue: { repo: string; number: number; title: string; url: string; labels: string[] };
+    recommendation: "approve" | "skip" | "needs_review";
+    viabilityScore: number;
+    horizon: "bigger-bet";
+  }>;
+  anchorRepos: string[];
+  message: string | null;
+}
+
+interface FeaturesCommandOptions {
+  maxResults: number;
+  state?: ScoutState;
+}
+
+export async function runFeatures(
+  options: FeaturesCommandOptions,
+): Promise<FeaturesOutput> {
+  const token = requireGitHubToken();
+  const scout = options.state
+    ? await createScout({
+        githubToken: token,
+        persistence: "provided",
+        initialState: options.state,
+      })
+    : await createScout({ githubToken: token });
+
+  const result = await scout.features({ count: options.maxResults });
+
+  saveLocalState(scout.getState() as ScoutState);
+  const persisted = await scout.checkpoint();
+  if (!persisted) {
+    console.error("Warning: changes saved locally but gist sync failed.");
+  }
+
+  const mapCandidate = (
+    c: (typeof result.quickWins)[number],
+    horizon: "quick-win" | "bigger-bet",
+  ) => ({
+    issue: {
+      repo: c.issue.repo,
+      number: c.issue.number,
+      title: c.issue.title,
+      url: c.issue.url,
+      labels: c.issue.labels,
+    },
+    recommendation: c.recommendation,
+    viabilityScore: c.viabilityScore,
+    horizon,
+  });
+
+  return {
+    quickWins: result.quickWins.map((c) => mapCandidate(c, "quick-win")),
+    biggerBets: result.biggerBets.map((c) => mapCandidate(c, "bigger-bet")),
+    anchorRepos: result.anchorRepos,
+    message: result.message,
+  };
+}
+```
+
+- [ ] **Step 4: Register CLI command**
+
+Edit `packages/core/src/cli.ts`. After the `search` command block, add:
+
+```ts
+program
+  .command("features [count]")
+  .description(
+    "Surface feature-scoped opportunities in repos where you have 3+ merged PRs",
+  )
+  .option("--json", "Output as JSON")
+  .action(
+    async (
+      count: string | undefined,
+      options: { json?: boolean },
+    ) => {
+      try {
+        const { runFeatures } = await import("./commands/features.js");
+        const maxResults = count ? parseInt(count, 10) : 10;
+        if (isNaN(maxResults) || maxResults < 1 || maxResults > 50) {
+          console.error("Error: count must be an integer between 1 and 50");
+          process.exit(1);
+        }
+        const state = loadLocalState();
+        const result = await runFeatures({ maxResults, state });
+        if (options.json) {
+          console.log(formatJsonSuccess(result));
+        } else {
+          // Human-readable output
+          const total = result.quickWins.length + result.biggerBets.length;
+          if (result.message) {
+            console.log(`\n${result.message}\n`);
+          }
+          if (total === 0) return;
+          console.log(
+            `\n🎯 Feature opportunities in your anchor repos (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
+          );
+          console.log(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
+          if (result.quickWins.length) {
+            console.log("── Quick wins ─────────────────────────────────────────");
+            for (const c of result.quickWins) {
+              console.log(
+                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+              );
+              console.log(`     ${c.issue.url}`);
+            }
+            console.log("");
+          }
+          if (result.biggerBets.length) {
+            console.log("── Bigger bets ────────────────────────────────────────");
+            for (const c of result.biggerBets) {
+              console.log(
+                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+              );
+              console.log(`     ${c.issue.url}`);
+            }
+            console.log("");
+          }
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (options.json) {
+          console.log(formatJsonError(msg, "FEATURES_FAILED"));
+        } else {
+          console.error(`Error: ${msg}`);
+        }
+        process.exit(1);
+      }
+    },
+  );
+```
+
+If `formatJsonSuccess` and `formatJsonError` are not already imported, check the imports at the top of `cli.ts` and add them. Look at how `search` uses them — copy the same imports.
+
+- [ ] **Step 5: Run tests + smoke-test the CLI**
+
+Run: `pnpm --filter @oss-scout/core test commands/features && pnpm --filter @oss-scout/core run bundle`
+Expected: PASS, bundle rebuilds.
+
+Smoke: `pnpm start -- features --json` against your real state. Confirm shape of envelope (success, data with quickWins/biggerBets/anchorRepos/message, timestamp). It is OK if the result is the no-anchors message because the running user has no qualifying repos.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/commands/features.ts packages/core/src/commands/features.test.ts packages/core/src/cli.ts
+git commit -m "feat(cli): add scout features subcommand (#92)"
+```
+
+---
+
+### Task 10: MCP tool `scout-features`
+
+**Files:**
+- Modify: `packages/mcp-server/src/tools.ts`
+- Modify: `packages/mcp-server/src/tools.test.ts`
+
+Mirrors the existing `search` tool registration.
+
+- [ ] **Step 1: Update existing tool-count test and add registration assertion**
+
+The existing test asserts `expect(server.tool).toHaveBeenCalledTimes(5)` and lists the registered names. With this addition the count becomes 6.
+
+Edit `packages/mcp-server/src/tools.test.ts`. In the `it("registers all five tools", ...)` block:
+- Change the test name to `"registers all six tools"`.
+- Change `expect(server.tool).toHaveBeenCalledTimes(5)` to `(6)`.
+- Add `expect(names).toContain("scout-features");` at the end of the assertions.
+
+Add a new `describe` block paralleling the existing `search tool execution` block:
+
+```ts
+describe("scout-features tool execution", () => {
+  it("returns JSON text content on success", async () => {
+    const featuresResult = {
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: "No anchor repos yet",
+    };
+    const local = createMockScout({
+      features: vi.fn().mockResolvedValue(featuresResult),
+    } as Partial<OssScout>);
+    const localServer = new McpServer({ name: "t", version: "0.0.1" });
+    vi.spyOn(localServer, "tool");
+    registerTools(localServer, local);
+    const handler = getToolHandler(localServer, "scout-features");
+    const result = (await handler({ maxResults: 5 }, {})) as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toMatchObject(featuresResult);
+  });
+});
+```
+
+Also add `features: vi.fn().mockResolvedValue({ quickWins: [], biggerBets: [], anchorRepos: [], message: null })` to the `createMockScout` defaults so the existing `beforeEach` registration succeeds with the new tool's expected method.
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm --filter @oss-scout/mcp test`
+Expected: FAIL — tool not registered.
+
+- [ ] **Step 3: Register tool**
+
+Edit `packages/mcp-server/src/tools.ts`. After the `search` `server.tool(...)` block, add:
+
+```ts
+server.tool(
+  "scout-features",
+  "Surface feature-scoped contribution opportunities in repos where you have 3+ merged PRs",
+  {
+    maxResults: z
+      .number()
+      .optional()
+      .describe("Maximum number of results to return (default 10)"),
+  },
+  async ({ maxResults }) => {
+    try {
+      const result = await withTimeout(
+        scout.features({ count: maxResults ?? 10 }),
+      );
+      scout.saveResults([...result.quickWins, ...result.biggerBets]);
+      await scout.checkpoint();
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Error: ${msg}` }],
+        isError: true,
+      };
+    }
+  },
+);
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm --filter @oss-scout/mcp test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/mcp-server/src/tools.ts packages/mcp-server/src/tools.test.ts
+git commit -m "feat(mcp): add scout-features tool (#92)"
+```
+
+---
+
+### Task 11: Public exports
+
+**Files:**
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Add exports**
+
+Edit `packages/core/src/index.ts`. Add to the existing `export {...} from "./core/schemas.js"` line: `Horizon, HorizonSchema`. Add a new export line:
+
+```ts
+export {
+  discoverFeatures,
+  resolveAnchorRepos,
+  classifyHorizon,
+  splitByHorizon,
+  ANCHOR_THRESHOLD,
+  FEATURE_LABELS,
+  NO_ANCHORS_MESSAGE,
+  NO_RESULTS_MESSAGE,
+  type FeatureSearchResult,
+  type FeatureCandidate,
+  type DiscoverFeaturesOptions,
+} from "./core/feature-discovery.js";
+
+export type { FeatureSignals } from "./core/issue-vetting.js";
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm --filter @oss-scout/core run typecheck`
+Expected: PASS, no missing exports or unresolved types.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/index.ts
+git commit -m "feat(core): export feature-discovery public API (#92)"
+```
+
+---
+
+### Task 12: Final integration — lint, full test, bundle, pre-commit review
+
+**Files:** entire repo.
+
+- [ ] **Step 1: Lint**
+
+Run: `pnpm run lint`
+Expected: PASS, zero errors.
+
+- [ ] **Step 2: Format check**
+
+Run: `pnpm run format:check`
+Expected: PASS. If failures, run `pnpm run format` and re-stage.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `pnpm test`
+Expected: all green; new feature-discovery tests included.
+
+- [ ] **Step 4: Bundle**
+
+Run: `pnpm run bundle`
+Expected: bundle rebuild succeeds.
+
+- [ ] **Step 5: Pre-commit review loop (per CLAUDE.md)**
+
+Invoke the `oss-autopilot:pr-ready` skill. Iterate until convergence (zero Critical / Recommended findings). Hard cap at 5 passes; if not converged, stop and report.
+
+- [ ] **Step 6: Open PR**
+
+```bash
+git push -u origin feat/92-scout-features-design
+gh pr create --base main --title "feat: add scout features subcommand (#92)" --body "$(cat <<'EOF'
+## Summary
+
+Implements `scout features` per design in `docs/superpowers/specs/2026-05-08-scout-features-design.md`. Closes #92.
+
+## Why
+
+`scout` optimizes for low-friction merges (small bugs). `scout features` adds a complementary objective function: feature-scoped opportunities in repos where the user has earned trust (3+ merged PRs).
+
+## Test plan
+
+- [ ] All unit tests pass
+- [ ] Lint, format, typecheck pass
+- [ ] Bundle rebuilds
+- [ ] Smoke test: `pnpm start -- features --json` returns the expected envelope
+- [ ] Smoke test: `pnpm start -- features` prints the sectioned terminal output
+- [ ] CI green on all matrix nodes
+EOF
+)"
+```
+
+- [ ] **Step 7: Wait for CI, then merge per the issue-batch-autopilot pattern**
+
+Use the until-loop pattern from the `issue-batch-autopilot` skill. Once green, squash-merge with `--delete-branch`.
+
+- [ ] **Step 8: File follow-up issues**
+
+For each item in the spec's "Out of scope for v1" section, file an issue. Use bare names (no `@user`, no `org/repo#N`).
+
+```bash
+for title in \
+  "feat(scout): project-board / ROADMAP.md scraping for richer maintainer-commitment signal" \
+  "feat(scout): wontfix-no-contributor detection" \
+  "feat(scout): stalled-PR revival mode" \
+  "feat(scout): configurable anchor threshold (featuresAnchorThreshold)" \
+  "feat(scout): configurable quick-wins / bigger-bets split ratio" \
+  "feat(scout): cross-repo features mode for first-touch contributors"; do
+  gh issue create --title "$title" --body "Follow-up to #92 design spec. See \`docs/superpowers/specs/2026-05-08-scout-features-design.md\` 'Out of scope for v1' section." --repo costajohnt/oss-scout
+done
+```
+
+---
+
+## Self-review notes
+
+Reviewed against the spec. Coverage:
+
+- Anchor resolution (3+ merged PRs) → Task 4
+- Both horizons ranked separately → Tasks 5 + 6
+- Subcommand sharing core pipeline → Tasks 7 + 8 + 9
+- Signals: labels (Task 7 `FEATURE_LABELS`), reactions / comments / milestone (Tasks 2 + 7)
+- Horizon classifier (milestone or roadmap/accepted-rfc/proposal label) → Task 5
+- Linked-PR penalty kept at -30 → reused via existing scoring (no change needed)
+- Empty-state messages → Task 7
+- JSON envelope (`success, data: { quickWins, biggerBets, anchorRepos, message }, timestamp`) → Task 9 (CLI uses existing `formatJsonSuccess`)
+- MCP tool → Task 10
+- Auth and rate-limit propagation → Task 7 orchestrator + reused vetter behavior
+- Test coverage for anchor resolution, horizon classifier, 60/40 split, persistence, CLI, MCP, error propagation → Tasks 4-10
+- Follow-up issues → Task 12 step 8

--- a/docs/superpowers/specs/2026-05-08-scout-features-design.md
+++ b/docs/superpowers/specs/2026-05-08-scout-features-design.md
@@ -1,0 +1,267 @@
+# `scout features` — feature-opportunity search mode
+
+**Issue:** #92
+**Status:** approved design, ready for implementation plan
+**Date:** 2026-05-08
+
+## Problem
+
+Today's `scout` optimizes for low-friction merges: small bugs, good-first-issue labels, fast review cycles. That objective function biases discovery toward maintenance work. A different objective function would surface bigger contribution opportunities — features rather than fixes — anchored on repos where the user has demonstrated relationships through merged PRs.
+
+`scout features` adds a complementary search mode that uses different signals to surface feature-scoped contribution opportunities, restricted to repos where the user has earned trust.
+
+## Design decisions (locked during brainstorm)
+
+| Decision | Value |
+|---|---|
+| Audience | Relationship-anchored only. No broad cross-repo discovery in v1. |
+| Time horizon | Both quick wins and bigger bets, ranked separately into two buckets. |
+| Surface | New `scout features [count]` subcommand sharing core discovery pipeline with `scout search`. |
+| v1 signals | Labels, reactions, comment count, milestone presence. Project boards / ROADMAP.md / wontfix-no-contributor deferred to v2. |
+| Anchor threshold | 3+ merged PRs into a repo. Hardcoded for v1; configurable in a follow-up. |
+| Horizon classifier | Bigger bet if issue has a milestone OR carries `roadmap` / `accepted-rfc` / `proposal` labels. Otherwise quick win. |
+| Linked-PR handling | Same -30 penalty as `scout`. Stalled-PR revival mode is a future follow-up. |
+
+## Architecture
+
+### New CLI command
+
+`scout features [count]` — sibling to `scout search`. Default count: 10. Same global flags (`--json`, `--strategy` not applicable).
+
+### New core module
+
+`packages/core/src/core/feature-discovery.ts` — orchestrator that:
+
+1. Resolves anchor repos from `ScoutState.repoScores` (filter `mergedPRCount >= 3`).
+2. Builds a `FeatureSearchConfig` with feature-flavored signals (label set, scoring adjustments, horizon classifier).
+3. Calls existing `IssueVetter` per anchor repo to fetch and vet issues with the feature filter applied.
+4. Classifies each surviving issue into `quick-win` or `bigger-bet`.
+5. Returns `FeatureSearchResult` with both buckets, anchor list, and an optional empty-state message.
+
+### Reused modules
+
+- `IssueVetter` (existing) for per-issue PR existence, claim detection, requirements check, scoring.
+- `issue-scoring.ts` viability score (existing weights, including -30 for existing PR).
+- `http-cache.ts`, `search-budget.ts`, `github.ts` — cache, rate limit, throttled client.
+- `errors.ts` (`getHttpStatusCode`, `isRateLimitError`) — auth and rate-limit propagation policy.
+
+### New files
+
+- `packages/core/src/core/feature-discovery.ts`
+- `packages/core/src/core/feature-discovery.test.ts`
+- `packages/core/src/commands/features.ts`
+- `packages/core/src/commands/features.test.ts`
+
+### Modified files
+
+- `packages/core/src/cli.ts` — register `features` command (mirror of `search`).
+- `packages/core/src/scout.ts` — expose `OssScout.features()` API method paralleling `OssScout.search()`.
+- `packages/core/src/index.ts` — export `FeatureSearchResult`, `FeatureCandidate` types.
+- `packages/core/src/core/schemas.ts` — extend `SavedCandidate` with optional `horizon: "quick-win" | "bigger-bet"`.
+- `packages/core/src/core/issue-scoring.ts` — extend `calculateViabilityScore` with optional `featureSignals` parameter.
+- `packages/mcp-server/src/tools.ts` — register `scout-features` MCP tool paralleling `search`.
+- `packages/mcp-server/src/tools.test.ts` — registration test for the new tool.
+
+### Schema delta
+
+```ts
+// schemas.ts
+export const HorizonSchema = z.enum(["quick-win", "bigger-bet"]);
+
+export const SavedCandidateSchema = z.object({
+  // ... existing fields ...
+  horizon: HorizonSchema.optional(),
+});
+```
+
+`horizon` is optional so existing `scout search` results validate unchanged. Feature-mode results always set it.
+
+## Data flow
+
+```
+scout features [count]
+  │
+  ▼
+commands/features.ts
+  • Validate count (1-50, like search)
+  • Load ScoutState (gist or local, via existing store)
+  • Call OssScout.features({ count, json })
+  │
+  ▼
+scout.ts → OssScout.features()
+  • Build context: prefs, octokit, stateReader
+  • Delegate to feature-discovery.ts
+  │
+  ▼
+feature-discovery.ts → discoverFeatures(ctx, count)
+  │
+  ├─ 1. Resolve anchors
+  │    repoScores.filter(rs => rs.mergedPRCount >= 3) → anchorRepos[]
+  │    if empty → return no-anchors result with explanatory message
+  │
+  ├─ 2. Build FeatureSearchConfig
+  │    • labelSet: ["enhancement","feature","proposal","roadmap","accepted-rfc"]
+  │    • requiredLabelMatch: any-of
+  │    • exclusionLabels: ["good first issue","bug","documentation"]
+  │    • horizonClassifier
+  │    • feature scoring adjustments
+  │
+  ├─ 3. Per-anchor-repo search (sequential, throttled by search-budget)
+  │    Reuse existing `fetchIssuesFromKnownRepos` helper from
+  │    `search-phases.ts` with the feature label set and exclusions.
+  │    → IssueCandidate[]
+  │
+  ├─ 4. Vet each candidate (existing IssueVetter)
+  │    • PR existence check, claim detection, requirements, spam filter, viability score
+  │
+  ├─ 5. Filter + classify
+  │    • Drop where viabilityScore < 40
+  │    • Tag each survivor with horizon
+  │    • Group into quickWins[] + biggerBets[]
+  │
+  ├─ 6. Sort within each bucket by score desc, take top N proportionally
+  │    Target split: 60% quick wins, 40% bigger bets, rounded to integers,
+  │    sum equals `count`.
+  │    • count=10 → 6 quick + 4 bigger
+  │    • count=5  → 3 + 2
+  │    Underfill rule: if either bucket has fewer than its target after
+  │    sort, redirect the deficit to the other bucket up to total `count`.
+  │    Example: target 6+4, but only 2 bigger bets exist → return 6 quick + 2 bigger
+  │    if quick has only 6; otherwise fill to 8 quick + 2 bigger.
+  │
+  ├─ 7. Persist into state.searchResults with horizon stamped on each
+  │
+  └─ Return FeatureSearchResult
+```
+
+### Empty-state messages
+
+| State | Detection | Message |
+|---|---|---|
+| no-anchors | `anchorRepos.length === 0` | "No anchor repos yet (need 3+ merged PRs in a repo). Try `scout search` to build relationships first." |
+| no-results | anchors exist, but `quickWins.length + biggerBets.length === 0` | "No open feature opportunities in your anchor repos right now. Check back next week, or try `scout search` for fix-mode work." |
+| success | results exist | (no message; output is the results) |
+
+## Scoring weights
+
+Feature mode reuses `calculateViabilityScore` with an optional `featureSignals` parameter that adds zero when absent. Existing `scout search` ignores it; feature mode populates it. One scoring function, no `if (mode === ...)` checks.
+
+| Signal | `scout search` | `scout features` | Source |
+|---|---|---|---|
+| Reaction bonus | not used | `+min(reactions / 2, 10)` | `featureSignals.reactions` |
+| Comment-depth bonus | not used | `+5` if `comments >= 5` | `featureSignals.comments` |
+| Milestone bonus | not used | `+5` if `hasMilestone` | `featureSignals.hasMilestone` |
+| Org affinity | `+5` | `+5` | existing |
+| Repo merged-PR bonus | `+15` | `+15` | existing |
+| Existing-PR penalty | `-30` | `-30` | existing |
+| Repo-quality bonus | up to `+12` | up to `+12` | existing |
+| Freshness | up to `+15` | up to `+15` | existing |
+
+Score range stays 0-100. A strong feature opportunity (anchor repo, recent activity, no PR, milestone, 10+ reactions) lands ~85-95.
+
+## Output
+
+### Terminal (default)
+
+```
+🎯 Feature opportunities in your anchor repos (5 quick wins + 3 bigger bets)
+
+Anchor repos: foo/bar (5 merged), baz/qux (4 merged), abc/xyz (3 merged)
+
+── Quick wins ─────────────────────────────────────────
+  1. [foo/bar] Add JSON output to `bar list`        Score 87
+     https://github.com/foo/bar/issues/123
+     Labels: enhancement
+     Updated 4d ago · 12 reactions · 7 comments
+
+── Bigger bets ────────────────────────────────────────
+  1. [baz/qux] Pluggable transport layer            Score 82
+     https://github.com/baz/qux/issues/456
+     Labels: roadmap, proposal · Milestone: v2.0
+     Updated 11d ago · 38 reactions · 24 comments
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "success": true,
+  "data": {
+    "quickWins": [SavedCandidate, ...],
+    "biggerBets": [SavedCandidate, ...],
+    "anchorRepos": ["foo/bar", "baz/qux", "abc/xyz"],
+    "message": null
+  },
+  "timestamp": "2026-05-08T..."
+}
+```
+
+Empty-state JSON:
+
+```json
+{
+  "success": true,
+  "data": {
+    "quickWins": [],
+    "biggerBets": [],
+    "anchorRepos": [],
+    "message": "No anchor repos yet (need 3+ merged PRs). Try `scout search` to build relationships first."
+  },
+  "timestamp": "..."
+}
+```
+
+`success: true` on empty: empty is not an error, it's "no results in this objective function." Matches existing `scout search` convention.
+
+## Error handling
+
+Same strategy as the rest of the codebase (per `errors.ts` documentation):
+
+- Auth errors (401) and rate-limit errors propagate unchanged via `getHttpStatusCode` + `isRateLimitError`.
+- Cache and filesystem errors degrade gracefully with `warn` logging.
+- No new error types introduced.
+
+The `feature-discovery.ts` orchestrator wraps per-anchor-repo search calls in the same try/catch pattern used in `issue-discovery.ts`, re-raising auth and rate-limit errors and continuing past other failures.
+
+## Testing strategy
+
+| Test | Module | Purpose |
+|---|---|---|
+| anchor resolution | `feature-discovery.test.ts` | Filter `repoScores` by threshold, returns expected anchors. |
+| empty-anchors path | `feature-discovery.test.ts` | Returns no-anchors message, makes no API calls. |
+| label filter | `feature-discovery.test.ts` | Issues without feature labels get filtered out. |
+| horizon classifier | `feature-discovery.test.ts` | Pure function, table-driven: milestone or `roadmap`/`accepted-rfc`/`proposal` label → bigger-bet, otherwise quick-win. |
+| scoring with feature signals | `issue-scoring.test.ts` | Reaction, comment, milestone bonuses applied when `featureSignals` present; ignored otherwise. |
+| 60/40 split | `feature-discovery.test.ts` | count=10 returns 6 quick + 4 bigger when both abundant; degrades gracefully when one bucket empty. |
+| persistence | `feature-discovery.test.ts` | Results saved with `horizon` field; `scout results` displays them. |
+| CLI integration | `commands/features.test.ts` | Argument validation, JSON envelope, exit codes match `search` conventions. |
+| MCP tool registration | `mcp-server/src/tools.test.ts` | `scout-features` tool registered, schema validates. |
+| Auth/rate-limit propagation | `feature-discovery.test.ts` | 401 and rate-limit errors from search and vet bubble up unchanged. |
+
+All tests use Vitest and the existing `mockOctokit` helpers.
+
+## Out of scope for v1
+
+Tracked as follow-up issues at the end of implementation:
+
+- Project-board and `ROADMAP.md` scraping (richer maintainer-commitment signal).
+- "Wontfix because no contributor" detection.
+- Stalled-PR revival mode (surface issues with linked PRs that have been inactive >30 days).
+- Configurable anchor threshold (`featuresAnchorThreshold` preference).
+- Configurable quick-wins / bigger-bets split ratio.
+- Cross-repo / first-touch broad mode (audience expansion).
+
+## Acceptance criteria
+
+- [x] Design approved section by section during brainstorm
+- [ ] `scout features` command available, default count 10, accepts 1-50 range
+- [ ] Anchor resolution uses `mergedPRCount >= 3`
+- [ ] Results split into `quickWins` and `biggerBets` with horizon classifier described above
+- [ ] JSON output matches `{ success, data: { quickWins, biggerBets, anchorRepos, message }, timestamp }` shape
+- [ ] Empty states emit explanatory message, `success: true`
+- [ ] Existing `scout search` behavior unchanged
+- [ ] `SavedCandidate.horizon` is optional in schema; existing saved results validate unchanged
+- [ ] Auth and rate-limit errors propagate (per project policy)
+- [ ] Test coverage for anchor resolution, horizon classifier, 60/40 split, persistence, CLI, MCP, error propagation
+- [ ] MCP `scout-features` tool exposed
+- [ ] Follow-up issues filed for the out-of-scope items above

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "overrides": {
       "vite": "^8.0.5",
       "hono": ">=4.12.14",
-      "@hono/node-server": ">=1.19.13"
+      "@hono/node-server": ">=1.19.13",
+      "fast-uri": ">=3.1.2"
     }
   }
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -193,6 +193,64 @@ program
     },
   );
 
+program
+  .command("features [count]")
+  .description(
+    "Surface feature-scoped opportunities in repos where you have 3+ merged PRs",
+  )
+  .option("--json", "Output as JSON")
+  .action(async (count: string | undefined, options: { json?: boolean }) => {
+    try {
+      const { runFeatures } = await import("./commands/features.js");
+      const maxResults = count ? parseInt(count, 10) : 10;
+      if (isNaN(maxResults) || maxResults < 1 || maxResults > 50) {
+        console.error("Error: count must be an integer between 1 and 50");
+        process.exit(1);
+      }
+      const state = loadLocalState();
+      const result = await runFeatures({ maxResults, state });
+      if (options.json) {
+        console.log(formatJsonSuccess(result));
+      } else {
+        const total = result.quickWins.length + result.biggerBets.length;
+        if (result.message) {
+          console.log(`\n${result.message}\n`);
+        }
+        if (total === 0) return;
+        console.log(
+          `\n🎯 Feature opportunities in your anchor repos (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
+        );
+        console.log(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
+        if (result.quickWins.length) {
+          console.log(
+            "── Quick wins ─────────────────────────────────────────",
+          );
+          for (const c of result.quickWins) {
+            console.log(
+              `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+            );
+            console.log(`     ${c.issue.url}`);
+          }
+          console.log("");
+        }
+        if (result.biggerBets.length) {
+          console.log(
+            "── Bigger bets ────────────────────────────────────────",
+          );
+          for (const c of result.biggerBets) {
+            console.log(
+              `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+            );
+            console.log(`     ${c.issue.url}`);
+          }
+          console.log("");
+        }
+      }
+    } catch (err) {
+      handleCommandError(err, options);
+    }
+  });
+
 // ── results command ────────────────────────────────────────────────
 
 const resultsCmd = program

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { runFeatures } from "./features.js";
+
+vi.mock("../scout.js", () => ({
+  createScout: vi.fn().mockResolvedValue({
+    features: vi.fn().mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: "No anchor repos yet",
+    }),
+    getState: () => ({}),
+    saveResults: vi.fn(),
+    checkpoint: vi.fn().mockResolvedValue(true),
+    getRepoScoreRecord: vi.fn().mockReturnValue(undefined),
+  }),
+}));
+
+vi.mock("../core/utils.js", () => ({
+  requireGitHubToken: () => "test-token",
+}));
+
+vi.mock("../core/local-state.js", () => ({
+  saveLocalState: vi.fn(),
+}));
+
+describe("runFeatures", () => {
+  it("returns the features result envelope", async () => {
+    const out = await runFeatures({ maxResults: 10 });
+    expect(out.quickWins).toEqual([]);
+    expect(out.biggerBets).toEqual([]);
+    expect(out.message).toBe("No anchor repos yet");
+  });
+});

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -1,0 +1,103 @@
+/**
+ * Features command — surfaces feature opportunities in anchor repos.
+ */
+
+import { createScout } from "../scout.js";
+import { requireGitHubToken } from "../core/utils.js";
+import { saveLocalState } from "../core/local-state.js";
+import type { ScoutState } from "../core/schemas.js";
+import type { FeatureCandidate } from "../core/feature-discovery.js";
+
+export interface FeaturesOutput {
+  quickWins: Array<{
+    issue: {
+      repo: string;
+      number: number;
+      title: string;
+      url: string;
+      labels: string[];
+    };
+    recommendation: "approve" | "skip" | "needs_review";
+    viabilityScore: number;
+    horizon: "quick-win";
+  }>;
+  biggerBets: Array<{
+    issue: {
+      repo: string;
+      number: number;
+      title: string;
+      url: string;
+      labels: string[];
+    };
+    recommendation: "approve" | "skip" | "needs_review";
+    viabilityScore: number;
+    horizon: "bigger-bet";
+  }>;
+  anchorRepos: string[];
+  message: string | null;
+}
+
+interface FeaturesCommandOptions {
+  maxResults: number;
+  state?: ScoutState;
+}
+
+function mapQuickWin(c: FeatureCandidate): FeaturesOutput["quickWins"][number] {
+  return {
+    issue: {
+      repo: c.issue.repo,
+      number: c.issue.number,
+      title: c.issue.title,
+      url: c.issue.url,
+      labels: c.issue.labels,
+    },
+    recommendation: c.recommendation,
+    viabilityScore: c.viabilityScore,
+    horizon: "quick-win",
+  };
+}
+
+function mapBiggerBet(
+  c: FeatureCandidate,
+): FeaturesOutput["biggerBets"][number] {
+  return {
+    issue: {
+      repo: c.issue.repo,
+      number: c.issue.number,
+      title: c.issue.title,
+      url: c.issue.url,
+      labels: c.issue.labels,
+    },
+    recommendation: c.recommendation,
+    viabilityScore: c.viabilityScore,
+    horizon: "bigger-bet",
+  };
+}
+
+export async function runFeatures(
+  options: FeaturesCommandOptions,
+): Promise<FeaturesOutput> {
+  const token = requireGitHubToken();
+  const scout = options.state
+    ? await createScout({
+        githubToken: token,
+        persistence: "provided",
+        initialState: options.state,
+      })
+    : await createScout({ githubToken: token });
+
+  const result = await scout.features({ count: options.maxResults });
+
+  saveLocalState(scout.getState() as ScoutState);
+  const persisted = await scout.checkpoint();
+  if (!persisted) {
+    console.error("Warning: changes saved locally but gist sync failed.");
+  }
+
+  return {
+    quickWins: result.quickWins.map(mapQuickWin),
+    biggerBets: result.biggerBets.map(mapBiggerBet),
+    anchorRepos: result.anchorRepos,
+    message: result.message,
+  };
+}

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -4,6 +4,8 @@ import {
   resolveAnchorRepos,
   ANCHOR_THRESHOLD,
   classifyHorizon,
+  splitByHorizon,
+  type FeatureCandidate,
 } from "./feature-discovery.js";
 
 const mkScore = (repo: string, mergedPRCount: number): RepoScore => ({
@@ -82,5 +84,85 @@ describe("classifyHorizon", () => {
     expect(classifyHorizon({ hasMilestone: false, labels: ["Roadmap"] })).toBe(
       "bigger-bet",
     );
+  });
+});
+
+const mkCand = (
+  url: string,
+  score: number,
+  horizon: "quick-win" | "bigger-bet",
+): FeatureCandidate =>
+  ({
+    issue: {
+      url,
+      repo: "x/y",
+      number: 1,
+      title: url,
+      labels: [],
+      updatedAt: "2026-05-08",
+    },
+    vettingResult: {} as never,
+    projectHealth: {} as never,
+    antiLLMPolicy: {} as never,
+    slmTriage: null,
+    recommendation: "approve",
+    reasonsToApprove: [],
+    reasonsToSkip: [],
+    viabilityScore: score,
+    searchPriority: "merged_pr",
+    horizon,
+  }) as never;
+
+describe("splitByHorizon 60/40 split", () => {
+  const quickWinPool = [
+    mkCand("q1", 90, "quick-win"),
+    mkCand("q2", 88, "quick-win"),
+    mkCand("q3", 85, "quick-win"),
+    mkCand("q4", 82, "quick-win"),
+    mkCand("q5", 80, "quick-win"),
+    mkCand("q6", 78, "quick-win"),
+    mkCand("q7", 75, "quick-win"),
+    mkCand("q8", 72, "quick-win"),
+  ];
+  const biggerBetPool = [
+    mkCand("b1", 95, "bigger-bet"),
+    mkCand("b2", 92, "bigger-bet"),
+    mkCand("b3", 88, "bigger-bet"),
+    mkCand("b4", 85, "bigger-bet"),
+    mkCand("b5", 80, "bigger-bet"),
+  ];
+
+  it("returns 6 quick + 4 bigger when count=10 and both abundant", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 10);
+    expect(out.quickWins).toHaveLength(6);
+    expect(out.biggerBets).toHaveLength(4);
+  });
+  it("returns 3 quick + 2 bigger when count=5", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 5);
+    expect(out.quickWins).toHaveLength(3);
+    expect(out.biggerBets).toHaveLength(2);
+  });
+  it("redirects deficit to other bucket when one is short", () => {
+    const out = splitByHorizon(
+      [...quickWinPool, biggerBetPool[0], biggerBetPool[1]],
+      10,
+    );
+    // target 6+4, but only 2 bigger bets exist → fill quick to 8.
+    expect(out.quickWins).toHaveLength(8);
+    expect(out.biggerBets).toHaveLength(2);
+  });
+  it("returns all of one bucket when other is empty", () => {
+    const out = splitByHorizon([...quickWinPool], 10);
+    expect(out.quickWins).toHaveLength(8);
+    expect(out.biggerBets).toHaveLength(0);
+  });
+  it("sorts each bucket by score desc", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 10);
+    expect(out.quickWins.map((c) => c.viabilityScore)).toEqual([
+      90, 88, 85, 82, 80, 78,
+    ]);
+    expect(out.biggerBets.map((c) => c.viabilityScore)).toEqual([
+      95, 92, 88, 85,
+    ]);
   });
 });

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import type { RepoScore } from "./schemas.js";
+import { resolveAnchorRepos, ANCHOR_THRESHOLD } from "./feature-discovery.js";
+
+const mkScore = (repo: string, mergedPRCount: number): RepoScore => ({
+  repo,
+  score: 5,
+  mergedPRCount,
+  closedWithoutMergeCount: 0,
+  avgResponseDays: null,
+  lastEvaluatedAt: "2026-05-08T00:00:00Z",
+  signals: {
+    hasActiveMaintainers: true,
+    isResponsive: true,
+    hasHostileComments: false,
+  },
+});
+
+const mkScores = (...entries: Array<[string, number]>): Record<string, RepoScore> =>
+  Object.fromEntries(entries.map(([repo, count]) => [repo, mkScore(repo, count)]));
+
+describe("resolveAnchorRepos", () => {
+  it("returns empty array when no scores meet threshold", () => {
+    const out = resolveAnchorRepos(mkScores(["a/b", 1], ["c/d", 2]));
+    expect(out).toEqual([]);
+  });
+  it("filters by ANCHOR_THRESHOLD (3)", () => {
+    expect(ANCHOR_THRESHOLD).toBe(3);
+    const out = resolveAnchorRepos(
+      mkScores(["a/b", 2], ["c/d", 3], ["e/f", 5]),
+    );
+    expect(out).toEqual(["e/f", "c/d"]);
+  });
+  it("sorts by mergedPRCount desc", () => {
+    const out = resolveAnchorRepos(
+      mkScores(["a/b", 4], ["c/d", 10], ["e/f", 7]),
+    );
+    expect(out).toEqual(["c/d", "e/f", "a/b"]);
+  });
+});

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import type { RepoScore } from "./schemas.js";
-import { resolveAnchorRepos, ANCHOR_THRESHOLD } from "./feature-discovery.js";
+import {
+  resolveAnchorRepos,
+  ANCHOR_THRESHOLD,
+  classifyHorizon,
+} from "./feature-discovery.js";
 
 const mkScore = (repo: string, mergedPRCount: number): RepoScore => ({
   repo,
@@ -16,8 +20,12 @@ const mkScore = (repo: string, mergedPRCount: number): RepoScore => ({
   },
 });
 
-const mkScores = (...entries: Array<[string, number]>): Record<string, RepoScore> =>
-  Object.fromEntries(entries.map(([repo, count]) => [repo, mkScore(repo, count)]));
+const mkScores = (
+  ...entries: Array<[string, number]>
+): Record<string, RepoScore> =>
+  Object.fromEntries(
+    entries.map(([repo, count]) => [repo, mkScore(repo, count)]),
+  );
 
 describe("resolveAnchorRepos", () => {
   it("returns empty array when no scores meet threshold", () => {
@@ -36,5 +44,43 @@ describe("resolveAnchorRepos", () => {
       mkScores(["a/b", 4], ["c/d", 10], ["e/f", 7]),
     );
     expect(out).toEqual(["c/d", "e/f", "a/b"]);
+  });
+});
+
+describe("classifyHorizon", () => {
+  it("returns bigger-bet when issue has a milestone", () => {
+    expect(classifyHorizon({ hasMilestone: true, labels: [] })).toBe(
+      "bigger-bet",
+    );
+  });
+  it("returns bigger-bet for roadmap label", () => {
+    expect(classifyHorizon({ hasMilestone: false, labels: ["roadmap"] })).toBe(
+      "bigger-bet",
+    );
+  });
+  it("returns bigger-bet for accepted-rfc label", () => {
+    expect(
+      classifyHorizon({ hasMilestone: false, labels: ["accepted-rfc"] }),
+    ).toBe("bigger-bet");
+  });
+  it("returns bigger-bet for proposal label", () => {
+    expect(classifyHorizon({ hasMilestone: false, labels: ["proposal"] })).toBe(
+      "bigger-bet",
+    );
+  });
+  it("returns quick-win for plain enhancement label", () => {
+    expect(
+      classifyHorizon({ hasMilestone: false, labels: ["enhancement"] }),
+    ).toBe("quick-win");
+  });
+  it("returns quick-win when no signals fire", () => {
+    expect(classifyHorizon({ hasMilestone: false, labels: [] })).toBe(
+      "quick-win",
+    );
+  });
+  it("is case-insensitive on label matching", () => {
+    expect(classifyHorizon({ hasMilestone: false, labels: ["Roadmap"] })).toBe(
+      "bigger-bet",
+    );
   });
 });

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { RepoScore } from "./schemas.js";
 import {
   resolveAnchorRepos,
   ANCHOR_THRESHOLD,
   classifyHorizon,
   splitByHorizon,
+  discoverFeatures,
   type FeatureCandidate,
 } from "./feature-discovery.js";
 
@@ -164,5 +165,136 @@ describe("splitByHorizon 60/40 split", () => {
     expect(out.biggerBets.map((c) => c.viabilityScore)).toEqual([
       95, 92, 88, 85,
     ]);
+  });
+});
+
+describe("discoverFeatures orchestrator", () => {
+  it("returns no-anchors message when repoScores has no qualifying repos", async () => {
+    const octokit = { issues: { listForRepo: vi.fn() } } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 1]),
+      count: 10,
+    });
+    expect(result.anchorRepos).toEqual([]);
+    expect(result.quickWins).toEqual([]);
+    expect(result.biggerBets).toEqual([]);
+    expect(result.message).toContain("No anchor repos yet");
+    expect(octokit.issues.listForRepo).not.toHaveBeenCalled();
+  });
+
+  it("returns no-results message when anchors exist but no feature issues found", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 10,
+    });
+    expect(result.anchorRepos).toEqual(["a/b"]);
+    expect(result.quickWins).toEqual([]);
+    expect(result.biggerBets).toEqual([]);
+    expect(result.message).toContain("No open feature opportunities");
+  });
+
+  it("classifies, vets, and splits issues into horizons", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: [
+            {
+              html_url: "https://github.com/a/b/issues/1",
+              title: "small enhancement",
+              labels: [{ name: "enhancement" }],
+              updated_at: "2026-05-01",
+              comments: 2,
+              reactions: { total_count: 4 },
+              milestone: null,
+              pull_request: undefined,
+              assignee: null,
+            },
+            {
+              html_url: "https://github.com/a/b/issues/2",
+              title: "big proposal",
+              labels: [{ name: "proposal" }],
+              updated_at: "2026-05-01",
+              comments: 30,
+              reactions: { total_count: 50 },
+              milestone: { number: 1 },
+              pull_request: undefined,
+              assignee: null,
+            },
+          ],
+        }),
+      },
+    } as never;
+    const vetter = {
+      vetIssue: vi.fn().mockImplementation(async (url: string) => ({
+        issue: {
+          url,
+          repo: "a/b",
+          number: 1,
+          title: "t",
+          labels: [],
+          updatedAt: "2026-05-01",
+        },
+        vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+        projectHealth: {},
+        antiLLMPolicy: {
+          matched: false,
+          matchedKeywords: [],
+          sourceFile: null,
+        },
+        slmTriage: null,
+        recommendation: "approve",
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        viabilityScore: 80,
+        searchPriority: "merged_pr",
+      })),
+    } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 10,
+    });
+    expect(result.anchorRepos).toEqual(["a/b"]);
+    expect(result.quickWins).toHaveLength(1);
+    expect(result.biggerBets).toHaveLength(1);
+    expect(result.quickWins[0].horizon).toBe("quick-win");
+    expect(result.biggerBets[0].horizon).toBe("bigger-bet");
+    expect(result.message).toBeNull();
+    expect(vetter.vetIssue).toHaveBeenCalledWith(
+      "https://github.com/a/b/issues/1",
+      { featureSignals: { reactions: 4, comments: 2, hasMilestone: false } },
+    );
+    expect(vetter.vetIssue).toHaveBeenCalledWith(
+      "https://github.com/a/b/issues/2",
+      { featureSignals: { reactions: 50, comments: 30, hasMilestone: true } },
+    );
+  });
+
+  it("propagates auth and rate-limit errors", async () => {
+    const error = Object.assign(new Error("401"), { status: 401 });
+    const octokit = {
+      issues: { listForRepo: vi.fn().mockRejectedValue(error) },
+    } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    await expect(
+      discoverFeatures({
+        octokit,
+        vetter,
+        repoScores: mkScores(["a/b", 4]),
+        count: 10,
+      }),
+    ).rejects.toThrow();
   });
 });

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -1,0 +1,32 @@
+/**
+ * Feature Discovery — orchestrates `scout features` mode: surfaces
+ * feature-scoped contribution opportunities in repos where the user has
+ * 3+ merged PRs, ranked into separate "quick wins" and "bigger bets" buckets.
+ *
+ * Reuses existing infrastructure:
+ * - issue-vetting.ts    — per-issue vetting + scoring (with featureSignals)
+ * - issue-scoring.ts    — viability score (existing weights + feature bonuses)
+ * - http-cache.ts       — response cache
+ * - errors.ts           — auth/rate-limit propagation
+ *
+ * No state singletons — anchor repos are resolved from RepoScore[] passed in.
+ */
+
+import type { RepoScore } from "./schemas.js";
+
+/** Minimum merged-PR count for a repo to qualify as an anchor. */
+export const ANCHOR_THRESHOLD = 3;
+
+/**
+ * Resolve anchor repos: those with mergedPRCount >= ANCHOR_THRESHOLD,
+ * sorted by mergedPRCount descending. ScoutState stores repoScores as a
+ * Record<string, RepoScore>, so we read its values.
+ */
+export function resolveAnchorRepos(
+  repoScores: Record<string, RepoScore>,
+): string[] {
+  return Object.values(repoScores)
+    .filter((rs) => rs.mergedPRCount >= ANCHOR_THRESHOLD)
+    .sort((a, b) => b.mergedPRCount - a.mergedPRCount)
+    .map((rs) => rs.repo);
+}

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -12,7 +12,7 @@
  * No state singletons — anchor repos are resolved from RepoScore[] passed in.
  */
 
-import type { RepoScore } from "./schemas.js";
+import type { RepoScore, Horizon } from "./schemas.js";
 
 /** Minimum merged-PR count for a repo to qualify as an anchor. */
 export const ANCHOR_THRESHOLD = 3;
@@ -29,4 +29,26 @@ export function resolveAnchorRepos(
     .filter((rs) => rs.mergedPRCount >= ANCHOR_THRESHOLD)
     .sort((a, b) => b.mergedPRCount - a.mergedPRCount)
     .map((rs) => rs.repo);
+}
+
+/** Labels that promote an issue to the "bigger-bet" bucket. */
+export const BIGGER_BET_LABELS = new Set([
+  "roadmap",
+  "accepted-rfc",
+  "proposal",
+]);
+
+/**
+ * Classify an issue into "quick-win" or "bigger-bet" based on
+ * maintainer-commitment signals (milestone presence + label set).
+ */
+export function classifyHorizon(input: {
+  hasMilestone: boolean;
+  labels: string[];
+}): Horizon {
+  if (input.hasMilestone) return "bigger-bet";
+  for (const label of input.labels) {
+    if (BIGGER_BET_LABELS.has(label.toLowerCase())) return "bigger-bet";
+  }
+  return "quick-win";
 }

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -13,6 +13,7 @@
  */
 
 import type { RepoScore, Horizon } from "./schemas.js";
+import type { IssueCandidate } from "./types.js";
 
 /** Minimum merged-PR count for a repo to qualify as an anchor. */
 export const ANCHOR_THRESHOLD = 3;
@@ -51,4 +52,47 @@ export function classifyHorizon(input: {
     if (BIGGER_BET_LABELS.has(label.toLowerCase())) return "bigger-bet";
   }
   return "quick-win";
+}
+
+/** A vetted issue candidate stamped with its horizon classification. */
+export type FeatureCandidate = IssueCandidate & { horizon: Horizon };
+
+/**
+ * Split feature candidates into two buckets respecting a 60/40 target.
+ * If either bucket is short, redirect the deficit to the other bucket.
+ * Each bucket is sorted by viabilityScore descending.
+ */
+export function splitByHorizon(
+  candidates: FeatureCandidate[],
+  count: number,
+): { quickWins: FeatureCandidate[]; biggerBets: FeatureCandidate[] } {
+  const allQuick = candidates
+    .filter((c) => c.horizon === "quick-win")
+    .sort((a, b) => b.viabilityScore - a.viabilityScore);
+  const allBigger = candidates
+    .filter((c) => c.horizon === "bigger-bet")
+    .sort((a, b) => b.viabilityScore - a.viabilityScore);
+
+  const targetQuick = Math.round(count * 0.6);
+  const targetBigger = count - targetQuick;
+
+  const quickTaken = Math.min(allQuick.length, targetQuick);
+  const biggerTaken = Math.min(allBigger.length, targetBigger);
+
+  // Redirect deficits.
+  let quickFinal = quickTaken;
+  let biggerFinal = biggerTaken;
+  const quickDeficit = targetQuick - quickTaken;
+  const biggerDeficit = targetBigger - biggerTaken;
+  if (quickDeficit > 0) {
+    biggerFinal = Math.min(allBigger.length, biggerFinal + quickDeficit);
+  }
+  if (biggerDeficit > 0) {
+    quickFinal = Math.min(allQuick.length, quickFinal + biggerDeficit);
+  }
+
+  return {
+    quickWins: allQuick.slice(0, quickFinal),
+    biggerBets: allBigger.slice(0, biggerFinal),
+  };
 }

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -12,8 +12,21 @@
  * No state singletons — anchor repos are resolved from RepoScore[] passed in.
  */
 
+import type { Octokit } from "@octokit/rest";
 import type { RepoScore, Horizon } from "./schemas.js";
 import type { IssueCandidate } from "./types.js";
+import type { IssueVetter } from "./issue-vetting.js";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import { warn } from "./logger.js";
+import { sleep } from "./utils.js";
+
+const MODULE = "feature-discovery";
+
+/** Delay between per-repo issue lists, mirroring search-phases.INTER_QUERY_DELAY_MS. */
+const INTER_REPO_DELAY_MS = 2000;
+
+/** Minimum viability score for a feature candidate to surface — same as scout search. */
+const MIN_VIABILITY_SCORE = 40;
 
 /** Minimum merged-PR count for a repo to qualify as an anchor. */
 export const ANCHOR_THRESHOLD = 3;
@@ -94,5 +107,153 @@ export function splitByHorizon(
   return {
     quickWins: allQuick.slice(0, quickFinal),
     biggerBets: allBigger.slice(0, biggerFinal),
+  };
+}
+
+/** Feature labels used to filter issues. Any-of match. */
+export const FEATURE_LABELS = [
+  "enhancement",
+  "feature",
+  "feature-request",
+  "proposal",
+  "roadmap",
+  "accepted-rfc",
+] as const;
+
+/** Labels excluded from feature-mode results (overlap with `scout` territory). */
+export const FEATURE_EXCLUSION_LABELS = new Set([
+  "good first issue",
+  "bug",
+  "documentation",
+]);
+
+export const NO_ANCHORS_MESSAGE =
+  "No anchor repos yet (need 3+ merged PRs in a repo). Try `scout search` to build relationships first.";
+
+export const NO_RESULTS_MESSAGE =
+  "No open feature opportunities in your anchor repos right now. Check back next week, or try `scout search` for fix-mode work.";
+
+export interface FeatureSearchResult {
+  quickWins: FeatureCandidate[];
+  biggerBets: FeatureCandidate[];
+  anchorRepos: string[];
+  message: string | null;
+}
+
+export interface DiscoverFeaturesOptions {
+  octokit: Octokit;
+  vetter: IssueVetter;
+  repoScores: Record<string, RepoScore>;
+  count: number;
+}
+
+interface RawIssueItem {
+  html_url: string;
+  title?: string;
+  labels?: Array<{ name?: string } | string>;
+  comments?: number;
+  reactions?: { total_count?: number } | null;
+  milestone?: { number?: number } | null;
+  pull_request?: unknown;
+  assignee?: unknown;
+}
+
+function extractLabels(item: RawIssueItem): string[] {
+  if (!Array.isArray(item.labels)) return [];
+  return item.labels
+    .map((l) => (typeof l === "string" ? l : l?.name))
+    .filter((s): s is string => typeof s === "string");
+}
+
+function isFeatureIssue(item: RawIssueItem): boolean {
+  const labels = extractLabels(item).map((l) => l.toLowerCase());
+  if (labels.length === 0) return false;
+  if (labels.some((l) => FEATURE_EXCLUSION_LABELS.has(l))) return false;
+  return labels.some((l) => (FEATURE_LABELS as readonly string[]).includes(l));
+}
+
+/**
+ * Orchestrate `scout features`: anchor resolution → per-repo issue listing
+ * → feature-signal extraction → vetting → horizon classification → bucket split.
+ *
+ * Returns separate "quick wins" and "bigger bets" buckets per the 60/40 target,
+ * with a human-friendly message when no anchors qualify or no candidates pass
+ * the viability threshold.
+ *
+ * Auth (401) and rate-limit errors propagate. Per-repo and per-issue failures
+ * degrade gracefully via `warn`.
+ */
+export async function discoverFeatures(
+  opts: DiscoverFeaturesOptions,
+): Promise<FeatureSearchResult> {
+  const anchorRepos = resolveAnchorRepos(opts.repoScores);
+  if (anchorRepos.length === 0) {
+    return {
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: NO_ANCHORS_MESSAGE,
+    };
+  }
+
+  const candidates: FeatureCandidate[] = [];
+
+  for (let i = 0; i < anchorRepos.length; i++) {
+    if (i > 0) await sleep(INTER_REPO_DELAY_MS);
+    const [owner, repo] = anchorRepos[i].split("/");
+    let response;
+    try {
+      response = await opts.octokit.issues.listForRepo({
+        owner,
+        repo,
+        state: "open",
+        sort: "updated",
+        direction: "desc",
+        per_page: 20,
+      });
+    } catch (err: unknown) {
+      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      warn(
+        MODULE,
+        `failed to list issues for ${anchorRepos[i]}: ${errorMessage(err)}`,
+      );
+      continue;
+    }
+
+    const items = (response.data as RawIssueItem[]).filter(
+      (it) => !it.pull_request && !it.assignee && isFeatureIssue(it),
+    );
+
+    for (const item of items) {
+      const labels = extractLabels(item);
+      const hasMilestone = !!item.milestone;
+      const reactions = item.reactions?.total_count ?? 0;
+      const comments = item.comments ?? 0;
+      let candidate;
+      try {
+        candidate = await opts.vetter.vetIssue(item.html_url, {
+          featureSignals: { reactions, comments, hasMilestone },
+        });
+      } catch (err: unknown) {
+        if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+        warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
+        continue;
+      }
+      const horizon = classifyHorizon({ hasMilestone, labels });
+      candidates.push({ ...candidate, horizon });
+    }
+  }
+
+  // Drop low-viability results — same threshold as scout search.
+  const passing = candidates.filter(
+    (c) => c.viabilityScore >= MIN_VIABILITY_SCORE,
+  );
+
+  const split = splitByHorizon(passing, opts.count);
+  const total = split.quickWins.length + split.biggerBets.length;
+  return {
+    ...split,
+    anchorRepos,
+    message: total === 0 ? NO_RESULTS_MESSAGE : null,
   };
 }

--- a/packages/core/src/core/issue-scoring.test.ts
+++ b/packages/core/src/core/issue-scoring.test.ts
@@ -213,4 +213,72 @@ describe("calculateViabilityScore", () => {
     // 50 + 20 + 12 + 15 + 15 + 10 + 5 + 5 + 15 = 147 → clamped to 100
     expect(score).toBe(100);
   });
+
+  describe("calculateViabilityScore feature signals", () => {
+    const baseFeature: ViabilityScoreParams = {
+      repoScore: null,
+      hasExistingPR: false,
+      isClaimed: false,
+      clearRequirements: false,
+      hasContributionGuidelines: false,
+      issueUpdatedAt: new Date().toISOString(),
+      closedWithoutMergeCount: 0,
+      mergedPRCount: 0,
+      orgHasMergedPRs: false,
+    };
+
+    it("adds nothing when featureSignals is absent", () => {
+      const score = calculateViabilityScore(baseFeature);
+      // base 50 + freshness 15 = 65
+      expect(score).toBe(65);
+    });
+
+    it("adds reactions/2 capped at 10", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: { reactions: 4, comments: 0, hasMilestone: false },
+      });
+      expect(score).toBe(65 + 2); // 4/2 = 2
+    });
+
+    it("caps reactions bonus at 10", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: { reactions: 100, comments: 0, hasMilestone: false },
+      });
+      expect(score).toBe(65 + 10);
+    });
+
+    it("adds +5 when comments >= 5", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: { reactions: 0, comments: 5, hasMilestone: false },
+      });
+      expect(score).toBe(65 + 5);
+    });
+
+    it("adds nothing when comments < 5", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: { reactions: 0, comments: 4, hasMilestone: false },
+      });
+      expect(score).toBe(65);
+    });
+
+    it("adds +5 when hasMilestone is true", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: { reactions: 0, comments: 0, hasMilestone: true },
+      });
+      expect(score).toBe(65 + 5);
+    });
+
+    it("combines all feature bonuses", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: { reactions: 20, comments: 10, hasMilestone: true },
+      });
+      expect(score).toBe(65 + 10 + 5 + 5);
+    });
+  });
 });

--- a/packages/core/src/core/issue-scoring.ts
+++ b/packages/core/src/core/issue-scoring.ts
@@ -43,6 +43,16 @@ export interface ViabilityScoreParams {
   repoQualityBonus?: number;
   /** True when the repo matches one of the user's preferred project categories. */
   matchesPreferredCategory?: boolean;
+  /**
+   * Optional feature-mode signals. When present, applies reaction (cap +10),
+   * comment-depth (+5 if >=5), and milestone (+5) bonuses. When absent,
+   * scoring behavior is unchanged.
+   */
+  featureSignals?: {
+    reactions: number;
+    comments: number;
+    hasMilestone: boolean;
+  };
 }
 
 /**
@@ -120,6 +130,14 @@ export function calculateViabilityScore(params: ViabilityScoreParams): number {
   // Penalty for closed-without-merge history with no successful merges (-15)
   if (params.closedWithoutMergeCount > 0 && params.mergedPRCount === 0) {
     score -= 15;
+  }
+
+  // Feature signals: reactions, comment depth, and milestone bonuses
+  if (params.featureSignals) {
+    const fs = params.featureSignals;
+    score += Math.min(Math.floor(fs.reactions / 2), 10);
+    if (fs.comments >= 5) score += 5;
+    if (fs.hasMilestone) score += 5;
   }
 
   // Clamp to 0-100

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IssueCandidate, ProjectHealth } from "./types.js";
+import { calculateViabilityScore } from "./issue-scoring.js";
 
 // ── Mocks ──────────────────────────────────────────────────────────
 
@@ -560,6 +561,104 @@ describe("IssueVetter", () => {
           10,
         ),
       ).rejects.toThrow("Bad credentials");
+    });
+  });
+
+  // ── feature signals plumbing ──────────────────────────────────────
+
+  describe("IssueVetter feature signals", () => {
+    /**
+     * Helper: builds a vetter and a `scoreOf` reader. The mocked
+     * `calculateViabilityScore` is rewired to apply the same
+     * featureSignals math as the real implementation so we can verify
+     * the option threads through end-to-end without depending on the
+     * full scoring constants (which Task 2 already covers).
+     */
+    function buildVetterUnderTest() {
+      // Rewire the mock to apply ONLY the featureSignals delta on top of
+      // a fixed base — this isolates the plumbing under test.
+      vi.mocked(calculateViabilityScore).mockImplementation(
+        (params: Parameters<typeof calculateViabilityScore>[0]) => {
+          let score = 50;
+          if (params.featureSignals) {
+            const fs = params.featureSignals;
+            score += Math.min(Math.floor(fs.reactions / 2), 10);
+            if (fs.comments >= 5) score += 5;
+            if (fs.hasMilestone) score += 5;
+          }
+          return score;
+        },
+      );
+
+      // Fresh cache per call so signals are not collapsed into one entry.
+      vi.mocked(getHttpCache).mockReturnValue({
+        getIfFresh: vi.fn(() => null),
+        set: vi.fn(),
+      } as unknown as ReturnType<typeof getHttpCache>);
+
+      const vetter = makeVetter();
+      const scoreOf = (c: IssueCandidate) => c.viabilityScore;
+      return { vetter, scoreOf };
+    }
+
+    it("plumbs featureSignals through to scoring", async () => {
+      const baselineUrl = "https://github.com/foo/bar/issues/100";
+      const { vetter, scoreOf } = buildVetterUnderTest();
+      const baseline = await vetter.vetIssue(baselineUrl);
+      const boosted = await vetter.vetIssue(baselineUrl, {
+        featureSignals: { reactions: 20, comments: 10, hasMilestone: true },
+      });
+      // 10 (reactions cap) + 5 (comments) + 5 (milestone) = 20
+      expect(scoreOf(boosted)).toBe(scoreOf(baseline) + 20);
+    });
+
+    it("forwards featureSignals to calculateViabilityScore", async () => {
+      const { vetter } = buildVetterUnderTest();
+      await vetter.vetIssue("https://github.com/foo/bar/issues/101", {
+        featureSignals: { reactions: 7, comments: 2, hasMilestone: false },
+      });
+      expect(calculateViabilityScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          featureSignals: { reactions: 7, comments: 2, hasMilestone: false },
+        }),
+      );
+    });
+
+    it("omits featureSignals when caller does not pass them", async () => {
+      const { vetter } = buildVetterUnderTest();
+      await vetter.vetIssue("https://github.com/foo/bar/issues/102");
+      const call = vi.mocked(calculateViabilityScore).mock.calls.at(-1);
+      expect(call?.[0].featureSignals).toBeUndefined();
+    });
+
+    it("uses a distinct cache key per featureSignals combination", async () => {
+      // Pre-seed a cached IssueCandidate keyed under the no-signals key.
+      // If signals were not part of the cache key, the call below would
+      // return that pre-seeded result — and `set` would never run.
+      const sentinel = { issue: {}, viabilityScore: -1 } as IssueCandidate;
+      const getIfFresh = vi.fn((key: string) =>
+        key === "vet:https://github.com/foo/bar/issues/103" ? sentinel : null,
+      );
+      const set = vi.fn();
+      vi.mocked(getHttpCache).mockReturnValue({
+        getIfFresh,
+        set,
+      } as unknown as ReturnType<typeof getHttpCache>);
+
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(
+        "https://github.com/foo/bar/issues/103",
+        { featureSignals: { reactions: 4, comments: 0, hasMilestone: true } },
+      );
+
+      // Should NOT be the sentinel — different signal key avoided the collision.
+      expect(result).not.toBe(sentinel);
+      expect(set).toHaveBeenCalled();
+      // Confirm the lookup used a signals-suffixed key.
+      expect(getIfFresh).toHaveBeenCalledWith(
+        "vet:https://github.com/foo/bar/issues/103:r4c0m1",
+        expect.any(Number),
+      );
     });
   });
 });

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -55,6 +55,18 @@ const MAX_CONCURRENT_VETTING = 3;
 const VETTING_CACHE_TTL_MS = 15 * 60 * 1000;
 
 /**
+ * Feature-mode signals supplied by the caller (orchestrator) — the vetter
+ * does NOT extract these from the GitHub issue itself. When passed, they
+ * plumb through to `calculateViabilityScore` to apply reaction, comment-depth,
+ * and milestone bonuses.
+ */
+export type FeatureSignals = {
+  reactions: number;
+  comments: number;
+  hasMilestone: boolean;
+};
+
+/**
  * Read-only interface for accessing scout state during issue vetting.
  * Implementations may be backed by gist persistence, in-memory state, etc.
  */
@@ -89,11 +101,22 @@ export class IssueVetter {
   /**
    * Vet a specific issue — runs all checks and computes recommendation + viability score.
    * Results are cached for 15 minutes to avoid redundant API calls on repeated searches.
+   *
+   * `opts.featureSignals` are forwarded directly to scoring; the vetter does
+   * not derive them from the fetched issue. Cache key includes a digest of
+   * the signals so the same URL with different signals doesn't return a
+   * stale score.
    */
-  async vetIssue(issueUrl: string): Promise<IssueCandidate> {
+  async vetIssue(
+    issueUrl: string,
+    opts?: { featureSignals?: FeatureSignals },
+  ): Promise<IssueCandidate> {
     // Check vetting cache first — avoids ~6+ API calls per issue
     const cache = getHttpCache();
-    const cacheKey = `vet:${issueUrl}`;
+    const sigKey = opts?.featureSignals
+      ? `:r${opts.featureSignals.reactions}c${opts.featureSignals.comments}m${opts.featureSignals.hasMilestone ? 1 : 0}`
+      : "";
+    const cacheKey = `vet:${issueUrl}${sigKey}`;
     const cached = cache.getIfFresh(cacheKey, VETTING_CACHE_TTL_MS);
     if (
       cached &&
@@ -323,6 +346,7 @@ export class IssueVetter {
       orgHasMergedPRs,
       repoQualityBonus,
       matchesPreferredCategory: matchesCategory,
+      featureSignals: opts?.featureSignals,
     });
 
     const starredRepos = this.stateReader.getStarredRepos();

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -3,6 +3,8 @@ import {
   ScoutStateSchema,
   ScoutPreferencesSchema,
   RepoScoreSchema,
+  SavedCandidateSchema,
+  HorizonSchema,
 } from "./schemas.js";
 
 describe("ScoutStateSchema", () => {
@@ -219,5 +221,39 @@ describe("RepoScoreSchema", () => {
     });
     expect(score.stargazersCount).toBe(5000);
     expect(score.language).toBe("typescript");
+  });
+});
+
+describe("HorizonSchema", () => {
+  it("accepts quick-win and bigger-bet", () => {
+    expect(HorizonSchema.parse("quick-win")).toBe("quick-win");
+    expect(HorizonSchema.parse("bigger-bet")).toBe("bigger-bet");
+  });
+  it("rejects unknown values", () => {
+    expect(() => HorizonSchema.parse("medium")).toThrow();
+  });
+});
+
+describe("SavedCandidateSchema horizon field", () => {
+  const base = {
+    issueUrl: "https://github.com/foo/bar/issues/1",
+    repo: "foo/bar",
+    number: 1,
+    title: "t",
+    labels: [],
+    recommendation: "approve" as const,
+    viabilityScore: 80,
+    searchPriority: "merged_pr" as const,
+    firstSeenAt: "2026-05-08T00:00:00Z",
+    lastSeenAt: "2026-05-08T00:00:00Z",
+    lastScore: 80,
+  };
+  it("validates without horizon (backwards compat)", () => {
+    expect(() => SavedCandidateSchema.parse(base)).not.toThrow();
+  });
+  it("validates with horizon set", () => {
+    expect(() =>
+      SavedCandidateSchema.parse({ ...base, horizon: "quick-win" }),
+    ).not.toThrow();
   });
 });

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -152,6 +152,8 @@ export const SkippedIssueSchema = z.object({
 
 // ── Saved candidate schema ─────────────────────────────────────────
 
+export const HorizonSchema = z.enum(["quick-win", "bigger-bet"]);
+
 export const SavedCandidateSchema = z.object({
   issueUrl: z.string(),
   repo: z.string(),
@@ -164,6 +166,7 @@ export const SavedCandidateSchema = z.object({
   firstSeenAt: z.string(),
   lastSeenAt: z.string(),
   lastScore: z.number(),
+  horizon: HorizonSchema.optional(),
 });
 
 // ── Scout preferences schema ────────────────────────────────────────
@@ -247,6 +250,7 @@ export type LinkedPR = z.infer<typeof LinkedPRSchema>;
 export type IssueVettingResult = z.infer<typeof IssueVettingResultSchema>;
 export type TrackedIssue = z.infer<typeof TrackedIssueSchema>;
 export type ScoutPreferences = z.infer<typeof ScoutPreferencesSchema>;
+export type Horizon = z.infer<typeof HorizonSchema>;
 export type SavedCandidate = z.infer<typeof SavedCandidateSchema>;
 export type SkippedIssue = z.infer<typeof SkippedIssueSchema>;
 export type ScoutState = z.infer<typeof ScoutStateSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export type {
   StoredOpenPR,
   SearchStrategy,
   SkippedIssue,
+  Horizon,
 } from "./core/schemas.js";
 
 // Schemas (for consumers who need runtime validation)
@@ -66,6 +67,7 @@ export {
   ProjectCategorySchema,
   SearchStrategySchema,
   SkippedIssueSchema,
+  HorizonSchema,
 } from "./core/schemas.js";
 
 // Utilities
@@ -73,8 +75,27 @@ export { requireGitHubToken, getGitHubToken } from "./core/utils.js";
 
 // Internal classes (for advanced use)
 export { IssueDiscovery } from "./core/issue-discovery.js";
-export { IssueVetter, type ScoutStateReader } from "./core/issue-vetting.js";
+export {
+  IssueVetter,
+  type ScoutStateReader,
+  type FeatureSignals,
+} from "./core/issue-vetting.js";
 export {
   scanForAntiLLMPolicy,
   ANTI_LLM_KEYWORDS,
 } from "./core/anti-llm-policy.js";
+
+// Feature discovery API
+export {
+  discoverFeatures,
+  resolveAnchorRepos,
+  classifyHorizon,
+  splitByHorizon,
+  ANCHOR_THRESHOLD,
+  FEATURE_LABELS,
+  NO_ANCHORS_MESSAGE,
+  NO_RESULTS_MESSAGE,
+  type FeatureCandidate,
+  type FeatureSearchResult,
+  type DiscoverFeaturesOptions,
+} from "./core/feature-discovery.js";

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -1,7 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createScout, OssScout } from "./scout.js";
 import { ScoutStateSchema } from "./core/schemas.js";
 import type { ScoutState } from "./core/schemas.js";
+
+vi.mock("./core/feature-discovery.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./core/feature-discovery.js")>();
+  return {
+    ...actual,
+    discoverFeatures: vi.fn(),
+  };
+});
+
+import { discoverFeatures } from "./core/feature-discovery.js";
 
 function makeState(overrides: Partial<ScoutState> = {}): ScoutState {
   return ScoutStateSchema.parse({ version: 1, ...overrides });
@@ -292,5 +303,74 @@ describe("OssScout", () => {
       const score = scout.getRepoScoreRecord("good/repo");
       expect(score!.score).toBeGreaterThan(5); // base is 5, merged adds
     });
+  });
+});
+
+describe("OssScout.features", () => {
+  it("delegates to discoverFeatures and persists results with horizon stamped", async () => {
+    const fakeQuick = {
+      issue: {
+        url: "https://github.com/foo/bar/issues/1",
+        repo: "foo/bar",
+        number: 1,
+        title: "qw",
+        labels: ["enhancement"],
+        updatedAt: "2026-05-08",
+      },
+      vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+      projectHealth: {},
+      antiLLMPolicy: { matched: false, matchedKeywords: [], sourceFile: null },
+      slmTriage: null,
+      recommendation: "approve",
+      reasonsToApprove: [],
+      reasonsToSkip: [],
+      viabilityScore: 80,
+      searchPriority: "merged_pr",
+      horizon: "quick-win" as const,
+    };
+    const fakeBigger = {
+      ...fakeQuick,
+      issue: {
+        ...fakeQuick.issue,
+        url: "https://github.com/foo/bar/issues/2",
+        number: 2,
+      },
+      horizon: "bigger-bet" as const,
+    };
+    vi.mocked(discoverFeatures).mockResolvedValue({
+      quickWins: [fakeQuick],
+      biggerBets: [fakeBigger],
+      anchorRepos: ["foo/bar"],
+      message: null,
+    } as never);
+
+    const state = ScoutStateSchema.parse({
+      version: 1,
+      repoScores: {
+        "foo/bar": {
+          repo: "foo/bar",
+          score: 5,
+          mergedPRCount: 4,
+          closedWithoutMergeCount: 0,
+          avgResponseDays: null,
+          lastEvaluatedAt: "2026-05-08T00:00:00Z",
+          signals: {
+            hasActiveMaintainers: true,
+            isResponsive: true,
+            hasHostileComments: false,
+          },
+        },
+      },
+    });
+    const scout = new OssScout("test-token", state);
+    const result = await scout.features({ count: 10 });
+    expect(result.quickWins).toHaveLength(1);
+    expect(result.biggerBets).toHaveLength(1);
+    expect(scout.getSavedResults().find((r) => r.number === 1)?.horizon).toBe(
+      "quick-win",
+    );
+    expect(scout.getSavedResults().find((r) => r.number === 2)?.horizon).toBe(
+      "bigger-bet",
+    );
   });
 });

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -6,7 +6,12 @@
  */
 
 import { IssueDiscovery } from "./core/issue-discovery.js";
+import { IssueVetter } from "./core/issue-vetting.js";
 import type { ScoutStateReader } from "./core/issue-vetting.js";
+import {
+  discoverFeatures,
+  type FeatureSearchResult,
+} from "./core/feature-discovery.js";
 import { ScoutStateSchema } from "./core/schemas.js";
 import type {
   ScoutState,
@@ -14,6 +19,7 @@ import type {
   RepoScore,
   SavedCandidate,
   SkippedIssue,
+  Horizon,
 } from "./core/schemas.js";
 import type {
   ScoutConfig,
@@ -217,6 +223,29 @@ export class OssScout implements ScoutStateReader {
       this,
     );
     return discovery.vetIssue(issueUrl);
+  }
+
+  /**
+   * `scout features` — surfaces feature-scoped contribution opportunities
+   * in repos where the user has 3+ merged PRs, ranked into separate
+   * "quick wins" and "bigger bets" buckets.
+   */
+  async features(options?: { count?: number }): Promise<FeatureSearchResult> {
+    const count = options?.count ?? 10;
+    const octokit = getOctokit(this.githubToken);
+    const vetter = new IssueVetter(octokit, this);
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: this.state.repoScores ?? {},
+      count,
+    });
+
+    this.saveResults([...result.quickWins, ...result.biggerBets]);
+    this.state.lastSearchAt = new Date().toISOString();
+    this.dirty = true;
+
+    return result;
   }
 
   // ── Batch Vetting ───────────────────────────────────────────────────
@@ -493,7 +522,11 @@ export class OssScout implements ScoutStateReader {
    * If a candidate already exists, updates score/recommendation/lastSeenAt
    * but preserves firstSeenAt.
    */
-  saveResults(candidates: IssueCandidate[]): void {
+  saveResults(
+    candidates: Array<
+      IssueCandidate | (IssueCandidate & { horizon?: Horizon })
+    >,
+  ): void {
     const now = new Date().toISOString();
     const existing = new Map(
       (this.state.savedResults ?? []).map((r) => [r.issueUrl, r]),
@@ -513,6 +546,7 @@ export class OssScout implements ScoutStateReader {
         firstSeenAt: prev?.firstSeenAt ?? now,
         lastSeenAt: now,
         lastScore: c.viabilityScore,
+        horizon: "horizon" in c ? c.horizon : undefined,
       });
     }
 

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -33,6 +33,12 @@ function createMockScout(overrides: Partial<OssScout> = {}): OssScout {
     unskipIssue: vi.fn(),
     clearSkippedIssues: vi.fn(),
     checkpoint: vi.fn().mockResolvedValue(true),
+    features: vi.fn().mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: null,
+    }),
     ...overrides,
   } as unknown as OssScout;
 }
@@ -64,8 +70,8 @@ describe("registerTools", () => {
     registerTools(server, scout);
   });
 
-  it("registers all five tools", () => {
-    expect(server.tool).toHaveBeenCalledTimes(5);
+  it("registers all six tools", () => {
+    expect(server.tool).toHaveBeenCalledTimes(6);
 
     const calls = vi.mocked(server.tool).mock.calls;
     const names = calls.map((c) => c[0]);
@@ -74,6 +80,7 @@ describe("registerTools", () => {
     expect(names).toContain("skip");
     expect(names).toContain("config");
     expect(names).toContain("config-set");
+    expect(names).toContain("scout-features");
   });
 
   describe("search tool execution", () => {
@@ -127,6 +134,30 @@ describe("registerTools", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("API rate limited");
+    });
+  });
+
+  describe("scout-features tool execution", () => {
+    it("returns JSON text content on success", async () => {
+      const featuresResult = {
+        quickWins: [],
+        biggerBets: [],
+        anchorRepos: [],
+        message: "No anchor repos yet",
+      };
+      const local = createMockScout({
+        features: vi.fn().mockResolvedValue(featuresResult),
+      } as Partial<OssScout>);
+      const localServer = new McpServer({ name: "t", version: "0.0.1" });
+      vi.spyOn(localServer, "tool");
+      registerTools(localServer, local);
+      const handler = getToolHandler(localServer, "scout-features");
+      const result = (await handler({ maxResults: 5 }, {})) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0].text)).toMatchObject(featuresResult);
     });
   });
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -67,6 +67,35 @@ export function registerTools(server: McpServer, scout: OssScout): void {
   );
 
   server.tool(
+    "scout-features",
+    "Surface feature-scoped contribution opportunities in repos where you have 3+ merged PRs",
+    {
+      maxResults: z
+        .number()
+        .optional()
+        .describe("Maximum number of results to return (default 10)"),
+    },
+    async ({ maxResults }) => {
+      try {
+        const result = await withTimeout(
+          scout.features({ count: maxResults ?? 10 }),
+        );
+        scout.saveResults([...result.quickWins, ...result.biggerBets]);
+        await scout.checkpoint();
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error: ${msg}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     "vet",
     "Vet a specific GitHub issue for contribution viability",
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   vite: ^8.0.5
   hono: '>=4.12.14'
   '@hono/node-server': '>=1.19.13'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -896,8 +897,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2066,7 +2067,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2330,7 +2331,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Implements `scout features` per design in `docs/superpowers/specs/2026-05-08-scout-features-design.md`. Closes #92.

## Why

`scout` optimizes for low-friction merges (small bugs). `scout features` adds a complementary objective function: feature-scoped opportunities in repos where the user has earned trust (3+ merged PRs).

## Design decisions (locked during brainstorm)

- **Audience:** relationship-anchored only (3+ merged PRs in a repo).
- **Time horizon:** both quick wins and bigger bets, ranked into separate buckets (60/40 split with deficit-redirect).
- **Surface:** new `scout features [count]` subcommand sharing the existing scoring, vetting, cache, and rate-limit infrastructure.
- **Signals (v1):** labels, reactions, comment count, milestone presence. Project boards / ROADMAP.md / wontfix-no-contributor detection deferred to v2.
- **Horizon classifier:** bigger bet if issue has a milestone OR carries `roadmap` / `accepted-rfc` / `proposal` labels.
- **Linked-PR handling:** same -30 penalty as `scout`. Stalled-PR revival mode is a future follow-up.

## What changed

- New core module `feature-discovery.ts` with pure helpers (`resolveAnchorRepos`, `classifyHorizon`, `splitByHorizon`) and the `discoverFeatures` orchestrator.
- `calculateViabilityScore` accepts an optional `featureSignals` parameter (reactions / comments / milestone). When absent, behavior is unchanged.
- `IssueVetter.vetIssue(url, opts?)` plumbs `featureSignals` into scoring; cache key gains a signal-derived suffix when present.
- `SavedCandidate.horizon` (optional) stamps each saved feature-mode result with its bucket.
- `OssScout.features({ count })` public API method on the core class.
- `scout features [count]` CLI subcommand with sectioned terminal output and JSON envelope.
- `scout-features` MCP tool.
- Public exports for the new types and helpers in `@oss-scout/core`.

## Test plan

- [x] All unit tests pass (619 core + 17 mcp = 636)
- [x] Lint, format, typecheck pass
- [x] Bundle rebuilds (cli 559kb, mcp 1.4mb)
- [ ] CI green on all matrix nodes
- [ ] Smoke test: `pnpm start -- features --json` returns the expected envelope

## Out of scope (filed as follow-ups)

- Project-board / `ROADMAP.md` scraping
- Wontfix-no-contributor detection
- Stalled-PR revival mode
- Configurable anchor threshold
- Configurable quick-wins / bigger-bets split ratio
- Cross-repo / first-touch broad mode