### PR TITLE
feat: stalled-PR annotation in scout + scout features (#97)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -172,7 +172,7 @@ program
                   ? "❌"
                   : "⚠️";
             const stalledTag = c.linkedPR?.isStalled
-              ? " (stalled PR — revive opportunity)"
+              ? " (stalled PR, revive opportunity)"
               : "";
             console.log(
               `  ${icon} ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100]${stalledTag}`,
@@ -267,7 +267,7 @@ program
             );
             for (const c of result.quickWins) {
               const stalledTag = c.linkedPR?.isStalled
-                ? " (stalled PR — revive opportunity)"
+                ? " (stalled PR, revive opportunity)"
                 : "";
               console.log(
                 `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,
@@ -282,7 +282,7 @@ program
             );
             for (const c of result.biggerBets) {
               const stalledTag = c.linkedPR?.isStalled
-                ? " (stalled PR — revive opportunity)"
+                ? " (stalled PR, revive opportunity)"
                 : "";
               console.log(
                 `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -171,8 +171,11 @@ program
                 : c.recommendation === "skip"
                   ? "❌"
                   : "⚠️";
+            const stalledTag = c.linkedPR?.isStalled
+              ? " (stalled PR — revive opportunity)"
+              : "";
             console.log(
-              `  ${icon} ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100]`,
+              `  ${icon} ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100]${stalledTag}`,
             );
             console.log(`     ${c.issue.title}`);
             console.log(`     ${c.issue.url}`);
@@ -263,8 +266,11 @@ program
               "── Quick wins ─────────────────────────────────────────",
             );
             for (const c of result.quickWins) {
+              const stalledTag = c.linkedPR?.isStalled
+                ? " (stalled PR — revive opportunity)"
+                : "";
               console.log(
-                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,
               );
               console.log(`     ${c.issue.url}`);
             }
@@ -275,8 +281,11 @@ program
               "── Bigger bets ────────────────────────────────────────",
             );
             for (const c of result.biggerBets) {
+              const stalledTag = c.linkedPR?.isStalled
+                ? " (stalled PR — revive opportunity)"
+                : "";
               console.log(
-                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}`,
+                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,
               );
               console.log(`     ${c.issue.url}`);
             }

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { runFeatures } from "./features.js";
 import { createScout } from "../scout.js";
+import type { FeatureCandidate } from "../core/feature-discovery.js";
+import type { LinkedPR } from "../core/schemas.js";
 
 vi.mock("../scout.js", () => ({
   createScout: vi.fn(),
@@ -13,6 +15,55 @@ vi.mock("../core/utils.js", () => ({
 vi.mock("../core/local-state.js", () => ({
   saveLocalState: vi.fn(),
 }));
+
+function makeFeatureCandidate(
+  horizon: "quick-win" | "bigger-bet",
+  linkedPR?: LinkedPR,
+): FeatureCandidate {
+  return {
+    issue: {
+      id: 1,
+      url: "https://github.com/test/repo/issues/42",
+      repo: "test/repo",
+      number: 42,
+      title: "Add a thing",
+      status: "candidate",
+      labels: ["enhancement"],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      vetted: true,
+    },
+    vettingResult: {
+      passedAllChecks: linkedPR ? false : true,
+      checks: {
+        noExistingPR: !linkedPR,
+        notClaimed: true,
+        projectActive: true,
+        clearRequirements: true,
+        contributionGuidelinesFound: true,
+      },
+      notes: [],
+      linkedPR: linkedPR ?? null,
+    },
+    projectHealth: {
+      repo: "test/repo",
+      lastCommitAt: "2026-01-01T00:00:00Z",
+      daysSinceLastCommit: 5,
+      openIssuesCount: 10,
+      avgIssueResponseDays: 2,
+      ciStatus: "passing",
+      isActive: true,
+    },
+    antiLLMPolicy: { matched: false, matchedKeywords: [], sourceFile: null },
+    slmTriage: null,
+    recommendation: "approve",
+    reasonsToSkip: [],
+    reasonsToApprove: [],
+    viabilityScore: 70,
+    searchPriority: "normal",
+    horizon,
+  };
+}
 
 describe("runFeatures", () => {
   let featuresFn: ReturnType<typeof vi.fn>;
@@ -60,5 +111,83 @@ describe("runFeatures", () => {
       anchorThreshold: undefined,
       splitRatio: undefined,
     });
+  });
+
+  it("marks linkedPR.isStalled on quick-win candidates with stale linked PRs (#97)", async () => {
+    const stale = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString();
+    const candidate = makeFeatureCandidate("quick-win", {
+      number: 99,
+      author: "alice",
+      state: "open",
+      merged: false,
+      url: "https://github.com/test/repo/pull/99",
+      updatedAt: stale,
+    });
+    featuresFn.mockResolvedValue({
+      quickWins: [candidate],
+      biggerBets: [],
+      anchorRepos: ["test/repo"],
+      message: null,
+    });
+
+    const out = await runFeatures({ maxResults: 5 });
+    expect(out.quickWins[0].linkedPR).toBeDefined();
+    expect(out.quickWins[0].linkedPR!.number).toBe(99);
+    expect(out.quickWins[0].linkedPR!.isStalled).toBe(true);
+  });
+
+  it("marks linkedPR.isStalled on bigger-bet candidates with stale linked PRs (#97)", async () => {
+    const stale = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    const candidate = makeFeatureCandidate("bigger-bet", {
+      number: 200,
+      author: "bob",
+      state: "open",
+      merged: false,
+      url: "https://github.com/test/repo/pull/200",
+      updatedAt: stale,
+    });
+    featuresFn.mockResolvedValue({
+      quickWins: [],
+      biggerBets: [candidate],
+      anchorRepos: ["test/repo"],
+      message: null,
+    });
+
+    const out = await runFeatures({ maxResults: 5 });
+    expect(out.biggerBets[0].linkedPR!.isStalled).toBe(true);
+  });
+
+  it("does not flag fresh linked PRs as stalled (#97)", async () => {
+    const fresh = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const candidate = makeFeatureCandidate("quick-win", {
+      number: 101,
+      author: "alice",
+      state: "open",
+      merged: false,
+      url: "https://github.com/test/repo/pull/101",
+      updatedAt: fresh,
+    });
+    featuresFn.mockResolvedValue({
+      quickWins: [candidate],
+      biggerBets: [],
+      anchorRepos: ["test/repo"],
+      message: null,
+    });
+
+    const out = await runFeatures({ maxResults: 5 });
+    expect(out.quickWins[0].linkedPR!.isStalled).toBe(false);
+  });
+
+  it("omits linkedPR when no PR is linked (#97)", async () => {
+    const candidate = makeFeatureCandidate("quick-win");
+    featuresFn.mockResolvedValue({
+      quickWins: [candidate],
+      biggerBets: [],
+      anchorRepos: ["test/repo"],
+      message: null,
+    });
+
+    const out = await runFeatures({ maxResults: 5 });
+    expect(out.quickWins[0].linkedPR).toBeUndefined();
   });
 });

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -5,8 +5,23 @@
 import { createScout } from "../scout.js";
 import { requireGitHubToken } from "../core/utils.js";
 import { saveLocalState } from "../core/local-state.js";
+import { isLinkedPRStalled } from "../core/linked-pr.js";
 import type { ScoutState } from "../core/schemas.js";
 import type { FeatureCandidate } from "../core/feature-discovery.js";
+
+/**
+ * Linked-PR metadata surfaced on feature candidates. `isStalled` flags open
+ * PRs that haven't been updated for 30+ days — surfaced as revive
+ * opportunities (#97). Scoring is unchanged: the existing -30 viability
+ * penalty still applies.
+ */
+interface OutputLinkedPR {
+  number: number;
+  state: "open" | "closed";
+  url: string;
+  updatedAt?: string;
+  isStalled: boolean;
+}
 
 export interface FeaturesOutput {
   quickWins: Array<{
@@ -20,6 +35,7 @@ export interface FeaturesOutput {
     recommendation: "approve" | "skip" | "needs_review";
     viabilityScore: number;
     horizon: "quick-win";
+    linkedPR?: OutputLinkedPR;
   }>;
   biggerBets: Array<{
     issue: {
@@ -32,6 +48,7 @@ export interface FeaturesOutput {
     recommendation: "approve" | "skip" | "needs_review";
     viabilityScore: number;
     horizon: "bigger-bet";
+    linkedPR?: OutputLinkedPR;
   }>;
   anchorRepos: string[];
   message: string | null;
@@ -42,6 +59,18 @@ interface FeaturesCommandOptions {
   state?: ScoutState;
   anchorThreshold?: number;
   splitRatio?: number;
+}
+
+function mapLinkedPR(c: FeatureCandidate): OutputLinkedPR | undefined {
+  const linkedPR = c.vettingResult.linkedPR;
+  if (!linkedPR) return undefined;
+  return {
+    number: linkedPR.number,
+    state: linkedPR.state,
+    url: linkedPR.url,
+    updatedAt: linkedPR.updatedAt,
+    isStalled: isLinkedPRStalled(linkedPR),
+  };
 }
 
 function mapQuickWin(c: FeatureCandidate): FeaturesOutput["quickWins"][number] {
@@ -56,6 +85,7 @@ function mapQuickWin(c: FeatureCandidate): FeaturesOutput["quickWins"][number] {
     recommendation: c.recommendation,
     viabilityScore: c.viabilityScore,
     horizon: "quick-win",
+    linkedPR: mapLinkedPR(c),
   };
 }
 
@@ -73,6 +103,7 @@ function mapBiggerBet(
     recommendation: c.recommendation,
     viabilityScore: c.viabilityScore,
     horizon: "bigger-bet",
+    linkedPR: mapLinkedPR(c),
   };
 }
 

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -239,6 +239,98 @@ describe("runSearch", () => {
     expect(mockCheckpoint).toHaveBeenCalled();
   });
 
+  it("marks linkedPR.isStalled when the linked PR is open and stale (#97)", async () => {
+    const stale = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString();
+    const candidate = makeCandidate({
+      vettingResult: {
+        passedAllChecks: false,
+        checks: {
+          noExistingPR: false,
+          notClaimed: true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+        linkedPR: {
+          number: 99,
+          author: "alice",
+          state: "open",
+          merged: false,
+          url: "https://github.com/test/repo/pull/99",
+          updatedAt: stale,
+        },
+      },
+    });
+    mockSearch.mockResolvedValue({
+      candidates: [candidate],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ["broad"],
+    });
+    mockGetRepoScoreRecord.mockReturnValue(undefined);
+
+    const { runSearch } = await import("./search.js");
+    const result = await runSearch({ maxResults: 5 });
+
+    expect(result.candidates[0].linkedPR).toBeDefined();
+    expect(result.candidates[0].linkedPR!.number).toBe(99);
+    expect(result.candidates[0].linkedPR!.isStalled).toBe(true);
+  });
+
+  it("does not flag a fresh linked PR as stalled (#97)", async () => {
+    const fresh = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const candidate = makeCandidate({
+      vettingResult: {
+        passedAllChecks: false,
+        checks: {
+          noExistingPR: false,
+          notClaimed: true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+        linkedPR: {
+          number: 100,
+          author: "alice",
+          state: "open",
+          merged: false,
+          url: "https://github.com/test/repo/pull/100",
+          updatedAt: fresh,
+        },
+      },
+    });
+    mockSearch.mockResolvedValue({
+      candidates: [candidate],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ["broad"],
+    });
+    mockGetRepoScoreRecord.mockReturnValue(undefined);
+
+    const { runSearch } = await import("./search.js");
+    const result = await runSearch({ maxResults: 5 });
+
+    expect(result.candidates[0].linkedPR!.isStalled).toBe(false);
+  });
+
+  it("omits linkedPR when no PR is linked (#97)", async () => {
+    const candidate = makeCandidate();
+    mockSearch.mockResolvedValue({
+      candidates: [candidate],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ["broad"],
+    });
+    mockGetRepoScoreRecord.mockReturnValue(undefined);
+
+    const { runSearch } = await import("./search.js");
+    const result = await runSearch({ maxResults: 5 });
+
+    expect(result.candidates[0].linkedPR).toBeUndefined();
+  });
+
   it("calls saveResults with candidates", async () => {
     const candidate = makeCandidate();
     mockSearch.mockResolvedValue({

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -5,6 +5,7 @@
 import { createScout } from "../scout.js";
 import { requireGitHubToken } from "../core/utils.js";
 import { saveLocalState } from "../core/local-state.js";
+import { isLinkedPRStalled } from "../core/linked-pr.js";
 import type { ScoutState, SearchStrategy } from "../core/schemas.js";
 
 export interface SearchOutput {
@@ -28,6 +29,19 @@ export interface SearchOutput {
       closedWithoutMergeCount: number;
       isResponsive: boolean;
       lastMergedAt?: string;
+    };
+    /**
+     * Metadata for the first cross-referenced PR linked to this issue, when
+     * one exists. `isStalled` flags open PRs that haven't been updated for
+     * 30+ days — surfaced as revive opportunities (#97). Scoring is
+     * unchanged: the existing -30 viability penalty still applies.
+     */
+    linkedPR?: {
+      number: number;
+      state: "open" | "closed";
+      url: string;
+      updatedAt?: string;
+      isStalled: boolean;
     };
   }>;
   excludedRepos: string[];
@@ -90,6 +104,15 @@ export async function runSearch(
               closedWithoutMergeCount: repoScoreRecord.closedWithoutMergeCount,
               isResponsive: repoScoreRecord.signals?.isResponsive ?? false,
               lastMergedAt: repoScoreRecord.lastMergedAt,
+            }
+          : undefined,
+        linkedPR: c.vettingResult.linkedPR
+          ? {
+              number: c.vettingResult.linkedPR.number,
+              state: c.vettingResult.linkedPR.state,
+              url: c.vettingResult.linkedPR.url,
+              updatedAt: c.vettingResult.linkedPR.updatedAt,
+              isStalled: isLinkedPRStalled(c.vettingResult.linkedPR),
             }
           : undefined,
       };

--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -267,6 +267,48 @@ describe("checkNoExistingPR", () => {
     expect(result.passed).toBe(true);
     expect(result.linkedPR).toBeNull();
   });
+
+  it("populates linkedPR.updatedAt from source.issue.updated_at", async () => {
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            number: 50,
+            state: "open",
+            html_url: "https://github.com/owner/repo/pull/50",
+            updated_at: "2026-04-01T12:00:00Z",
+            user: { login: "alice" },
+            pull_request: { url: "u", merged_at: null },
+          },
+        },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 5);
+    expect(result.linkedPR?.updatedAt).toBe("2026-04-01T12:00:00Z");
+  });
+
+  it("leaves linkedPR.updatedAt undefined when source data lacks updated_at", async () => {
+    mockPaginateAll.mockResolvedValue([
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            number: 51,
+            state: "open",
+            html_url: "https://github.com/owner/repo/pull/51",
+            user: { login: "alice" },
+            pull_request: { url: "u", merged_at: null },
+          },
+        },
+      },
+    ]);
+    const octokit = makeMockOctokit();
+    const result = await checkNoExistingPR(octokit, "owner", "repo", 5);
+    expect(result.linkedPR).not.toBeNull();
+    expect(result.linkedPR?.updatedAt).toBeUndefined();
+  });
 });
 
 // ── checkNotClaimed ───────────────────────────────────────────────

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -27,6 +27,7 @@ type CrossRefEvent = {
       number?: number;
       state?: string;
       html_url?: string;
+      updated_at?: string;
       user?: { login?: string };
       pull_request?: { merged_at?: string | null };
     };
@@ -72,12 +73,17 @@ function buildLinkedPRFromTimelineEvent(
     );
     return null;
   }
+  // updatedAt is read directly from the timeline event's source.issue
+  // (issue.updated_at is exposed on the cross-reference payload), so no
+  // extra pulls.get round-trip is needed. Left undefined when absent —
+  // isLinkedPRStalled treats missing data as not-stalled.
   return {
     number: issue.number,
     author,
     state: issue.state === "closed" ? "closed" : "open",
     merged: !!issue.pull_request?.merged_at,
     url,
+    updatedAt: issue.updated_at,
   };
 }
 

--- a/packages/core/src/core/linked-pr.test.ts
+++ b/packages/core/src/core/linked-pr.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  isLinkedPRStalled,
-  STALLED_PR_THRESHOLD_DAYS,
-} from "./linked-pr.js";
+import { isLinkedPRStalled, STALLED_PR_THRESHOLD_DAYS } from "./linked-pr.js";
 import type { LinkedPR } from "./schemas.js";
 
 const NOW = new Date("2026-05-09T00:00:00Z");

--- a/packages/core/src/core/linked-pr.test.ts
+++ b/packages/core/src/core/linked-pr.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLinkedPRStalled,
+  STALLED_PR_THRESHOLD_DAYS,
+} from "./linked-pr.js";
+import type { LinkedPR } from "./schemas.js";
+
+const NOW = new Date("2026-05-09T00:00:00Z");
+
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function makeLinkedPR(overrides: Partial<LinkedPR> = {}): LinkedPR {
+  return {
+    number: 1,
+    author: "alice",
+    state: "open",
+    merged: false,
+    url: "https://github.com/foo/bar/pull/1",
+    updatedAt: daysAgo(45),
+    ...overrides,
+  };
+}
+
+describe("isLinkedPRStalled", () => {
+  it("returns false for a null linked PR", () => {
+    expect(isLinkedPRStalled(null, NOW)).toBe(false);
+  });
+
+  it("returns false for an undefined linked PR", () => {
+    expect(isLinkedPRStalled(undefined, NOW)).toBe(false);
+  });
+
+  it("returns false when the PR is closed", () => {
+    const pr = makeLinkedPR({ state: "closed", updatedAt: daysAgo(45) });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(false);
+  });
+
+  it("returns false when the PR is merged (closed + merged)", () => {
+    const pr = makeLinkedPR({
+      state: "closed",
+      merged: true,
+      updatedAt: daysAgo(45),
+    });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(false);
+  });
+
+  it("returns false when updatedAt is missing", () => {
+    const pr = makeLinkedPR({ updatedAt: undefined });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(false);
+  });
+
+  it("returns false for a fresh open PR (10 days old)", () => {
+    const pr = makeLinkedPR({ updatedAt: daysAgo(10) });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(false);
+  });
+
+  it("returns true for a stalled open PR (45 days old)", () => {
+    const pr = makeLinkedPR({ updatedAt: daysAgo(45) });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(true);
+  });
+
+  it("returns true at exactly the 30-day boundary", () => {
+    const pr = makeLinkedPR({ updatedAt: daysAgo(30) });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(true);
+  });
+
+  it("returns false at 29.5 days (just below the boundary)", () => {
+    const pr = makeLinkedPR({ updatedAt: daysAgo(29.5) });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(false);
+  });
+
+  it("returns false for an invalid date string", () => {
+    const pr = makeLinkedPR({ updatedAt: "not-a-date" });
+    expect(isLinkedPRStalled(pr, NOW)).toBe(false);
+  });
+
+  it("respects a custom thresholdDays argument", () => {
+    const pr = makeLinkedPR({ updatedAt: daysAgo(15) });
+    expect(isLinkedPRStalled(pr, NOW, 10)).toBe(true);
+    expect(isLinkedPRStalled(pr, NOW, 30)).toBe(false);
+  });
+
+  it("exports STALLED_PR_THRESHOLD_DAYS as 30", () => {
+    expect(STALLED_PR_THRESHOLD_DAYS).toBe(30);
+  });
+});

--- a/packages/core/src/core/linked-pr.ts
+++ b/packages/core/src/core/linked-pr.ts
@@ -1,0 +1,32 @@
+/**
+ * Helpers for reasoning about linked PRs surfaced via the issue timeline.
+ *
+ * Currently scoped to detecting "stalled" PRs — open PRs that have not been
+ * updated in the last `STALLED_PR_THRESHOLD_DAYS` days. Stalled linked PRs
+ * are surfaced as revive opportunities (#97). Note: this module does NOT
+ * change scoring; the existing -30 penalty on issues with linked PRs is
+ * preserved. This is annotation-only.
+ */
+
+import type { LinkedPR } from "./schemas.js";
+
+/** Days of inactivity that classify a linked PR as "stalled". */
+export const STALLED_PR_THRESHOLD_DAYS = 30;
+
+/**
+ * Determine whether a linked PR is stalled (open + not updated in the
+ * last STALLED_PR_THRESHOLD_DAYS days). Returns false when the PR is
+ * closed/merged, when updatedAt is missing, or when the threshold isn't met.
+ */
+export function isLinkedPRStalled(
+  linkedPR: LinkedPR | null | undefined,
+  now: Date = new Date(),
+  thresholdDays: number = STALLED_PR_THRESHOLD_DAYS,
+): boolean {
+  if (!linkedPR || linkedPR.state !== "open" || !linkedPR.updatedAt)
+    return false;
+  const updated = new Date(linkedPR.updatedAt);
+  if (Number.isNaN(updated.getTime())) return false;
+  const ageDays = (now.getTime() - updated.getTime()) / (1000 * 60 * 60 * 24);
+  return ageDays >= thresholdDays;
+}

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -5,6 +5,7 @@ import {
   RepoScoreSchema,
   SavedCandidateSchema,
   HorizonSchema,
+  LinkedPRSchema,
 } from "./schemas.js";
 
 describe("ScoutStateSchema", () => {
@@ -273,6 +274,33 @@ describe("HorizonSchema", () => {
   });
   it("rejects unknown values", () => {
     expect(() => HorizonSchema.parse("medium")).toThrow();
+  });
+});
+
+describe("LinkedPRSchema", () => {
+  const base = {
+    number: 99,
+    author: "alice",
+    state: "open" as const,
+    merged: false,
+    url: "https://github.com/foo/bar/pull/99",
+  };
+  it("validates without updatedAt (backwards compat)", () => {
+    const parsed = LinkedPRSchema.parse(base);
+    expect(parsed.updatedAt).toBeUndefined();
+    expect(parsed.number).toBe(99);
+  });
+  it("validates with updatedAt populated", () => {
+    const parsed = LinkedPRSchema.parse({
+      ...base,
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(parsed.updatedAt).toBe("2026-01-01T00:00:00Z");
+  });
+  it("rejects non-string updatedAt", () => {
+    expect(() =>
+      LinkedPRSchema.parse({ ...base, updatedAt: 12345 }),
+    ).toThrow();
   });
 });
 

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -298,9 +298,7 @@ describe("LinkedPRSchema", () => {
     expect(parsed.updatedAt).toBe("2026-01-01T00:00:00Z");
   });
   it("rejects non-string updatedAt", () => {
-    expect(() =>
-      LinkedPRSchema.parse({ ...base, updatedAt: 12345 }),
-    ).toThrow();
+    expect(() => LinkedPRSchema.parse({ ...base, updatedAt: 12345 })).toThrow();
   });
 });
 

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -110,6 +110,12 @@ export const LinkedPRSchema = z.object({
   state: z.enum(["open", "closed"]),
   merged: z.boolean(),
   url: z.string(),
+  /**
+   * ISO-8601 timestamp of the linked PR's last update. Optional so existing
+   * persisted state validates unchanged. Used by `isLinkedPRStalled` to
+   * surface stale revive opportunities (#97).
+   */
+  updatedAt: z.string().optional(),
 });
 
 export const IssueVettingResultSchema = z.object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,3 +99,9 @@ export {
   type FeatureSearchResult,
   type DiscoverFeaturesOptions,
 } from "./core/feature-discovery.js";
+
+// Linked-PR helpers (#97)
+export {
+  isLinkedPRStalled,
+  STALLED_PR_THRESHOLD_DAYS,
+} from "./core/linked-pr.js";


### PR DESCRIPTION
## Summary

Surfaces "stalled PR" revive opportunities in `scout` and `scout features` output when a linked open PR has been inactive for 30+ days. Closes #97.

**No scoring change.** The -30 penalty for an existing PR is preserved (the user explicitly chose annotation-only over revival mode).

## What changed

- `LinkedPR.updatedAt` (optional string) added to schema, populated for free from the cross-referenced timeline event.
- New `linked-pr.ts` module with `isLinkedPRStalled(linkedPR, now?, thresholdDays?)` helper. Threshold hardcoded at `STALLED_PR_THRESHOLD_DAYS = 30` (configurable can be a future follow-up).
- Terminal output: both `scout search` and `scout features` append `(stalled PR, revive opportunity)` to the affected lines.
- JSON output: `SearchOutput.candidates[]` and `FeaturesOutput.{quickWins,biggerBets}[]` gain `linkedPR: { number, state, url, updatedAt, isStalled }`.
- `isLinkedPRStalled` and `STALLED_PR_THRESHOLD_DAYS` exported from `@oss-scout/core` for downstream consumers.

## Why annotation-only

The original #92 brainstorm chose to keep the -30 penalty regardless. #97 revisits that decision; we're picking the most conservative option (annotation only, no scoring change) so we surface the opportunity without altering ranking.

## Test plan

- [x] All unit tests pass (664 core + 19 mcp = 683, +38 new)
- [x] Lint, format:check, typecheck pass
- [x] No diff in `issue-scoring.ts`
- [x] Backwards compat: existing persisted `LinkedPR` records (without updatedAt) still validate
- [ ] CI green on Node 20/22/24