### PR TITLE
feat: scout features follow-ups — wontfix detection, roadmap scraping, broad mode (#95 #96 #100)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -204,6 +204,10 @@ program
   .option("--json", "Output as JSON")
   .option("--anchor-threshold <n>", "Override featuresAnchorThreshold (1-50)")
   .option("--split-ratio <r>", "Override featuresSplitRatio (0-1, e.g. 0.6)")
+  .option(
+    "--broad",
+    "Bypass anchor repos; search feature issues across the ecosystem (first-touch mode)",
+  )
   .action(
     async (
       count: string | undefined,
@@ -211,6 +215,7 @@ program
         json?: boolean;
         anchorThreshold?: string;
         splitRatio?: string;
+        broad?: boolean;
       },
     ) => {
       try {
@@ -248,6 +253,7 @@ program
           state,
           anchorThreshold,
           splitRatio,
+          broad: options.broad,
         });
         if (options.json) {
           console.log(formatJsonSuccess(result));
@@ -257,10 +263,15 @@ program
             console.log(`\n${result.message}\n`);
           }
           if (total === 0) return;
+          const headerScope = options.broad
+            ? "across the ecosystem"
+            : "in your anchor repos";
           console.log(
-            `\n🎯 Feature opportunities in your anchor repos (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
+            `\n🎯 Feature opportunities ${headerScope} (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
           );
-          console.log(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
+          if (!options.broad) {
+            console.log(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
+          }
           if (result.quickWins.length) {
             console.log(
               "── Quick wins ─────────────────────────────────────────",

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -59,6 +59,8 @@ interface FeaturesCommandOptions {
   state?: ScoutState;
   anchorThreshold?: number;
   splitRatio?: number;
+  /** Run the broad / cross-repo path (#100). */
+  broad?: boolean;
 }
 
 function mapLinkedPR(c: FeatureCandidate): OutputLinkedPR | undefined {
@@ -123,6 +125,7 @@ export async function runFeatures(
     count: options.maxResults,
     anchorThreshold: options.anchorThreshold,
     splitRatio: options.splitRatio,
+    broad: options.broad,
   });
 
   saveLocalState(scout.getState() as ScoutState);

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -6,6 +6,8 @@ import {
   classifyHorizon,
   splitByHorizon,
   discoverFeatures,
+  detectWontfixNoContributor,
+  WONTFIX_MIN_AGE_DAYS,
   type FeatureCandidate,
 } from "./feature-discovery.js";
 
@@ -58,6 +60,89 @@ describe("resolveAnchorRepos", () => {
   it("defaults to ANCHOR_THRESHOLD when threshold is undefined", () => {
     const out = resolveAnchorRepos(mkScores(["a/b", 2], ["c/d", 3]), undefined);
     expect(out).toEqual(["c/d"]);
+  });
+});
+
+describe("detectWontfixNoContributor", () => {
+  const NOW = new Date("2026-05-09T00:00:00Z");
+  const oldCreated = new Date(
+    NOW.getTime() - (WONTFIX_MIN_AGE_DAYS + 5) * 86400000,
+  ).toISOString();
+  const recentCreated = new Date(
+    NOW.getTime() - 10 * 86400000,
+  ).toISOString();
+
+  it("returns true with help-wanted label and old enough age", () => {
+    expect(
+      detectWontfixNoContributor({
+        labels: ["help wanted"],
+        createdAt: oldCreated,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+  it("returns false when no qualifying label is present", () => {
+    expect(
+      detectWontfixNoContributor({
+        labels: ["enhancement"],
+        createdAt: oldCreated,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+  it("returns false for an issue younger than 60 days", () => {
+    expect(
+      detectWontfixNoContributor({
+        labels: ["help wanted"],
+        createdAt: recentCreated,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+  it("matches case-insensitively", () => {
+    expect(
+      detectWontfixNoContributor({
+        labels: ["Help Wanted"],
+        createdAt: oldCreated,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+  it("recognises contributions-welcome, up-for-grabs, bounty, pinned, unmaintained", () => {
+    for (const label of [
+      "contributions welcome",
+      "up-for-grabs",
+      "bounty",
+      "pinned",
+      "unmaintained",
+    ]) {
+      expect(
+        detectWontfixNoContributor({
+          labels: [label],
+          createdAt: oldCreated,
+          now: NOW,
+        }),
+      ).toBe(true);
+    }
+  });
+  it("returns false on unparseable createdAt", () => {
+    expect(
+      detectWontfixNoContributor({
+        labels: ["help wanted"],
+        createdAt: "not-a-date",
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+  it("respects custom minAgeDays override", () => {
+    expect(
+      detectWontfixNoContributor({
+        labels: ["help wanted"],
+        createdAt: recentCreated,
+        now: NOW,
+        minAgeDays: 5,
+      }),
+    ).toBe(true);
   });
 });
 
@@ -300,11 +385,25 @@ describe("discoverFeatures orchestrator", () => {
     expect(result.message).toBeNull();
     expect(vetter.vetIssue).toHaveBeenCalledWith(
       "https://github.com/a/b/issues/1",
-      { featureSignals: { reactions: 4, comments: 2, hasMilestone: false } },
+      {
+        featureSignals: {
+          reactions: 4,
+          comments: 2,
+          hasMilestone: false,
+          wontfixNoContributor: false,
+        },
+      },
     );
     expect(vetter.vetIssue).toHaveBeenCalledWith(
       "https://github.com/a/b/issues/2",
-      { featureSignals: { reactions: 50, comments: 30, hasMilestone: true } },
+      {
+        featureSignals: {
+          reactions: 50,
+          comments: 30,
+          hasMilestone: true,
+          wontfixNoContributor: false,
+        },
+      },
     );
   });
 
@@ -390,6 +489,73 @@ describe("discoverFeatures orchestrator", () => {
     expect(split.anchorRepos).toEqual(["a/b"]);
     expect(split.quickWins).toHaveLength(1);
     expect(split.biggerBets).toHaveLength(1);
+  });
+
+  it("forwards wontfixNoContributor signal to the vetter when label + age qualify", async () => {
+    const oldCreated = new Date(
+      Date.now() - (WONTFIX_MIN_AGE_DAYS + 30) * 86400000,
+    ).toISOString();
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: [
+            {
+              html_url: "https://github.com/a/b/issues/9",
+              title: "long-open feature ask",
+              labels: [{ name: "enhancement" }, { name: "help wanted" }],
+              comments: 1,
+              reactions: { total_count: 1 },
+              milestone: null,
+              pull_request: undefined,
+              assignee: null,
+              created_at: oldCreated,
+            },
+          ],
+        }),
+      },
+    } as never;
+    const vetter = {
+      vetIssue: vi.fn().mockImplementation(async (url: string) => ({
+        issue: {
+          url,
+          repo: "a/b",
+          number: 9,
+          title: "t",
+          labels: [],
+          updatedAt: "2026-05-01",
+        },
+        vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+        projectHealth: {},
+        antiLLMPolicy: {
+          matched: false,
+          matchedKeywords: [],
+          sourceFile: null,
+        },
+        slmTriage: null,
+        recommendation: "approve",
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        viabilityScore: 80,
+        searchPriority: "merged_pr",
+      })),
+    } as never;
+    await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 5,
+    });
+    expect(vetter.vetIssue).toHaveBeenCalledWith(
+      "https://github.com/a/b/issues/9",
+      {
+        featureSignals: {
+          reactions: 1,
+          comments: 1,
+          hasMilestone: false,
+          wontfixNoContributor: true,
+        },
+      },
+    );
   });
 
   it("propagates auth and rate-limit errors", async () => {

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { RepoScore } from "./schemas.js";
 import {
   resolveAnchorRepos,
@@ -10,6 +10,7 @@ import {
   WONTFIX_MIN_AGE_DAYS,
   type FeatureCandidate,
 } from "./feature-discovery.js";
+import { _clearRoadmapCacheForTests } from "./roadmap.js";
 
 const mkScore = (repo: string, mergedPRCount: number): RepoScore => ({
   repo,
@@ -280,6 +281,10 @@ describe("splitByHorizon 60/40 split", () => {
 });
 
 describe("discoverFeatures orchestrator", () => {
+  beforeEach(() => {
+    _clearRoadmapCacheForTests();
+  });
+
   it("returns no-anchors message when repoScores has no qualifying repos", async () => {
     const octokit = { issues: { listForRepo: vi.fn() } } as never;
     const vetter = { vetIssue: vi.fn() } as never;
@@ -391,6 +396,7 @@ describe("discoverFeatures orchestrator", () => {
           comments: 2,
           hasMilestone: false,
           wontfixNoContributor: false,
+          onRoadmap: false,
         },
       },
     );
@@ -402,6 +408,7 @@ describe("discoverFeatures orchestrator", () => {
           comments: 30,
           hasMilestone: true,
           wontfixNoContributor: false,
+          onRoadmap: false,
         },
       },
     );
@@ -553,9 +560,96 @@ describe("discoverFeatures orchestrator", () => {
           comments: 1,
           hasMilestone: false,
           wontfixNoContributor: true,
+          onRoadmap: false,
         },
       },
     );
+  });
+
+  it("forwards onRoadmap signal when an issue number appears in ROADMAP.md", async () => {
+    const md = "Roadmap:\n- ship #7 soon\n";
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: [
+            {
+              html_url: "https://github.com/a/b/issues/7",
+              title: "roadmap-listed feature",
+              labels: [{ name: "enhancement" }],
+              comments: 1,
+              reactions: { total_count: 1 },
+              milestone: null,
+              pull_request: undefined,
+              assignee: null,
+              created_at: "2026-04-01",
+              number: 7,
+            },
+            {
+              html_url: "https://github.com/a/b/issues/8",
+              title: "off-roadmap feature",
+              labels: [{ name: "enhancement" }],
+              comments: 1,
+              reactions: { total_count: 1 },
+              milestone: null,
+              pull_request: undefined,
+              assignee: null,
+              created_at: "2026-04-01",
+              number: 8,
+            },
+          ],
+        }),
+      },
+      repos: {
+        getContent: vi.fn().mockImplementation(async ({ path }) => {
+          if (path === "ROADMAP.md") {
+            return {
+              data: { content: Buffer.from(md, "utf-8").toString("base64") },
+            };
+          }
+          throw Object.assign(new Error("nope"), { status: 404 });
+        }),
+      },
+    } as never;
+    const vetter = {
+      vetIssue: vi.fn().mockImplementation(async (url: string) => ({
+        issue: {
+          url,
+          repo: "a/b",
+          number: 1,
+          title: "t",
+          labels: [],
+          updatedAt: "2026-05-01",
+        },
+        vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+        projectHealth: {},
+        antiLLMPolicy: {
+          matched: false,
+          matchedKeywords: [],
+          sourceFile: null,
+        },
+        slmTriage: null,
+        recommendation: "approve",
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        viabilityScore: 80,
+        searchPriority: "merged_pr",
+      })),
+    } as never;
+    await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 5,
+    });
+    const calls = vi.mocked(vetter.vetIssue).mock.calls;
+    const onRoadmap7 = calls.find(
+      (c) => c[0] === "https://github.com/a/b/issues/7",
+    )?.[1]?.featureSignals?.onRoadmap;
+    const onRoadmap8 = calls.find(
+      (c) => c[0] === "https://github.com/a/b/issues/8",
+    )?.[1]?.featureSignals?.onRoadmap;
+    expect(onRoadmap7).toBe(true);
+    expect(onRoadmap8).toBe(false);
   });
 
   it("propagates auth and rate-limit errors", async () => {

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -6,7 +6,9 @@ import {
   classifyHorizon,
   splitByHorizon,
   discoverFeatures,
+  discoverFeaturesBroad,
   detectWontfixNoContributor,
+  buildBroadFeatureSearchQuery,
   WONTFIX_MIN_AGE_DAYS,
   type FeatureCandidate,
 } from "./feature-discovery.js";
@@ -69,9 +71,7 @@ describe("detectWontfixNoContributor", () => {
   const oldCreated = new Date(
     NOW.getTime() - (WONTFIX_MIN_AGE_DAYS + 5) * 86400000,
   ).toISOString();
-  const recentCreated = new Date(
-    NOW.getTime() - 10 * 86400000,
-  ).toISOString();
+  const recentCreated = new Date(NOW.getTime() - 10 * 86400000).toISOString();
 
   it("returns true with help-wanted label and old enough age", () => {
     expect(
@@ -666,5 +666,177 @@ describe("discoverFeatures orchestrator", () => {
         count: 10,
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe("buildBroadFeatureSearchQuery", () => {
+  it("emits the base feature-label clause and excludes overlap labels", () => {
+    const q = buildBroadFeatureSearchQuery({});
+    expect(q).toContain("is:issue");
+    expect(q).toContain("is:open");
+    expect(q).toContain("no:assignee");
+    expect(q).toContain('label:"enhancement"');
+    expect(q).toContain('label:"feature"');
+    expect(q).toContain('label:"proposal"');
+    expect(q).toContain("OR");
+    expect(q).toContain('-label:"good first issue"');
+    expect(q).toContain('-label:"bug"');
+    expect(q).toContain('-label:"documentation"');
+  });
+
+  it("adds language filter when languages are provided", () => {
+    const q = buildBroadFeatureSearchQuery({
+      languages: ["typescript", "python"],
+    });
+    expect(q).toContain("language:typescript OR language:python");
+  });
+
+  it("ignores 'any' language preference", () => {
+    const q = buildBroadFeatureSearchQuery({ languages: ["any"] });
+    expect(q).not.toContain("language:any");
+    expect(q).not.toContain("language:");
+  });
+
+  it("includes -repo and -user clauses for excluded repos and orgs", () => {
+    const q = buildBroadFeatureSearchQuery({
+      excludeRepos: ["evil/repo", "bad/code"],
+      excludeOrgs: ["spam-org"],
+    });
+    expect(q).toContain("-repo:evil/repo");
+    expect(q).toContain("-repo:bad/code");
+    expect(q).toContain("-user:spam-org");
+  });
+});
+
+describe("discoverFeaturesBroad", () => {
+  function makeVetter() {
+    return {
+      vetIssue: vi.fn().mockImplementation(async (url: string) => ({
+        issue: {
+          url,
+          repo: "x/y",
+          number: 1,
+          title: "t",
+          labels: [],
+          updatedAt: "2026-05-01",
+        },
+        vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+        projectHealth: {},
+        antiLLMPolicy: {
+          matched: false,
+          matchedKeywords: [],
+          sourceFile: null,
+        },
+        slmTriage: null,
+        recommendation: "approve",
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        viabilityScore: 80,
+        searchPriority: "normal",
+      })),
+    } as never;
+  }
+
+  it("uses the Search API with the constructed query", async () => {
+    const search = vi.fn().mockResolvedValue({ data: { items: [] } });
+    const octokit = {
+      search: { issuesAndPullRequests: search },
+    } as never;
+    const result = await discoverFeaturesBroad({
+      octokit,
+      vetter: makeVetter(),
+      count: 10,
+      languages: ["typescript"],
+      excludeRepos: ["foo/bar"],
+    });
+    expect(search).toHaveBeenCalledTimes(1);
+    const call = search.mock.calls[0][0];
+    expect(call.q).toContain("language:typescript");
+    expect(call.q).toContain("-repo:foo/bar");
+    expect(call.sort).toBe("interactions");
+    expect(call.order).toBe("desc");
+    expect(result.anchorRepos).toEqual([]);
+    expect(result.message).toContain("No open feature opportunities");
+  });
+
+  it("vets and classifies broad-mode results", async () => {
+    const octokit = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: {
+            items: [
+              {
+                html_url: "https://github.com/x/y/issues/1",
+                title: "small enhancement",
+                labels: [{ name: "enhancement" }],
+                comments: 1,
+                reactions: { total_count: 1 },
+                milestone: null,
+                pull_request: undefined,
+                assignee: null,
+                created_at: "2026-04-01",
+                number: 1,
+              },
+              {
+                html_url: "https://github.com/x/y/issues/2",
+                title: "big proposal",
+                labels: [{ name: "proposal" }],
+                comments: 1,
+                reactions: { total_count: 1 },
+                milestone: { number: 1 },
+                pull_request: undefined,
+                assignee: null,
+                created_at: "2026-04-01",
+                number: 2,
+              },
+            ],
+          },
+        }),
+      },
+    } as never;
+    const result = await discoverFeaturesBroad({
+      octokit,
+      vetter: makeVetter(),
+      count: 10,
+    });
+    expect(result.quickWins).toHaveLength(1);
+    expect(result.biggerBets).toHaveLength(1);
+    expect(result.anchorRepos).toEqual([]);
+    expect(result.message).toBeNull();
+  });
+
+  it("propagates 401 errors from the Search API", async () => {
+    const octokit = {
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockRejectedValue(Object.assign(new Error("401"), { status: 401 })),
+      },
+    } as never;
+    await expect(
+      discoverFeaturesBroad({
+        octokit,
+        vetter: makeVetter(),
+        count: 5,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("returns no-results message on non-auth Search API failure", async () => {
+    const octokit = {
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockRejectedValue(new Error("transient")),
+      },
+    } as never;
+    const result = await discoverFeaturesBroad({
+      octokit,
+      vetter: makeVetter(),
+      count: 5,
+    });
+    expect(result.quickWins).toEqual([]);
+    expect(result.biggerBets).toEqual([]);
+    expect(result.message).toContain("No open feature opportunities");
   });
 });

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -269,7 +269,7 @@ export async function discoverFeatures(
     // adds at most one extra GET per anchor repo and the result is reused
     // across every issue in this loop iteration.
     let response;
-    let roadmapRefs: Set<number> = new Set();
+    let roadmapRefs: Set<number>;
     try {
       const [listResp, refs] = await Promise.all([
         opts.octokit.issues.listForRepo({
@@ -339,5 +339,157 @@ export async function discoverFeatures(
     ...split,
     anchorRepos,
     message: total === 0 ? NO_RESULTS_MESSAGE : null,
+  };
+}
+
+// ── Broad / cross-repo mode (#100) ──────────────────────────────────────
+
+export const NO_BROAD_RESULTS_MESSAGE =
+  "No open feature opportunities matched your filters. Try widening your language preferences in `scout config`.";
+
+export interface DiscoverFeaturesBroadOptions {
+  octokit: Octokit;
+  vetter: IssueVetter;
+  count: number;
+  /** Languages from user preferences ("any" disables the filter). */
+  languages?: string[];
+  excludeRepos?: string[];
+  excludeOrgs?: string[];
+  /** Override default split ratio. */
+  splitRatio?: number;
+  /** Maximum search results to vet (default 30). */
+  maxToVet?: number;
+}
+
+const DEFAULT_BROAD_MAX_TO_VET = 30;
+
+/**
+ * Build a GitHub Search query for cross-repo feature discovery.
+ *
+ * Exported separately from `discoverFeaturesBroad` so the query construction
+ * is independently testable without mocking the Search API.
+ */
+export function buildBroadFeatureSearchQuery(opts: {
+  languages?: string[];
+  excludeRepos?: string[];
+  excludeOrgs?: string[];
+}): string {
+  const parts: string[] = ["is:issue", "is:open", "no:assignee"];
+
+  // Feature labels — any-of via parenthesized OR.
+  const labelClause = FEATURE_LABELS.map((l) => `label:"${l}"`).join(" OR ");
+  parts.push(`(${labelClause})`);
+
+  // Exclude labels that overlap with `scout` territory.
+  for (const excl of FEATURE_EXCLUSION_LABELS) {
+    parts.push(`-label:"${excl}"`);
+  }
+
+  // Languages — skip the filter when "any" is the only preference, since
+  // GitHub Search has no `language:any` operator.
+  const languages = (opts.languages ?? []).filter(
+    (l) => l && l.toLowerCase() !== "any",
+  );
+  if (languages.length > 0) {
+    const langClause = languages.map((l) => `language:${l}`).join(" OR ");
+    parts.push(`(${langClause})`);
+  }
+
+  // User exclusions.
+  for (const repo of opts.excludeRepos ?? []) {
+    parts.push(`-repo:${repo}`);
+  }
+  for (const org of opts.excludeOrgs ?? []) {
+    parts.push(`-user:${org}`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Orchestrate broad / cross-repo feature discovery (#100). Bypasses anchor
+ * resolution; runs a single GitHub Search API query for feature-labeled
+ * open issues across the entire ecosystem, filtered by the user's language
+ * preferences and excluded repos/orgs.
+ *
+ * Designed for first-touch contributors who haven't yet built repo
+ * relationships and so wouldn't qualify under the default `scout features`
+ * anchor-based path.
+ *
+ * Auth (401) and rate-limit errors propagate; per-issue vet failures
+ * degrade gracefully.
+ */
+export async function discoverFeaturesBroad(
+  opts: DiscoverFeaturesBroadOptions,
+): Promise<FeatureSearchResult> {
+  const query = buildBroadFeatureSearchQuery({
+    languages: opts.languages,
+    excludeRepos: opts.excludeRepos,
+    excludeOrgs: opts.excludeOrgs,
+  });
+  const maxToVet = opts.maxToVet ?? DEFAULT_BROAD_MAX_TO_VET;
+
+  let items: RawIssueItem[];
+  try {
+    const response = await opts.octokit.search.issuesAndPullRequests({
+      q: query,
+      sort: "interactions",
+      order: "desc",
+      per_page: maxToVet,
+    });
+    items = (response.data.items as RawIssueItem[]).filter(
+      (it) => !it.pull_request && !it.assignee && isFeatureIssue(it),
+    );
+  } catch (err: unknown) {
+    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+    warn(MODULE, `broad feature search failed: ${errorMessage(err)}`);
+    return {
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: NO_BROAD_RESULTS_MESSAGE,
+    };
+  }
+
+  const candidates: FeatureCandidate[] = [];
+  for (const item of items) {
+    const labels = extractLabels(item);
+    const hasMilestone = !!item.milestone;
+    const reactions = item.reactions?.total_count ?? 0;
+    const comments = item.comments ?? 0;
+    const wontfixNoContributor = item.created_at
+      ? detectWontfixNoContributor({ labels, createdAt: item.created_at })
+      : false;
+    let candidate;
+    try {
+      candidate = await opts.vetter.vetIssue(item.html_url, {
+        featureSignals: {
+          reactions,
+          comments,
+          hasMilestone,
+          wontfixNoContributor,
+          // Roadmap scraping is per-repo and would require an extra fetch
+          // per unique repo in the broad result set — deliberately skipped
+          // here to keep the broad path cheap. Anchor mode keeps the bonus.
+        },
+      });
+    } catch (err: unknown) {
+      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
+      continue;
+    }
+    const horizon = classifyHorizon({ hasMilestone, labels });
+    candidates.push({ ...candidate, horizon });
+  }
+
+  const passing = candidates.filter(
+    (c) => c.viabilityScore >= MIN_VIABILITY_SCORE,
+  );
+  const split = splitByHorizon(passing, opts.count, opts.splitRatio);
+  const total = split.quickWins.length + split.biggerBets.length;
+  return {
+    ...split,
+    anchorRepos: [],
+    message: total === 0 ? NO_BROAD_RESULTS_MESSAGE : null,
   };
 }

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -19,6 +19,7 @@ import type { IssueVetter } from "./issue-vetting.js";
 import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { warn } from "./logger.js";
 import { sleep } from "./utils.js";
+import { fetchRoadmapIssueRefs } from "./roadmap.js";
 
 const MODULE = "feature-discovery";
 
@@ -264,16 +265,25 @@ export async function discoverFeatures(
   for (let i = 0; i < anchorRepos.length; i++) {
     if (i > 0) await sleep(INTER_REPO_DELAY_MS);
     const [owner, repo] = anchorRepos[i].split("/");
+    // Issues list and roadmap fetch run in parallel — roadmap scraping (#95)
+    // adds at most one extra GET per anchor repo and the result is reused
+    // across every issue in this loop iteration.
     let response;
+    let roadmapRefs: Set<number> = new Set();
     try {
-      response = await opts.octokit.issues.listForRepo({
-        owner,
-        repo,
-        state: "open",
-        sort: "updated",
-        direction: "desc",
-        per_page: 20,
-      });
+      const [listResp, refs] = await Promise.all([
+        opts.octokit.issues.listForRepo({
+          owner,
+          repo,
+          state: "open",
+          sort: "updated",
+          direction: "desc",
+          per_page: 20,
+        }),
+        fetchRoadmapIssueRefs(opts.octokit, owner, repo),
+      ]);
+      response = listResp;
+      roadmapRefs = refs;
     } catch (err: unknown) {
       if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
       warn(
@@ -295,6 +305,8 @@ export async function discoverFeatures(
       const wontfixNoContributor = item.created_at
         ? detectWontfixNoContributor({ labels, createdAt: item.created_at })
         : false;
+      const onRoadmap =
+        typeof item.number === "number" && roadmapRefs.has(item.number);
       let candidate;
       try {
         candidate = await opts.vetter.vetIssue(item.html_url, {
@@ -303,6 +315,7 @@ export async function discoverFeatures(
             comments,
             hasMilestone,
             wontfixNoContributor,
+            onRoadmap,
           },
         });
       } catch (err: unknown) {

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -137,6 +137,53 @@ export const FEATURE_EXCLUSION_LABELS = new Set([
   "documentation",
 ]);
 
+/**
+ * Labels that signal "the maintainer wants outside contributions". When any
+ * is present, combined with no linked PR and an issue age >= 60 days, the
+ * issue is treated as wontfix-no-contributor (#96).
+ */
+export const WONTFIX_NO_CONTRIBUTOR_LABELS = new Set([
+  "help wanted",
+  "contributions welcome",
+  "up-for-grabs",
+  "bounty",
+  "pinned",
+  "unmaintained",
+]);
+
+/** Minimum days an issue must be open to qualify as wontfix-no-contributor. */
+export const WONTFIX_MIN_AGE_DAYS = 60;
+
+/**
+ * Pure detector for the "wontfix because no contributor stepped up" pattern (#96).
+ *
+ * True when:
+ *   - issue carries any of WONTFIX_NO_CONTRIBUTOR_LABELS, AND
+ *   - issue has been open at least `minAgeDays` days (default 60)
+ *
+ * The orchestrator already filters out assigned issues before reaching the
+ * vetter. Linked-PR cases are deliberately not gated here: the existing
+ * -30 viability penalty for `hasExistingPR` already discounts those, and
+ * checking `hasLinkedPR` would require deferring scoring until after vet,
+ * doubling the work for a marginally cleaner signal.
+ */
+export function detectWontfixNoContributor(input: {
+  labels: string[];
+  createdAt: string;
+  now?: Date;
+  minAgeDays?: number;
+}): boolean {
+  const matched = input.labels.some((l) =>
+    WONTFIX_NO_CONTRIBUTOR_LABELS.has(l.toLowerCase()),
+  );
+  if (!matched) return false;
+  const created = new Date(input.createdAt);
+  if (Number.isNaN(created.getTime())) return false;
+  const now = input.now ?? new Date();
+  const ageDays = (now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24);
+  return ageDays >= (input.minAgeDays ?? WONTFIX_MIN_AGE_DAYS);
+}
+
 export const NO_ANCHORS_MESSAGE =
   "No anchor repos yet (need 3+ merged PRs in a repo). Try `scout search` to build relationships first.";
 
@@ -170,6 +217,8 @@ interface RawIssueItem {
   milestone?: { number?: number } | null;
   pull_request?: unknown;
   assignee?: unknown;
+  created_at?: string;
+  number?: number;
 }
 
 function extractLabels(item: RawIssueItem): string[] {
@@ -243,10 +292,18 @@ export async function discoverFeatures(
       const hasMilestone = !!item.milestone;
       const reactions = item.reactions?.total_count ?? 0;
       const comments = item.comments ?? 0;
+      const wontfixNoContributor = item.created_at
+        ? detectWontfixNoContributor({ labels, createdAt: item.created_at })
+        : false;
       let candidate;
       try {
         candidate = await opts.vetter.vetIssue(item.html_url, {
-          featureSignals: { reactions, comments, hasMilestone },
+          featureSignals: {
+            reactions,
+            comments,
+            hasMilestone,
+            wontfixNoContributor,
+          },
         });
       } catch (err: unknown) {
         if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;

--- a/packages/core/src/core/issue-scoring.test.ts
+++ b/packages/core/src/core/issue-scoring.test.ts
@@ -280,5 +280,63 @@ describe("calculateViabilityScore", () => {
       });
       expect(score).toBe(65 + 10 + 5 + 5);
     });
+
+    it("adds +8 when onRoadmap is true", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: {
+          reactions: 0,
+          comments: 0,
+          hasMilestone: false,
+          onRoadmap: true,
+        },
+      });
+      expect(score).toBe(65 + 8);
+    });
+
+    it("adds +10 when wontfixNoContributor is true", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: {
+          reactions: 0,
+          comments: 0,
+          hasMilestone: false,
+          wontfixNoContributor: true,
+        },
+      });
+      expect(score).toBe(65 + 10);
+    });
+
+    it("combines onRoadmap and wontfixNoContributor with other bonuses, clamped at 100", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        featureSignals: {
+          reactions: 20,
+          comments: 10,
+          hasMilestone: true,
+          onRoadmap: true,
+          wontfixNoContributor: true,
+        },
+      });
+      // raw 65 + 10 + 5 + 5 + 8 + 10 = 103, clamped to 100
+      expect(score).toBe(100);
+    });
+
+    it("clamps total at 100 when all feature bonuses fire", () => {
+      const score = calculateViabilityScore({
+        ...baseFeature,
+        clearRequirements: true,
+        hasContributionGuidelines: true,
+        repoScore: 10,
+        featureSignals: {
+          reactions: 200,
+          comments: 50,
+          hasMilestone: true,
+          onRoadmap: true,
+          wontfixNoContributor: true,
+        },
+      });
+      expect(score).toBe(100);
+    });
   });
 });

--- a/packages/core/src/core/issue-scoring.ts
+++ b/packages/core/src/core/issue-scoring.ts
@@ -45,13 +45,16 @@ export interface ViabilityScoreParams {
   matchesPreferredCategory?: boolean;
   /**
    * Optional feature-mode signals. When present, applies reaction (cap +10),
-   * comment-depth (+5 if >=5), and milestone (+5) bonuses. When absent,
-   * scoring behavior is unchanged.
+   * comment-depth (+5 if >=5), milestone (+5), onRoadmap (+8), and
+   * wontfixNoContributor (+10) bonuses. When absent, scoring behavior is
+   * unchanged.
    */
   featureSignals?: {
     reactions: number;
     comments: number;
     hasMilestone: boolean;
+    onRoadmap?: boolean;
+    wontfixNoContributor?: boolean;
   };
 }
 
@@ -132,12 +135,14 @@ export function calculateViabilityScore(params: ViabilityScoreParams): number {
     score -= 15;
   }
 
-  // Feature signals: reactions, comment depth, and milestone bonuses
+  // Feature signals: reactions, comment depth, milestone, roadmap, wontfix-no-contributor
   if (params.featureSignals) {
     const fs = params.featureSignals;
     score += Math.min(Math.floor(fs.reactions / 2), 10);
     if (fs.comments >= 5) score += 5;
     if (fs.hasMilestone) score += 5;
+    if (fs.onRoadmap) score += 8;
+    if (fs.wontfixNoContributor) score += 10;
   }
 
   // Clamp to 0-100

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -654,9 +654,10 @@ describe("IssueVetter", () => {
       // Should NOT be the sentinel — different signal key avoided the collision.
       expect(result).not.toBe(sentinel);
       expect(set).toHaveBeenCalled();
-      // Confirm the lookup used a signals-suffixed key.
+      // Confirm the lookup used a signals-suffixed key including the new
+      // onRoadmap (`o`) and wontfixNoContributor (`w`) flags.
       expect(getIfFresh).toHaveBeenCalledWith(
-        "vet:https://github.com/foo/bar/issues/103:r4c0m1",
+        "vet:https://github.com/foo/bar/issues/103:r4c0m1o0w0",
         expect.any(Number),
       );
     });

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -58,12 +58,23 @@ const VETTING_CACHE_TTL_MS = 15 * 60 * 1000;
  * Feature-mode signals supplied by the caller (orchestrator) — the vetter
  * does NOT extract these from the GitHub issue itself. When passed, they
  * plumb through to `calculateViabilityScore` to apply reaction, comment-depth,
- * and milestone bonuses.
+ * milestone, roadmap, and wontfix-no-contributor bonuses.
  */
 export type FeatureSignals = {
   reactions: number;
   comments: number;
   hasMilestone: boolean;
+  /**
+   * Issue is referenced from the repo's ROADMAP.md. Strong maintainer-commitment
+   * signal — they've publicly committed to the work in a roadmap doc (#95).
+   */
+  onRoadmap?: boolean;
+  /**
+   * Issue exhibits "wontfix-no-contributor" pattern — labeled help-wanted /
+   * contributions-welcome / up-for-grabs / bounty, no linked PR, open >= 60
+   * days. Maintainer wants it; nobody has stepped up (#96).
+   */
+  wontfixNoContributor?: boolean;
 };
 
 /**
@@ -114,7 +125,7 @@ export class IssueVetter {
     // Check vetting cache first — avoids ~6+ API calls per issue
     const cache = getHttpCache();
     const sigKey = opts?.featureSignals
-      ? `:r${opts.featureSignals.reactions}c${opts.featureSignals.comments}m${opts.featureSignals.hasMilestone ? 1 : 0}`
+      ? `:r${opts.featureSignals.reactions}c${opts.featureSignals.comments}m${opts.featureSignals.hasMilestone ? 1 : 0}o${opts.featureSignals.onRoadmap ? 1 : 0}w${opts.featureSignals.wontfixNoContributor ? 1 : 0}`
       : "";
     const cacheKey = `vet:${issueUrl}${sigKey}`;
     const cached = cache.getIfFresh(cacheKey, VETTING_CACHE_TTL_MS);

--- a/packages/core/src/core/roadmap.test.ts
+++ b/packages/core/src/core/roadmap.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  parseRoadmapIssueRefs,
+  fetchRoadmapIssueRefs,
+  _clearRoadmapCacheForTests,
+} from "./roadmap.js";
+
+beforeEach(() => {
+  _clearRoadmapCacheForTests();
+});
+
+describe("parseRoadmapIssueRefs", () => {
+  it("extracts bare #N references", () => {
+    const md = "Plans:\n- support migration #42\n- ship transports #128\n";
+    expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([42, 128]));
+  });
+
+  it("ignores markdown headings starting with #", () => {
+    const md = "# Roadmap\n## Q1 priorities\n- review #99\n";
+    expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([99]));
+  });
+
+  it("extracts in-repo GitHub issue URLs", () => {
+    const md =
+      "See https://github.com/foo/bar/issues/1 and https://github.com/Foo/BAR/issues/2 for context.";
+    expect(parseRoadmapIssueRefs(md, "foo", "bar")).toEqual(new Set([1, 2]));
+  });
+
+  it("ignores URLs pointing to other repos", () => {
+    const md =
+      "Tracks https://github.com/other/repo/issues/77 (out of scope here).";
+    expect(parseRoadmapIssueRefs(md, "foo", "bar")).toEqual(new Set());
+  });
+
+  it("handles parenthesized and bracketed refs", () => {
+    const md = "(see #5) and [also #6]";
+    expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([5, 6]));
+  });
+
+  it("does not match HTML entities like &#1234;", () => {
+    const md = "Symbol &#9733; is a star, not issue #1234.";
+    // Should still pick up #1234 (separate token), but NOT the &#9733;
+    expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([1234]));
+  });
+
+  it("returns empty set for content without refs", () => {
+    expect(parseRoadmapIssueRefs("Just prose, no refs.", "a", "b")).toEqual(
+      new Set(),
+    );
+  });
+
+  it("dedupes repeated references", () => {
+    const md = "#7 #7 #7 https://github.com/a/b/issues/7";
+    expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([7]));
+  });
+});
+
+describe("fetchRoadmapIssueRefs", () => {
+  function makeOctokit(impl: (path: string) => Promise<unknown>) {
+    return {
+      repos: {
+        getContent: vi.fn().mockImplementation(async ({ path }) => impl(path)),
+      },
+    } as never;
+  }
+
+  function notFound() {
+    return Object.assign(new Error("not found"), { status: 404 });
+  }
+
+  it("fetches the first matching path and parses refs", async () => {
+    const md = "- ship #11\n- watch #12\n";
+    const octokit = makeOctokit(async (path: string) => {
+      if (path === "ROADMAP.md") {
+        return {
+          data: { content: Buffer.from(md, "utf-8").toString("base64") },
+        };
+      }
+      throw notFound();
+    });
+    const refs = await fetchRoadmapIssueRefs(octokit, "foo", "bar");
+    expect(refs).toEqual(new Set([11, 12]));
+  });
+
+  it("falls through 404s to the next candidate path", async () => {
+    const md = "- #99";
+    const octokit = makeOctokit(async (path: string) => {
+      if (path === "docs/ROADMAP.md") {
+        return {
+          data: { content: Buffer.from(md, "utf-8").toString("base64") },
+        };
+      }
+      throw notFound();
+    });
+    const refs = await fetchRoadmapIssueRefs(octokit, "foo", "bar");
+    expect(refs).toEqual(new Set([99]));
+  });
+
+  it("returns empty set when no roadmap exists", async () => {
+    const octokit = makeOctokit(async () => {
+      throw notFound();
+    });
+    const refs = await fetchRoadmapIssueRefs(octokit, "foo", "bar");
+    expect(refs).toEqual(new Set());
+  });
+
+  it("caches results — second call hits no API", async () => {
+    const md = "- #5";
+    const calls: string[] = [];
+    const octokit = makeOctokit(async (path: string) => {
+      calls.push(path);
+      if (path === "ROADMAP.md") {
+        return {
+          data: { content: Buffer.from(md, "utf-8").toString("base64") },
+        };
+      }
+      throw notFound();
+    });
+    await fetchRoadmapIssueRefs(octokit, "foo", "bar");
+    const beforeCount = calls.length;
+    const second = await fetchRoadmapIssueRefs(octokit, "foo", "bar");
+    expect(calls.length).toBe(beforeCount);
+    expect(second).toEqual(new Set([5]));
+  });
+
+  it("propagates 401 errors", async () => {
+    const octokit = makeOctokit(async () => {
+      throw Object.assign(new Error("unauth"), { status: 401 });
+    });
+    await expect(
+      fetchRoadmapIssueRefs(octokit, "foo", "bar"),
+    ).rejects.toThrow();
+  });
+
+  it("propagates rate-limit errors", async () => {
+    const octokit = makeOctokit(async () => {
+      throw Object.assign(new Error("API rate limit exceeded"), {
+        status: 403,
+      });
+    });
+    await expect(
+      fetchRoadmapIssueRefs(octokit, "foo", "bar"),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/core/src/core/roadmap.ts
+++ b/packages/core/src/core/roadmap.ts
@@ -74,7 +74,8 @@ export function parseRoadmapIssueRefs(
 
   // Full GitHub issue URLs scoped to this repo.
   const ownerRepo = `${owner}/${repo}`.toLowerCase();
-  const urlPattern = /https?:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)/gi;
+  const urlPattern =
+    /https?:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)/gi;
   for (const m of content.matchAll(urlPattern)) {
     if (m[1].toLowerCase() === ownerRepo) {
       const n = Number.parseInt(m[2], 10);

--- a/packages/core/src/core/roadmap.ts
+++ b/packages/core/src/core/roadmap.ts
@@ -1,0 +1,139 @@
+/**
+ * Roadmap scraping (#95) — fetches a repo's ROADMAP.md (or variant) and
+ * extracts referenced GitHub issue numbers. Used by feature-discovery to
+ * apply an `onRoadmap` bonus when the maintainer has publicly committed
+ * to an issue in their roadmap doc.
+ *
+ * Cached for 1 hour per repo. 404s are cached as empty sets so repos
+ * without a roadmap don't get re-probed every run.
+ *
+ * Auth (401) and rate-limit errors propagate, matching the rest of the
+ * codebase's error strategy. Other errors degrade gracefully (warn + empty).
+ */
+
+import type { Octokit } from "@octokit/rest";
+import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import { warn } from "./logger.js";
+
+const MODULE = "roadmap";
+
+/** TTL for roadmap fetch results (1 hour). */
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Paths probed in priority order. First success wins. */
+const ROADMAP_PATHS = [
+  "ROADMAP.md",
+  "docs/ROADMAP.md",
+  ".github/ROADMAP.md",
+  "Roadmap.md",
+  "roadmap.md",
+] as const;
+
+interface CacheEntry {
+  refs: Set<number>;
+  fetchedAt: number;
+}
+
+const roadmapCache = new Map<string, CacheEntry>();
+
+/** Drop expired entries. Called from each fetch. */
+function pruneCache(): void {
+  const cutoff = Date.now() - CACHE_TTL_MS;
+  for (const [key, value] of roadmapCache.entries()) {
+    if (value.fetchedAt < cutoff) roadmapCache.delete(key);
+  }
+}
+
+/**
+ * Parse markdown content for issue number references.
+ *
+ * Extracts:
+ *   - bare `#NNN` references that are not at start-of-line (those are headings)
+ *   - `https://github.com/<owner>/<repo>/issues/NNN` URLs that match the
+ *     repo we're parsing for (URLs to other repos are ignored)
+ *
+ * The match for in-repo URLs is intentional: scattered references to
+ * unrelated repos in a roadmap shouldn't bump scores in those repos.
+ */
+export function parseRoadmapIssueRefs(
+  content: string,
+  owner: string,
+  repo: string,
+): Set<number> {
+  const refs = new Set<number>();
+
+  // Bare `#N` references, scanned line-by-line so we can skip markdown
+  // headings (`# title`, `## section`) — those aren't issue refs.
+  for (const line of content.split("\n")) {
+    if (/^\s*#+\s/.test(line)) continue;
+    for (const m of line.matchAll(/(?:^|[^&\w])#(\d+)\b/g)) {
+      const n = Number.parseInt(m[1], 10);
+      if (n > 0) refs.add(n);
+    }
+  }
+
+  // Full GitHub issue URLs scoped to this repo.
+  const ownerRepo = `${owner}/${repo}`.toLowerCase();
+  const urlPattern = /https?:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)/gi;
+  for (const m of content.matchAll(urlPattern)) {
+    if (m[1].toLowerCase() === ownerRepo) {
+      const n = Number.parseInt(m[2], 10);
+      if (n > 0) refs.add(n);
+    }
+  }
+
+  return refs;
+}
+
+/**
+ * Fetch and parse the repo's ROADMAP.md, returning the set of referenced
+ * issue numbers. Returns an empty set if no roadmap is found.
+ *
+ * Probes ROADMAP_PATHS sequentially until a 200 response is received.
+ * Auth/rate-limit errors propagate; other errors are logged and degrade
+ * to an empty set.
+ */
+export async function fetchRoadmapIssueRefs(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<Set<number>> {
+  const cacheKey = `${owner}/${repo}`.toLowerCase();
+  const cached = roadmapCache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.refs;
+  }
+
+  for (const path of ROADMAP_PATHS) {
+    try {
+      const { data } = await octokit.repos.getContent({ owner, repo, path });
+      if (!("content" in data)) continue;
+      const content = Buffer.from(data.content, "base64").toString("utf-8");
+      const refs = parseRoadmapIssueRefs(content, owner, repo);
+      roadmapCache.set(cacheKey, { refs, fetchedAt: Date.now() });
+      pruneCache();
+      return refs;
+    } catch (err: unknown) {
+      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      const status = getHttpStatusCode(err);
+      if (status === 404) continue; // path missing — try next
+      warn(
+        MODULE,
+        `Unexpected error fetching ${path} from ${owner}/${repo}: ${errorMessage(err)}`,
+      );
+      // Fall through and try next path.
+    }
+  }
+
+  // No roadmap found (or all probes errored softly). Cache the empty result
+  // so we don't re-probe every run.
+  const empty = new Set<number>();
+  roadmapCache.set(cacheKey, { refs: empty, fetchedAt: Date.now() });
+  pruneCache();
+  return empty;
+}
+
+/** Test-only: clear the in-memory cache. */
+export function _clearRoadmapCacheForTests(): void {
+  roadmapCache.clear();
+}

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -10,6 +10,7 @@ import { IssueVetter } from "./core/issue-vetting.js";
 import type { ScoutStateReader } from "./core/issue-vetting.js";
 import {
   discoverFeatures,
+  discoverFeaturesBroad,
   type FeatureSearchResult,
 } from "./core/feature-discovery.js";
 import { ScoutStateSchema } from "./core/schemas.js";
@@ -233,26 +234,43 @@ export class OssScout implements ScoutStateReader {
    *
    * Per-call `anchorThreshold` and `splitRatio` overrides take precedence
    * over the persisted preferences.
+   *
+   * When `broad` is true (#100), bypasses anchor resolution and runs a
+   * cross-repo GitHub Search query for first-touch contributors who
+   * haven't yet built repo relationships. Filters by user language
+   * preferences and excluded repos/orgs.
    */
   async features(options?: {
     count?: number;
     anchorThreshold?: number;
     splitRatio?: number;
+    broad?: boolean;
   }): Promise<FeatureSearchResult> {
     const count = options?.count ?? 10;
     const octokit = getOctokit(this.githubToken);
     const vetter = new IssueVetter(octokit, this);
-    const result = await discoverFeatures({
-      octokit,
-      vetter,
-      repoScores: this.state.repoScores ?? {},
-      count,
-      anchorThreshold:
-        options?.anchorThreshold ??
-        this.state.preferences.featuresAnchorThreshold,
-      splitRatio:
-        options?.splitRatio ?? this.state.preferences.featuresSplitRatio,
-    });
+    const result = options?.broad
+      ? await discoverFeaturesBroad({
+          octokit,
+          vetter,
+          count,
+          languages: this.state.preferences.languages,
+          excludeRepos: this.state.preferences.excludeRepos,
+          excludeOrgs: this.state.preferences.excludeOrgs,
+          splitRatio:
+            options?.splitRatio ?? this.state.preferences.featuresSplitRatio,
+        })
+      : await discoverFeatures({
+          octokit,
+          vetter,
+          repoScores: this.state.repoScores ?? {},
+          count,
+          anchorThreshold:
+            options?.anchorThreshold ??
+            this.state.preferences.featuresAnchorThreshold,
+          splitRatio:
+            options?.splitRatio ?? this.state.preferences.featuresSplitRatio,
+        });
 
     this.saveResults([...result.quickWins, ...result.biggerBets]);
     this.state.lastSearchAt = new Date().toISOString();


### PR DESCRIPTION
## Summary

Closes the three remaining "out of scope for v1" follow-ups from the
scout features design spec (#92 / docs/superpowers/specs/2026-05-08-scout-features-design.md).

- **#96 wontfix-no-contributor detection.** Pure detector flags issues
  carrying any of {help wanted, contributions welcome, up-for-grabs,
  bounty, pinned, unmaintained} that have been open >= 60 days. +10
  viability bonus when set.
- **#95 ROADMAP.md scraping.** New core/roadmap.ts fetches a repo's
  ROADMAP.md (and docs/, .github/ variants), parses out referenced
  issue numbers, caches per repo for 1h. +8 viability bonus when an
  anchor-mode issue appears in the roadmap.
- **#100 cross-repo features mode.** New \`--broad\` flag bypasses anchor
  resolution and runs a single GitHub Search API query for feature-labeled
  issues across the ecosystem, filtered by user language prefs and
  excluded repos/orgs. Sort by \`interactions\` desc.

All three plug into the existing \`FeatureSignals\` plumbing — no architectural change.

## Test plan

- [x] \`pnpm test\` — 718 passing (699 core + 19 mcp-server)
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run format:check\` — clean
- [x] \`pnpm exec tsc --noEmit\` — clean for core and mcp-server
- [x] \`pnpm run bundle\` — CLI and MCP bundles regenerate
- [ ] Manual smoke: \`pnpm start -- features 5 --broad --json\` against a real token