### PR TITLE
fix: align ROADMAP scraping with intended design (#95)

### DIFF
--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -710,7 +710,11 @@ describe("discoverFeatures orchestrator", () => {
         },
         vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
         projectHealth: {},
-        antiLLMPolicy: { matched: false, matchedKeywords: [], sourceFile: null },
+        antiLLMPolicy: {
+          matched: false,
+          matchedKeywords: [],
+          sourceFile: null,
+        },
         slmTriage: null,
         recommendation: "approve",
         reasonsToApprove: [],

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -183,6 +183,15 @@ describe("classifyHorizon", () => {
       "bigger-bet",
     );
   });
+  it("returns bigger-bet when isOnRoadmap is true even without milestone or label", () => {
+    expect(
+      classifyHorizon({
+        hasMilestone: false,
+        labels: ["enhancement"],
+        isOnRoadmap: true,
+      }),
+    ).toBe("bigger-bet");
+  });
 });
 
 const mkCand = (
@@ -635,7 +644,7 @@ describe("discoverFeatures orchestrator", () => {
         searchPriority: "merged_pr",
       })),
     } as never;
-    await discoverFeatures({
+    const result = await discoverFeatures({
       octokit,
       vetter,
       repoScores: mkScores(["a/b", 4]),
@@ -650,6 +659,96 @@ describe("discoverFeatures orchestrator", () => {
     )?.[1]?.featureSignals?.onRoadmap;
     expect(onRoadmap7).toBe(true);
     expect(onRoadmap8).toBe(false);
+
+    // Horizon classification: roadmap-listed issue forces bigger-bet, off-roadmap stays quick-win.
+    const all = [...result.quickWins, ...result.biggerBets];
+    const cand7 = all.find(
+      (c) => c.issue.url === "https://github.com/a/b/issues/7",
+    );
+    const cand8 = all.find(
+      (c) => c.issue.url === "https://github.com/a/b/issues/8",
+    );
+    expect(cand7?.horizon).toBe("bigger-bet");
+    expect(cand8?.horizon).toBe("quick-win");
+  });
+
+  it("does not throw when roadmap fetch returns 404 — issue stays quick-win without other signals", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({
+          data: [
+            {
+              html_url: "https://github.com/a/b/issues/100",
+              title: "feature with no roadmap",
+              labels: [{ name: "enhancement" }],
+              comments: 1,
+              reactions: { total_count: 1 },
+              milestone: null,
+              pull_request: undefined,
+              assignee: null,
+              created_at: "2026-04-01",
+              number: 100,
+            },
+          ],
+        }),
+      },
+      repos: {
+        getContent: vi
+          .fn()
+          .mockRejectedValue(Object.assign(new Error("nf"), { status: 404 })),
+      },
+    } as never;
+    const vetter = {
+      vetIssue: vi.fn().mockImplementation(async (url: string) => ({
+        issue: {
+          url,
+          repo: "a/b",
+          number: 100,
+          title: "t",
+          labels: [],
+          updatedAt: "2026-05-01",
+        },
+        vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
+        projectHealth: {},
+        antiLLMPolicy: { matched: false, matchedKeywords: [], sourceFile: null },
+        slmTriage: null,
+        recommendation: "approve",
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        viabilityScore: 80,
+        searchPriority: "merged_pr",
+      })),
+    } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(["a/b", 4]),
+      count: 5,
+    });
+    const all = [...result.quickWins, ...result.biggerBets];
+    expect(all).toHaveLength(1);
+    expect(all[0].horizon).toBe("quick-win");
+  });
+
+  it("propagates 401 from roadmap fetch", async () => {
+    const auth401 = Object.assign(new Error("unauth"), { status: 401 });
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      repos: {
+        getContent: vi.fn().mockRejectedValue(auth401),
+      },
+    } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    await expect(
+      discoverFeatures({
+        octokit,
+        vetter,
+        repoScores: mkScores(["a/b", 4]),
+        count: 5,
+      }),
+    ).rejects.toThrow();
   });
 
   it("propagates auth and rate-limit errors", async () => {

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -61,13 +61,16 @@ export const BIGGER_BET_LABELS = new Set([
 
 /**
  * Classify an issue into "quick-win" or "bigger-bet" based on
- * maintainer-commitment signals (milestone presence + label set).
+ * maintainer-commitment signals (milestone presence, label set, ROADMAP.md
+ * membership). Roadmap membership (#95) is treated as an explicit
+ * maintainer commitment and forces the bigger-bet horizon.
  */
 export function classifyHorizon(input: {
   hasMilestone: boolean;
   labels: string[];
+  isOnRoadmap?: boolean;
 }): Horizon {
-  if (input.hasMilestone) return "bigger-bet";
+  if (input.hasMilestone || input.isOnRoadmap) return "bigger-bet";
   for (const label of input.labels) {
     if (BIGGER_BET_LABELS.has(label.toLowerCase())) return "bigger-bet";
   }
@@ -323,7 +326,11 @@ export async function discoverFeatures(
         warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
         continue;
       }
-      const horizon = classifyHorizon({ hasMilestone, labels });
+      const horizon = classifyHorizon({
+        hasMilestone,
+        labels,
+        isOnRoadmap: onRoadmap,
+      });
       candidates.push({ ...candidate, horizon });
     }
   }

--- a/packages/core/src/core/issue-scoring.test.ts
+++ b/packages/core/src/core/issue-scoring.test.ts
@@ -281,7 +281,7 @@ describe("calculateViabilityScore", () => {
       expect(score).toBe(65 + 10 + 5 + 5);
     });
 
-    it("adds +8 when onRoadmap is true", () => {
+    it("does not score onRoadmap (#95: roadmap drives horizon, not score)", () => {
       const score = calculateViabilityScore({
         ...baseFeature,
         featureSignals: {
@@ -291,7 +291,7 @@ describe("calculateViabilityScore", () => {
           onRoadmap: true,
         },
       });
-      expect(score).toBe(65 + 8);
+      expect(score).toBe(65);
     });
 
     it("adds +10 when wontfixNoContributor is true", () => {
@@ -307,7 +307,7 @@ describe("calculateViabilityScore", () => {
       expect(score).toBe(65 + 10);
     });
 
-    it("combines onRoadmap and wontfixNoContributor with other bonuses, clamped at 100", () => {
+    it("combines wontfixNoContributor with other bonuses (onRoadmap excluded from score)", () => {
       const score = calculateViabilityScore({
         ...baseFeature,
         featureSignals: {
@@ -318,8 +318,8 @@ describe("calculateViabilityScore", () => {
           wontfixNoContributor: true,
         },
       });
-      // raw 65 + 10 + 5 + 5 + 8 + 10 = 103, clamped to 100
-      expect(score).toBe(100);
+      // raw 65 + 10 + 5 + 5 + 10 = 95 (onRoadmap contributes 0)
+      expect(score).toBe(95);
     });
 
     it("clamps total at 100 when all feature bonuses fire", () => {

--- a/packages/core/src/core/issue-scoring.ts
+++ b/packages/core/src/core/issue-scoring.ts
@@ -45,9 +45,12 @@ export interface ViabilityScoreParams {
   matchesPreferredCategory?: boolean;
   /**
    * Optional feature-mode signals. When present, applies reaction (cap +10),
-   * comment-depth (+5 if >=5), milestone (+5), onRoadmap (+8), and
-   * wontfixNoContributor (+10) bonuses. When absent, scoring behavior is
-   * unchanged.
+   * comment-depth (+5 if >=5), milestone (+5), and wontfixNoContributor
+   * (+10) bonuses. When absent, scoring behavior is unchanged.
+   *
+   * Note: `onRoadmap` is forwarded for cache-key uniqueness but does NOT
+   * contribute to the viability score (#95) — roadmap membership influences
+   * horizon classification only, not score.
    */
   featureSignals?: {
     reactions: number;
@@ -135,13 +138,14 @@ export function calculateViabilityScore(params: ViabilityScoreParams): number {
     score -= 15;
   }
 
-  // Feature signals: reactions, comment depth, milestone, roadmap, wontfix-no-contributor
+  // Feature signals: reactions, comment depth, milestone, wontfix-no-contributor.
+  // Note: onRoadmap (#95) is intentionally NOT scored — roadmap membership is
+  // surfaced via the horizon classifier instead.
   if (params.featureSignals) {
     const fs = params.featureSignals;
     score += Math.min(Math.floor(fs.reactions / 2), 10);
     if (fs.comments >= 5) score += 5;
     if (fs.hasMilestone) score += 5;
-    if (fs.onRoadmap) score += 8;
     if (fs.wontfixNoContributor) score += 10;
   }
 

--- a/packages/core/src/core/roadmap.test.ts
+++ b/packages/core/src/core/roadmap.test.ts
@@ -53,6 +53,23 @@ describe("parseRoadmapIssueRefs", () => {
     const md = "#7 #7 #7 https://github.com/a/b/issues/7";
     expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([7]));
   });
+
+  it("extracts owner/repo#N cross-repo refs scoped to the current repo", () => {
+    const md = "Track foo/bar#42 and FOO/BAR#43 alongside #44.";
+    expect(parseRoadmapIssueRefs(md, "foo", "bar")).toEqual(
+      new Set([42, 43, 44]),
+    );
+  });
+
+  it("ignores owner/repo#N refs pointing to other repos", () => {
+    const md = "See other/proj#99 for context (out of scope here).";
+    expect(parseRoadmapIssueRefs(md, "foo", "bar")).toEqual(new Set());
+  });
+
+  it("dedupes when the same issue appears as #N, owner/repo#N, and URL", () => {
+    const md = "Track #7, foo/bar#7, and https://github.com/foo/bar/issues/7.";
+    expect(parseRoadmapIssueRefs(md, "foo", "bar")).toEqual(new Set([7]));
+  });
 });
 
 describe("fetchRoadmapIssueRefs", () => {

--- a/packages/core/src/core/roadmap.ts
+++ b/packages/core/src/core/roadmap.ts
@@ -48,12 +48,14 @@ function pruneCache(): void {
  * Parse markdown content for issue number references.
  *
  * Extracts:
- *   - bare `#NNN` references that are not at start-of-line (those are headings)
+ *   - bare `#NNN` references that are not on a markdown heading line
+ *   - `<owner>/<repo>#NNN` cross-repo refs that match the repo we're parsing for
  *   - `https://github.com/<owner>/<repo>/issues/NNN` URLs that match the
  *     repo we're parsing for (URLs to other repos are ignored)
  *
- * The match for in-repo URLs is intentional: scattered references to
- * unrelated repos in a roadmap shouldn't bump scores in those repos.
+ * The match for cross-repo `owner/repo#N` and full URLs is intentional:
+ * scattered references to unrelated repos in a roadmap shouldn't bump
+ * scores in those repos.
  */
 export function parseRoadmapIssueRefs(
   content: string,
@@ -61,23 +63,39 @@ export function parseRoadmapIssueRefs(
   repo: string,
 ): Set<number> {
   const refs = new Set<number>();
+  const ownerRepoLower = `${owner}/${repo}`.toLowerCase();
+
+  // `owner/repo#N` cross-repo style refs — must match the current repo.
+  // We escape regex metachars in case repo names contain `.` or `-`.
+  const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const fullRefPattern = new RegExp(
+    `\\b${escape(owner)}/${escape(repo)}#(\\d+)\\b`,
+    "gi",
+  );
+  for (const m of content.matchAll(fullRefPattern)) {
+    const n = Number.parseInt(m[1], 10);
+    if (n > 0) refs.add(n);
+  }
 
   // Bare `#N` references, scanned line-by-line so we can skip markdown
-  // headings (`# title`, `## section`) — those aren't issue refs.
+  // headings (`# title`, `## section`) — those aren't issue refs. We also
+  // strip out `owner/repo#N` matches first so `#N` in a cross-repo ref to
+  // a different repo doesn't leak in as a bare match.
+  const fullRefStripPattern = /\b[\w.-]+\/[\w.-]+#\d+\b/gi;
   for (const line of content.split("\n")) {
     if (/^\s*#+\s/.test(line)) continue;
-    for (const m of line.matchAll(/(?:^|[^&\w])#(\d+)\b/g)) {
+    const stripped = line.replace(fullRefStripPattern, "");
+    for (const m of stripped.matchAll(/(?:^|[^&\w])#(\d+)\b/g)) {
       const n = Number.parseInt(m[1], 10);
       if (n > 0) refs.add(n);
     }
   }
 
   // Full GitHub issue URLs scoped to this repo.
-  const ownerRepo = `${owner}/${repo}`.toLowerCase();
   const urlPattern =
     /https?:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)/gi;
   for (const m of content.matchAll(urlPattern)) {
-    if (m[1].toLowerCase() === ownerRepo) {
+    if (m[1].toLowerCase() === ownerRepoLower) {
       const n = Number.parseInt(m[2], 10);
       if (n > 0) refs.add(n);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,3 +105,9 @@ export {
   isLinkedPRStalled,
   STALLED_PR_THRESHOLD_DAYS,
 } from "./core/linked-pr.js";
+
+// Roadmap scraping (#95)
+export {
+  fetchRoadmapIssueRefs,
+  parseRoadmapIssueRefs,
+} from "./core/roadmap.js";


### PR DESCRIPTION
## Summary

Aligns the existing `ROADMAP.md` scraping implementation (shipped in #103) with the design we landed in the original #92 brainstorm and reaffirmed in a follow-up brainstorm for #95: **force bigger-bet horizon, no score boost.**

## Why

PR #103 shipped a partial implementation that:
- Added a +8 viability score boost when an issue is referenced in ROADMAP.md
- Did not wire the roadmap signal into `classifyHorizon` (so the horizon classifier still ignored it)
- Only detected bare `#N` and full URL refs, missing `owner/repo#N` cross-repo refs

The agreed design is the opposite: force bigger-bet horizon when on the roadmap, no score change. Score boosts compound with other signals in unintended ways; horizon classification is the primary axis the user reads.

## What changed

- **Drop the +8 score boost** (`issue-scoring.ts`) and update its tests.
- **Wire roadmap signal into `classifyHorizon`**: new optional `isOnRoadmap` parameter, returns "bigger-bet" when true (alongside milestone and existing label triggers).
- **Detect `owner/repo#N`** cross-repo references (case-insensitive, filtered to current repo only) in `parseRoadmapIssueRefs`.
- **Export `fetchRoadmapIssueRefs` + `parseRoadmapIssueRefs`** from the public API.

## Behavioral note

Roadmap-listed issues get a horizon promotion (quick-win to bigger-bet, if applicable) but no score bump going forward. This is intentional per the brainstorm decision; users who relied on the +8 boost from the brief window between #103 and this fix will see lower viability scores for those issues, but they will appear in the bigger-bets section instead.

## Test plan

- [x] All unit tests pass (705 core + 19 mcp = 724, +6 new)
- [x] Lint, format:check, typecheck, bundle clean
- [x] `classifyHorizon({ isOnRoadmap: true, ... })` returns "bigger-bet"
- [x] `parseRoadmapIssueRefs` detects `foo/bar#123` and skips `other/proj#456`
- [x] `discoverFeatures` 401 from roadmap fetch propagates; 404 silently falls through
- [ ] CI green on Node 20/22/24