### PR TITLE
feat: configurable anchor threshold + split ratio for scout features (#98 #99)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -199,57 +199,95 @@ program
     "Surface feature-scoped opportunities in repos where you have 3+ merged PRs",
   )
   .option("--json", "Output as JSON")
-  .action(async (count: string | undefined, options: { json?: boolean }) => {
-    try {
-      const { runFeatures } = await import("./commands/features.js");
-      const maxResults = count ? parseInt(count, 10) : 10;
-      if (isNaN(maxResults) || maxResults < 1 || maxResults > 50) {
-        console.error("Error: count must be an integer between 1 and 50");
-        process.exit(1);
-      }
-      const state = loadLocalState();
-      const result = await runFeatures({ maxResults, state });
-      if (options.json) {
-        console.log(formatJsonSuccess(result));
-      } else {
-        const total = result.quickWins.length + result.biggerBets.length;
-        if (result.message) {
-          console.log(`\n${result.message}\n`);
+  .option("--anchor-threshold <n>", "Override featuresAnchorThreshold (1-50)")
+  .option("--split-ratio <r>", "Override featuresSplitRatio (0-1, e.g. 0.6)")
+  .action(
+    async (
+      count: string | undefined,
+      options: {
+        json?: boolean;
+        anchorThreshold?: string;
+        splitRatio?: string;
+      },
+    ) => {
+      try {
+        const { runFeatures } = await import("./commands/features.js");
+        const maxResults = count ? parseInt(count, 10) : 10;
+        if (isNaN(maxResults) || maxResults < 1 || maxResults > 50) {
+          console.error("Error: count must be an integer between 1 and 50");
+          process.exit(1);
         }
-        if (total === 0) return;
-        console.log(
-          `\n🎯 Feature opportunities in your anchor repos (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
-        );
-        console.log(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
-        if (result.quickWins.length) {
-          console.log(
-            "── Quick wins ─────────────────────────────────────────",
-          );
-          for (const c of result.quickWins) {
-            console.log(
-              `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+        let anchorThreshold: number | undefined;
+        if (options.anchorThreshold !== undefined) {
+          const parsed = parseInt(options.anchorThreshold, 10);
+          if (isNaN(parsed) || parsed < 1 || parsed > 50) {
+            console.error(
+              "Error: --anchor-threshold must be an integer between 1 and 50",
             );
-            console.log(`     ${c.issue.url}`);
+            process.exit(1);
           }
-          console.log("");
+          anchorThreshold = parsed;
         }
-        if (result.biggerBets.length) {
-          console.log(
-            "── Bigger bets ────────────────────────────────────────",
-          );
-          for (const c of result.biggerBets) {
-            console.log(
-              `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+        let splitRatio: number | undefined;
+        if (options.splitRatio !== undefined) {
+          const parsed = Number.parseFloat(options.splitRatio);
+          if (isNaN(parsed) || parsed < 0 || parsed > 1) {
+            console.error(
+              "Error: --split-ratio must be a number between 0 and 1",
             );
-            console.log(`     ${c.issue.url}`);
+            process.exit(1);
           }
-          console.log("");
+          splitRatio = parsed;
         }
+        const state = loadLocalState();
+        const result = await runFeatures({
+          maxResults,
+          state,
+          anchorThreshold,
+          splitRatio,
+        });
+        if (options.json) {
+          console.log(formatJsonSuccess(result));
+        } else {
+          const total = result.quickWins.length + result.biggerBets.length;
+          if (result.message) {
+            console.log(`\n${result.message}\n`);
+          }
+          if (total === 0) return;
+          console.log(
+            `\n🎯 Feature opportunities in your anchor repos (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
+          );
+          console.log(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
+          if (result.quickWins.length) {
+            console.log(
+              "── Quick wins ─────────────────────────────────────────",
+            );
+            for (const c of result.quickWins) {
+              console.log(
+                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+              );
+              console.log(`     ${c.issue.url}`);
+            }
+            console.log("");
+          }
+          if (result.biggerBets.length) {
+            console.log(
+              "── Bigger bets ────────────────────────────────────────",
+            );
+            for (const c of result.biggerBets) {
+              console.log(
+                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+              );
+              console.log(`     ${c.issue.url}`);
+            }
+            console.log("");
+          }
+        }
+      } catch (err) {
+        handleCommandError(err, options);
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    },
+  );
 
 // ── results command ────────────────────────────────────────────────
 

--- a/packages/core/src/commands/config.test.ts
+++ b/packages/core/src/commands/config.test.ts
@@ -300,6 +300,46 @@ describe("config command", () => {
       });
     });
 
+    describe("features tunables", () => {
+      it("should set featuresAnchorThreshold as integer", () => {
+        writeState(makeState());
+
+        const result = runConfigSet("featuresAnchorThreshold", "5");
+
+        expect(result.featuresAnchorThreshold).toBe(5);
+        expect(readState().preferences.featuresAnchorThreshold).toBe(5);
+      });
+
+      it("should reject featuresAnchorThreshold above max", () => {
+        writeState(makeState());
+
+        expect(() => runConfigSet("featuresAnchorThreshold", "51")).toThrow();
+      });
+
+      it("should set featuresSplitRatio as float", () => {
+        writeState(makeState());
+
+        const result = runConfigSet("featuresSplitRatio", "0.7");
+
+        expect(result.featuresSplitRatio).toBe(0.7);
+        expect(readState().preferences.featuresSplitRatio).toBe(0.7);
+      });
+
+      it("should reject featuresSplitRatio above 1", () => {
+        writeState(makeState());
+
+        expect(() => runConfigSet("featuresSplitRatio", "1.5")).toThrow();
+      });
+
+      it("should reject non-numeric featuresSplitRatio", () => {
+        writeState(makeState());
+
+        expect(() => runConfigSet("featuresSplitRatio", "abc")).toThrow(
+          "Invalid number",
+        );
+      });
+    });
+
     describe("broad phase settings", () => {
       it("should set broadPhaseDelayMs", () => {
         writeState(makeState());

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -14,7 +14,7 @@ import type { ScoutPreferences } from "../core/schemas.js";
 import { ValidationError } from "../core/errors.js";
 
 type FieldConfig =
-  | { type: "array" | "number" | "boolean" | "string" }
+  | { type: "array" | "number" | "float" | "boolean" | "string" }
   | { type: "enum" | "enum-array"; validValues: readonly string[] };
 
 const FIELD_CONFIGS: Record<string, FieldConfig> = {
@@ -41,6 +41,8 @@ const FIELD_CONFIGS: Record<string, FieldConfig> = {
   githubUsername: { type: "string" },
   broadPhaseDelayMs: { type: "number" },
   skipBroadWhenSufficientResults: { type: "number" },
+  featuresAnchorThreshold: { type: "number" },
+  featuresSplitRatio: { type: "float" },
 };
 
 function parseBoolean(value: string): boolean {
@@ -54,6 +56,14 @@ function parseBoolean(value: string): boolean {
 
 function parseNumber(value: string, key: string): number {
   const num = parseInt(value, 10);
+  if (isNaN(num)) {
+    throw new ValidationError(`Invalid number for "${key}": "${value}"`);
+  }
+  return num;
+}
+
+function parseFloat(value: string, key: string): number {
+  const num = Number.parseFloat(value);
   if (isNaN(num)) {
     throw new ValidationError(`Invalid number for "${key}": "${value}"`);
   }
@@ -131,6 +141,8 @@ export function runConfigShow(): void {
   console.log(
     `  skipBroadWhenSufficientResults: ${prefs.skipBroadWhenSufficientResults}`,
   );
+  console.log(`  featuresAnchorThreshold: ${prefs.featuresAnchorThreshold}`);
+  console.log(`  featuresSplitRatio:    ${prefs.featuresSplitRatio}`);
   console.log();
 }
 
@@ -167,6 +179,10 @@ export function runConfigSet(key: string, value: string): ScoutPreferences {
 
     case "number":
       (prefs as Record<string, unknown>)[key] = parseNumber(value, key);
+      break;
+
+    case "float":
+      (prefs as Record<string, unknown>)[key] = parseFloat(value, key);
       break;
 
     case "array": {

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -1,19 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { runFeatures } from "./features.js";
+import { createScout } from "../scout.js";
 
 vi.mock("../scout.js", () => ({
-  createScout: vi.fn().mockResolvedValue({
-    features: vi.fn().mockResolvedValue({
-      quickWins: [],
-      biggerBets: [],
-      anchorRepos: [],
-      message: "No anchor repos yet",
-    }),
-    getState: () => ({}),
-    saveResults: vi.fn(),
-    checkpoint: vi.fn().mockResolvedValue(true),
-    getRepoScoreRecord: vi.fn().mockReturnValue(undefined),
-  }),
+  createScout: vi.fn(),
 }));
 
 vi.mock("../core/utils.js", () => ({
@@ -25,10 +15,50 @@ vi.mock("../core/local-state.js", () => ({
 }));
 
 describe("runFeatures", () => {
+  let featuresFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    featuresFn = vi.fn().mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: "No anchor repos yet",
+    });
+    vi.mocked(createScout).mockResolvedValue({
+      features: featuresFn,
+      getState: () => ({}),
+      saveResults: vi.fn(),
+      checkpoint: vi.fn().mockResolvedValue(true),
+      getRepoScoreRecord: vi.fn().mockReturnValue(undefined),
+    } as never);
+  });
+
   it("returns the features result envelope", async () => {
     const out = await runFeatures({ maxResults: 10 });
     expect(out.quickWins).toEqual([]);
     expect(out.biggerBets).toEqual([]);
     expect(out.message).toBe("No anchor repos yet");
+  });
+
+  it("forwards anchorThreshold and splitRatio to scout.features", async () => {
+    await runFeatures({
+      maxResults: 8,
+      anchorThreshold: 4,
+      splitRatio: 0.3,
+    });
+    expect(featuresFn).toHaveBeenCalledWith({
+      count: 8,
+      anchorThreshold: 4,
+      splitRatio: 0.3,
+    });
+  });
+
+  it("passes undefined overrides through unchanged", async () => {
+    await runFeatures({ maxResults: 5 });
+    expect(featuresFn).toHaveBeenCalledWith({
+      count: 5,
+      anchorThreshold: undefined,
+      splitRatio: undefined,
+    });
   });
 });

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -40,6 +40,8 @@ export interface FeaturesOutput {
 interface FeaturesCommandOptions {
   maxResults: number;
   state?: ScoutState;
+  anchorThreshold?: number;
+  splitRatio?: number;
 }
 
 function mapQuickWin(c: FeatureCandidate): FeaturesOutput["quickWins"][number] {
@@ -86,7 +88,11 @@ export async function runFeatures(
       })
     : await createScout({ githubToken: token });
 
-  const result = await scout.features({ count: options.maxResults });
+  const result = await scout.features({
+    count: options.maxResults,
+    anchorThreshold: options.anchorThreshold,
+    splitRatio: options.splitRatio,
+  });
 
   saveLocalState(scout.getState() as ScoutState);
   const persisted = await scout.checkpoint();

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -48,6 +48,17 @@ describe("resolveAnchorRepos", () => {
     );
     expect(out).toEqual(["c/d", "e/f", "a/b"]);
   });
+  it("honors an explicit threshold override", () => {
+    const out = resolveAnchorRepos(
+      mkScores(["a/b", 3], ["c/d", 5], ["e/f", 8]),
+      5,
+    );
+    expect(out).toEqual(["e/f", "c/d"]);
+  });
+  it("defaults to ANCHOR_THRESHOLD when threshold is undefined", () => {
+    const out = resolveAnchorRepos(mkScores(["a/b", 2], ["c/d", 3]), undefined);
+    expect(out).toEqual(["c/d"]);
+  });
 });
 
 describe("classifyHorizon", () => {
@@ -166,6 +177,21 @@ describe("splitByHorizon 60/40 split", () => {
       95, 92, 88, 85,
     ]);
   });
+  it("honors an explicit ratio override (0.5 = 5+5 at count 10)", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 10, 0.5);
+    expect(out.quickWins).toHaveLength(5);
+    expect(out.biggerBets).toHaveLength(5);
+  });
+  it("ratio 1.0 puts all into quick wins", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 5, 1);
+    expect(out.quickWins).toHaveLength(5);
+    expect(out.biggerBets).toHaveLength(0);
+  });
+  it("ratio 0 puts all into bigger bets when both available", () => {
+    const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 4, 0);
+    expect(out.quickWins).toHaveLength(0);
+    expect(out.biggerBets).toHaveLength(4);
+  });
 });
 
 describe("discoverFeatures orchestrator", () => {
@@ -280,6 +306,90 @@ describe("discoverFeatures orchestrator", () => {
       "https://github.com/a/b/issues/2",
       { featureSignals: { reactions: 50, comments: 30, hasMilestone: true } },
     );
+  });
+
+  it("honors anchorThreshold and splitRatio overrides", async () => {
+    // Build issues so quick-win and bigger-bet candidates both exist.
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: [
+            {
+              html_url: "https://github.com/a/b/issues/1",
+              title: "qw",
+              labels: [{ name: "enhancement" }],
+              comments: 1,
+              reactions: { total_count: 1 },
+              milestone: null,
+              pull_request: undefined,
+              assignee: null,
+            },
+            {
+              html_url: "https://github.com/a/b/issues/2",
+              title: "bb",
+              labels: [{ name: "proposal" }],
+              comments: 1,
+              reactions: { total_count: 1 },
+              milestone: { number: 1 },
+              pull_request: undefined,
+              assignee: null,
+            },
+          ],
+        }),
+      },
+    } as never;
+    const vetter = {
+      vetIssue: vi.fn().mockImplementation(async (url: string) => ({
+        issue: {
+          url,
+          repo: "a/b",
+          number: 1,
+          title: "t",
+          labels: [],
+          updatedAt: "2026-05-01",
+        },
+        vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+        projectHealth: {},
+        antiLLMPolicy: {
+          matched: false,
+          matchedKeywords: [],
+          sourceFile: null,
+        },
+        slmTriage: null,
+        recommendation: "approve",
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        viabilityScore: 80,
+        searchPriority: "merged_pr",
+      })),
+    } as never;
+
+    // anchorThreshold 10 → "a/b" (mergedPRCount 4) is below threshold; no anchors.
+    const tightened = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 10,
+      anchorThreshold: 10,
+    });
+    expect(tightened.anchorRepos).toEqual([]);
+    expect(tightened.message).toContain("No anchor repos yet");
+
+    // anchorThreshold 1 enables the anchor; splitRatio 0.5 → 1 quick + 1 bigger
+    // (rounding behavior with count=2 and one of each candidate).
+    vi.mocked(octokit.issues.listForRepo).mockClear();
+    vi.mocked(vetter.vetIssue).mockClear();
+    const split = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 2,
+      anchorThreshold: 1,
+      splitRatio: 0.5,
+    });
+    expect(split.anchorRepos).toEqual(["a/b"]);
+    expect(split.quickWins).toHaveLength(1);
+    expect(split.biggerBets).toHaveLength(1);
   });
 
   it("propagates auth and rate-limit errors", async () => {

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -28,19 +28,25 @@ const INTER_REPO_DELAY_MS = 2000;
 /** Minimum viability score for a feature candidate to surface — same as scout search. */
 const MIN_VIABILITY_SCORE = 40;
 
-/** Minimum merged-PR count for a repo to qualify as an anchor. */
+/** Default minimum merged-PR count for a repo to qualify as an anchor. */
 export const ANCHOR_THRESHOLD = 3;
 
+/** Default quick-wins / bigger-bets split ratio (60/40). */
+export const DEFAULT_SPLIT_RATIO = 0.6;
+
 /**
- * Resolve anchor repos: those with mergedPRCount >= ANCHOR_THRESHOLD,
+ * Resolve anchor repos: those with mergedPRCount >= threshold (default 3),
  * sorted by mergedPRCount descending. ScoutState stores repoScores as a
  * Record<string, RepoScore>, so we read its values.
+ *
+ * @param threshold Override minimum merged-PR count (#98).
  */
 export function resolveAnchorRepos(
   repoScores: Record<string, RepoScore>,
+  threshold: number = ANCHOR_THRESHOLD,
 ): string[] {
   return Object.values(repoScores)
-    .filter((rs) => rs.mergedPRCount >= ANCHOR_THRESHOLD)
+    .filter((rs) => rs.mergedPRCount >= threshold)
     .sort((a, b) => b.mergedPRCount - a.mergedPRCount)
     .map((rs) => rs.repo);
 }
@@ -71,13 +77,17 @@ export function classifyHorizon(input: {
 export type FeatureCandidate = IssueCandidate & { horizon: Horizon };
 
 /**
- * Split feature candidates into two buckets respecting a 60/40 target.
- * If either bucket is short, redirect the deficit to the other bucket.
- * Each bucket is sorted by viabilityScore descending.
+ * Split feature candidates into two buckets respecting a configurable
+ * quick-wins / bigger-bets ratio (default 60/40). If either bucket is
+ * short, redirect the deficit to the other bucket. Each bucket is
+ * sorted by viabilityScore descending.
+ *
+ * @param ratio Fraction (0..1) of `count` to allocate to quick wins (#99).
  */
 export function splitByHorizon(
   candidates: FeatureCandidate[],
   count: number,
+  ratio: number = DEFAULT_SPLIT_RATIO,
 ): { quickWins: FeatureCandidate[]; biggerBets: FeatureCandidate[] } {
   const allQuick = candidates
     .filter((c) => c.horizon === "quick-win")
@@ -86,7 +96,7 @@ export function splitByHorizon(
     .filter((c) => c.horizon === "bigger-bet")
     .sort((a, b) => b.viabilityScore - a.viabilityScore);
 
-  const targetQuick = Math.round(count * 0.6);
+  const targetQuick = Math.round(count * ratio);
   const targetBigger = count - targetQuick;
 
   const quickTaken = Math.min(allQuick.length, targetQuick);
@@ -145,6 +155,10 @@ export interface DiscoverFeaturesOptions {
   vetter: IssueVetter;
   repoScores: Record<string, RepoScore>;
   count: number;
+  /** Override default anchor threshold (3 merged PRs). */
+  anchorThreshold?: number;
+  /** Override default split ratio (0.6 = 60% quick wins, 40% bigger bets). */
+  splitRatio?: number;
 }
 
 interface RawIssueItem {
@@ -186,7 +200,7 @@ function isFeatureIssue(item: RawIssueItem): boolean {
 export async function discoverFeatures(
   opts: DiscoverFeaturesOptions,
 ): Promise<FeatureSearchResult> {
-  const anchorRepos = resolveAnchorRepos(opts.repoScores);
+  const anchorRepos = resolveAnchorRepos(opts.repoScores, opts.anchorThreshold);
   if (anchorRepos.length === 0) {
     return {
       quickWins: [],
@@ -249,7 +263,7 @@ export async function discoverFeatures(
     (c) => c.viabilityScore >= MIN_VIABILITY_SCORE,
   );
 
-  const split = splitByHorizon(passing, opts.count);
+  const split = splitByHorizon(passing, opts.count, opts.splitRatio);
   const total = split.quickWins.length + split.biggerBets.length;
   return {
     ...split,

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -177,6 +177,48 @@ describe("ScoutPreferencesSchema", () => {
     });
     expect(prefs.skipBroadWhenSufficientResults).toBe(0);
   });
+
+  it("defaults featuresAnchorThreshold to 3 and featuresSplitRatio to 0.6", () => {
+    const prefs = ScoutPreferencesSchema.parse({});
+    expect(prefs.featuresAnchorThreshold).toBe(3);
+    expect(prefs.featuresSplitRatio).toBe(0.6);
+  });
+
+  it("accepts custom featuresAnchorThreshold and featuresSplitRatio", () => {
+    const prefs = ScoutPreferencesSchema.parse({
+      featuresAnchorThreshold: 5,
+      featuresSplitRatio: 0.4,
+    });
+    expect(prefs.featuresAnchorThreshold).toBe(5);
+    expect(prefs.featuresSplitRatio).toBe(0.4);
+  });
+
+  it("rejects featuresAnchorThreshold below 1", () => {
+    expect(() =>
+      ScoutPreferencesSchema.parse({ featuresAnchorThreshold: 0 }),
+    ).toThrow();
+  });
+
+  it("rejects featuresAnchorThreshold above 50", () => {
+    expect(() =>
+      ScoutPreferencesSchema.parse({ featuresAnchorThreshold: 51 }),
+    ).toThrow();
+  });
+
+  it("rejects non-integer featuresAnchorThreshold", () => {
+    expect(() =>
+      ScoutPreferencesSchema.parse({ featuresAnchorThreshold: 3.5 }),
+    ).toThrow();
+  });
+
+  it("rejects featuresSplitRatio outside 0..1", () => {
+    expect(() =>
+      ScoutPreferencesSchema.parse({ featuresSplitRatio: -0.1 }),
+    ).toThrow();
+    expect(() =>
+      ScoutPreferencesSchema.parse({ featuresSplitRatio: 1.1 }),
+    ).toThrow();
+  });
 });
 
 describe("RepoScoreSchema", () => {

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -204,6 +204,18 @@ export const ScoutPreferencesSchema = z.object({
    * local network.
    */
   slmTriageHost: z.string().default(""),
+  /**
+   * Minimum merged-PR count for a repo to qualify as an anchor in
+   * `scout features` (#98). Lowering surfaces more anchors at the cost
+   * of weaker prior engagement signal.
+   */
+  featuresAnchorThreshold: z.number().int().min(1).max(50).default(3),
+  /**
+   * Quick-wins / bigger-bets split ratio for `scout features` (#99).
+   * 0.6 means 60% quick wins, 40% bigger bets when both pools are
+   * abundant. Deficits redirect to the other bucket.
+   */
+  featuresSplitRatio: z.number().min(0).max(1).default(0.6),
 });
 
 // ── Root state schema ───────────────────────────────────────────────

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -373,4 +373,54 @@ describe("OssScout.features", () => {
       "bigger-bet",
     );
   });
+
+  it("forwards featuresAnchorThreshold + featuresSplitRatio prefs to discoverFeatures", async () => {
+    vi.mocked(discoverFeatures).mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: null,
+    } as never);
+    const state = ScoutStateSchema.parse({
+      version: 1,
+      preferences: {
+        featuresAnchorThreshold: 5,
+        featuresSplitRatio: 0.4,
+      },
+    });
+    const scout = new OssScout("test-token", state);
+    await scout.features();
+    expect(discoverFeatures).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anchorThreshold: 5,
+        splitRatio: 0.4,
+        count: 10,
+      }),
+    );
+  });
+
+  it("per-call overrides take precedence over preferences", async () => {
+    vi.mocked(discoverFeatures).mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: null,
+    } as never);
+    const state = ScoutStateSchema.parse({
+      version: 1,
+      preferences: {
+        featuresAnchorThreshold: 5,
+        featuresSplitRatio: 0.4,
+      },
+    });
+    const scout = new OssScout("test-token", state);
+    await scout.features({ count: 4, anchorThreshold: 2, splitRatio: 0.75 });
+    expect(discoverFeatures).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anchorThreshold: 2,
+        splitRatio: 0.75,
+        count: 4,
+      }),
+    );
+  });
 });

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -227,10 +227,18 @@ export class OssScout implements ScoutStateReader {
 
   /**
    * `scout features` — surfaces feature-scoped contribution opportunities
-   * in repos where the user has 3+ merged PRs, ranked into separate
-   * "quick wins" and "bigger bets" buckets.
+   * in repos where the user has 3+ merged PRs (configurable via
+   * `featuresAnchorThreshold`), ranked into separate "quick wins" and
+   * "bigger bets" buckets (split via `featuresSplitRatio`).
+   *
+   * Per-call `anchorThreshold` and `splitRatio` overrides take precedence
+   * over the persisted preferences.
    */
-  async features(options?: { count?: number }): Promise<FeatureSearchResult> {
+  async features(options?: {
+    count?: number;
+    anchorThreshold?: number;
+    splitRatio?: number;
+  }): Promise<FeatureSearchResult> {
     const count = options?.count ?? 10;
     const octokit = getOctokit(this.githubToken);
     const vetter = new IssueVetter(octokit, this);
@@ -239,6 +247,11 @@ export class OssScout implements ScoutStateReader {
       vetter,
       repoScores: this.state.repoScores ?? {},
       count,
+      anchorThreshold:
+        options?.anchorThreshold ??
+        this.state.preferences.featuresAnchorThreshold,
+      splitRatio:
+        options?.splitRatio ?? this.state.preferences.featuresSplitRatio,
     });
 
     this.saveResults([...result.quickWins, ...result.biggerBets]);

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -159,6 +159,50 @@ describe("registerTools", () => {
       expect(result.isError).toBeUndefined();
       expect(JSON.parse(result.content[0].text)).toMatchObject(featuresResult);
     });
+
+    it("forwards anchorThreshold and splitRatio to scout.features", async () => {
+      const featuresFn = vi.fn().mockResolvedValue({
+        quickWins: [],
+        biggerBets: [],
+        anchorRepos: [],
+        message: null,
+      });
+      const local = createMockScout({
+        features: featuresFn,
+      } as Partial<OssScout>);
+      const localServer = new McpServer({ name: "t", version: "0.0.1" });
+      vi.spyOn(localServer, "tool");
+      registerTools(localServer, local);
+      const handler = getToolHandler(localServer, "scout-features");
+      await handler({ maxResults: 8, anchorThreshold: 5, splitRatio: 0.5 }, {});
+      expect(featuresFn).toHaveBeenCalledWith({
+        count: 8,
+        anchorThreshold: 5,
+        splitRatio: 0.5,
+      });
+    });
+
+    it("omits overrides when not provided", async () => {
+      const featuresFn = vi.fn().mockResolvedValue({
+        quickWins: [],
+        biggerBets: [],
+        anchorRepos: [],
+        message: null,
+      });
+      const local = createMockScout({
+        features: featuresFn,
+      } as Partial<OssScout>);
+      const localServer = new McpServer({ name: "t", version: "0.0.1" });
+      vi.spyOn(localServer, "tool");
+      registerTools(localServer, local);
+      const handler = getToolHandler(localServer, "scout-features");
+      await handler({ maxResults: 5 }, {});
+      expect(featuresFn).toHaveBeenCalledWith({
+        count: 5,
+        anchorThreshold: undefined,
+        splitRatio: undefined,
+      });
+    });
   });
 
   describe("vet tool execution", () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -74,11 +74,28 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         .number()
         .optional()
         .describe("Maximum number of results to return (default 10)"),
+      anchorThreshold: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Anchor threshold override (default 3)"),
+      splitRatio: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("Quick-wins/bigger-bets split ratio (default 0.6)"),
     },
-    async ({ maxResults }) => {
+    async ({ maxResults, anchorThreshold, splitRatio }) => {
       try {
         const result = await withTimeout(
-          scout.features({ count: maxResults ?? 10 }),
+          scout.features({
+            count: maxResults ?? 10,
+            anchorThreshold,
+            splitRatio,
+          }),
         );
         scout.saveResults([...result.quickWins, ...result.biggerBets]);
         await scout.checkpoint();
@@ -258,6 +275,8 @@ export function registerTools(server: McpServer, scout: OssScout): void {
     "interPhaseDelayMs",
     "broadPhaseDelayMs",
     "skipBroadWhenSufficientResults",
+    "featuresAnchorThreshold",
+    "featuresSplitRatio",
   ]);
   const BOOLEAN_KEYS = new Set(["includeDocIssues"]);
 


### PR DESCRIPTION
## Summary

Make the two hard-coded tuning parameters in `scout features` user-configurable while preserving current defaults. Closes #98 and #99.

## What changed

- **New preferences** in `ScoutPreferences`:
  - `featuresAnchorThreshold` (int 1-50, default 3) — minimum merged-PR count for a repo to qualify as an anchor
  - `featuresSplitRatio` (float 0-1, default 0.6) — fraction of results allocated to quick wins vs bigger bets
- **CLI flags** on `scout features`:
  - `--anchor-threshold <n>`
  - `--split-ratio <r>`
- **MCP tool** `scout-features` accepts optional `anchorThreshold` and `splitRatio`
- **OssScout API**: `features({ count?, anchorThreshold?, splitRatio? })`
- **Pure helpers** `resolveAnchorRepos` and `splitByHorizon` accept optional override args; call sites pass them through
- **`scout config set`**: `featuresAnchorThreshold` and `featuresSplitRatio` are settable. New `"float"` field type added to `FIELD_CONFIGS` since `parseInt` could not parse `0.6`.

## Precedence

Per-call argument > preference > schema default. All three layers tested.

## Test plan

- [x] All unit tests pass (640 core + 19 mcp = 659, +23 new)
- [x] Lint, format:check, typecheck pass
- [x] Bundle rebuilds
- [ ] CI green on Node 20/22/24