### PR TITLE
fix(search): fan out Phase 2 per language when combined with labels

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -102,7 +102,7 @@ const mockFetchIssuesFromKnownRepos = vi.fn().mockResolvedValue({
   rateLimitHit: false,
 });
 
-const mockSearchWithChunkedLabels = vi.fn().mockResolvedValue([]);
+const mockSearchAcrossLanguagesAndLabels = vi.fn().mockResolvedValue([]);
 
 const mockFilterVetAndScore = vi.fn().mockResolvedValue({
   candidates: [],
@@ -126,8 +126,8 @@ vi.mock("./search-phases.js", () => ({
   interleaveArrays: vi.fn((arrays: unknown[][]) => arrays.flat()),
   fetchIssuesFromKnownRepos: (...args: unknown[]) =>
     mockFetchIssuesFromKnownRepos(...args),
-  searchWithChunkedLabels: (...args: unknown[]) =>
-    mockSearchWithChunkedLabels(...args),
+  searchAcrossLanguagesAndLabels: (...args: unknown[]) =>
+    mockSearchAcrossLanguagesAndLabels(...args),
   filterVetAndScore: (...args: unknown[]) => mockFilterVetAndScore(...args),
   cachedSearchIssues: (...args: unknown[]) => mockCachedSearchIssues(...args),
   fetchIssuesFromMaintainedRepos: (...args: unknown[]) =>
@@ -254,7 +254,7 @@ describe("IssueDiscovery", () => {
       allReposFailed: false,
       rateLimitHit: false,
     });
-    mockSearchWithChunkedLabels.mockResolvedValue([]);
+    mockSearchAcrossLanguagesAndLabels.mockResolvedValue([]);
     mockFilterVetAndScore.mockResolvedValue({
       candidates: [],
       allVetFailed: false,
@@ -426,7 +426,7 @@ describe("IssueDiscovery", () => {
         repository_url: "https://api.github.com/repos/broad/repo",
         updated_at: "2026-01-01T00:00:00Z",
       };
-      mockSearchWithChunkedLabels.mockResolvedValue([item]);
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue([item]);
       const c = makeCandidate("broad/repo", "normal");
       mockFilterVetAndScore.mockResolvedValue({
         candidates: [c],
@@ -437,7 +437,7 @@ describe("IssueDiscovery", () => {
       const discovery = makeDiscovery();
       await discovery.searchIssues({ maxResults: 5 });
 
-      expect(mockSearchWithChunkedLabels).toHaveBeenCalled();
+      expect(mockSearchAcrossLanguagesAndLabels).toHaveBeenCalled();
       expect(mockFilterVetAndScore).toHaveBeenCalled();
     });
 
@@ -775,7 +775,7 @@ describe("IssueDiscovery", () => {
         rateLimitHit: false,
       });
       // Phase 2 (broad) returns normal
-      mockSearchWithChunkedLabels.mockResolvedValue([]);
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue([]);
       mockFilterVetAndScore.mockResolvedValueOnce({
         candidates: [normal],
         allVetFailed: false,
@@ -809,7 +809,7 @@ describe("IssueDiscovery", () => {
           updated_at: "2026-01-01T00:00:00Z",
         },
       ];
-      mockSearchWithChunkedLabels.mockResolvedValue(items);
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue(items);
 
       const discovery = makeDiscovery({}, { excludeRepos: ["excluded/repo"] });
 
@@ -891,7 +891,7 @@ describe("IssueDiscovery", () => {
       // broad should still be listed in strategiesUsed (strategy was enabled)
       // but searchWithChunkedLabels should NOT have been called (Phase 2 body skipped)
       expect(strategiesUsed).toContain("broad");
-      expect(mockSearchWithChunkedLabels).not.toHaveBeenCalled();
+      expect(mockSearchAcrossLanguagesAndLabels).not.toHaveBeenCalled();
     });
 
     it("applies broadPhaseDelayMs before Phase 2 when previous phases found some results", async () => {
@@ -969,7 +969,7 @@ describe("IssueDiscovery", () => {
       await discovery.searchIssues({ maxResults: 25 });
 
       // Phase 2 should have run (searchWithChunkedLabels called)
-      expect(mockSearchWithChunkedLabels).toHaveBeenCalled();
+      expect(mockSearchAcrossLanguagesAndLabels).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -49,7 +49,7 @@ import {
   fetchIssuesFromMaintainedRepos,
   filterVetAndScore,
   fetchIssuesFromKnownRepos,
-  searchWithChunkedLabels,
+  searchAcrossLanguagesAndLabels,
 } from "./search-phases.js";
 
 const MODULE = "issue-discovery";
@@ -180,7 +180,8 @@ async function runPhase2(
   scopes: IssueScope[] | undefined,
   labels: string[],
   configLabels: string[],
-  baseQualifiers: string,
+  languages: string[],
+  isAnyLanguage: boolean,
   maxResults: number,
   minStars: number,
   phase0RepoSet: Set<string>,
@@ -220,11 +221,13 @@ async function runPhase2(
 
   for (const { tier, tierLabels } of tierLabelGroups) {
     try {
-      const allItems = await searchWithChunkedLabels(
+      const allItems = await searchAcrossLanguagesAndLabels(
         octokit,
+        languages,
+        isAnyLanguage,
         tierLabels,
-        0,
-        (labelQ) => `${baseQualifiers} ${labelQ}`.replace(/  +/g, " ").trim(),
+        (langQ) =>
+          `is:issue is:open ${langQ} no:assignee`.replace(/  +/g, " ").trim(),
         budgetPerTier * 3,
       );
 
@@ -582,9 +585,6 @@ export class IssueDiscovery {
     const langQuery = isAnyLanguage
       ? ""
       : languages.map((l) => `language:${l}`).join(" ");
-    const baseQualifiers = `is:issue is:open ${langQuery} no:assignee`
-      .replace(/  +/g, " ")
-      .trim();
 
     // Build reusable filter
     const aiBlocklisted = new Set(config.aiPolicyBlocklist);
@@ -717,7 +717,8 @@ export class IssueDiscovery {
           scopes,
           labels,
           config.labels,
-          baseQualifiers,
+          languages,
+          isAnyLanguage,
           remaining,
           minStars,
           phase0RepoSet,

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -964,9 +964,9 @@ describe("searchWithChunkedLabels", () => {
 
 describe("buildLanguageVariants", () => {
   it("returns a single empty variant when isAnyLanguage is true", () => {
-    expect(buildLanguageVariants(["typescript", "python"], true, true)).toEqual([
-      "",
-    ]);
+    expect(buildLanguageVariants(["typescript", "python"], true, true)).toEqual(
+      [""],
+    );
   });
 
   it("returns a single empty variant when languages is empty", () => {
@@ -980,9 +980,9 @@ describe("buildLanguageVariants", () => {
   });
 
   it("combines multi-language into one ANDed clause when no labels are present", () => {
-    expect(buildLanguageVariants(["typescript", "python"], false, false)).toEqual([
-      "language:typescript language:python",
-    ]);
+    expect(
+      buildLanguageVariants(["typescript", "python"], false, false),
+    ).toEqual(["language:typescript language:python"]);
   });
 
   it("fans out per-language when 2+ languages combine with labels", () => {
@@ -1012,8 +1012,9 @@ describe("searchAcrossLanguagesAndLabels", () => {
     );
 
     expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
-    const call = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
+    const call = (
+      octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0];
     expect(call.q).toContain("language:typescript");
   });
 
@@ -1034,8 +1035,9 @@ describe("searchAcrossLanguagesAndLabels", () => {
     );
 
     expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(3);
-    const calls = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>)
-      .mock.calls;
+    const calls = (
+      octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>
+    ).mock.calls;
     const queries = calls.map((c) => c[0].q);
     expect(queries[0]).toContain("language:typescript");
     expect(queries[0]).not.toContain("language:python");
@@ -1057,8 +1059,9 @@ describe("searchAcrossLanguagesAndLabels", () => {
     );
 
     expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
-    const call = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
+    const call = (
+      octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0];
     expect(call.q).toContain("language:typescript");
     expect(call.q).toContain("language:python");
   });
@@ -1111,8 +1114,9 @@ describe("searchAcrossLanguagesAndLabels", () => {
     );
 
     expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
-    const call = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
+    const call = (
+      octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0];
     expect(call.q).not.toContain("language:");
   });
 });

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -76,6 +76,8 @@ import {
   cachedSearchIssues,
   fetchIssuesFromMaintainedRepos,
   searchWithChunkedLabels,
+  searchAcrossLanguagesAndLabels,
+  buildLanguageVariants,
   filterVetAndScore,
   fetchIssuesFromKnownRepos,
   searchInRepos,
@@ -957,6 +959,161 @@ describe("searchWithChunkedLabels", () => {
     expect(result).toHaveLength(2); // deduplicated: sharedItem appears once
     expect(result[0].html_url).toBe("https://github.com/a/b/issues/1");
     expect(result[1].html_url).toBe("https://github.com/c/d/issues/2");
+  });
+});
+
+describe("buildLanguageVariants", () => {
+  it("returns a single empty variant when isAnyLanguage is true", () => {
+    expect(buildLanguageVariants(["typescript", "python"], true, true)).toEqual([
+      "",
+    ]);
+  });
+
+  it("returns a single empty variant when languages is empty", () => {
+    expect(buildLanguageVariants([], false, true)).toEqual([""]);
+  });
+
+  it("returns a single language qualifier for one language", () => {
+    expect(buildLanguageVariants(["typescript"], false, true)).toEqual([
+      "language:typescript",
+    ]);
+  });
+
+  it("combines multi-language into one ANDed clause when no labels are present", () => {
+    expect(buildLanguageVariants(["typescript", "python"], false, false)).toEqual([
+      "language:typescript language:python",
+    ]);
+  });
+
+  it("fans out per-language when 2+ languages combine with labels", () => {
+    expect(
+      buildLanguageVariants(["typescript", "python", "rust"], false, true),
+    ).toEqual(["language:typescript", "language:python", "language:rust"]);
+  });
+});
+
+describe("searchAcrossLanguagesAndLabels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCache.getIfFresh.mockReturnValue(null);
+  });
+
+  it("issues one search call when only one language is configured", async () => {
+    const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+    const octokit = makeMockOctokit(items);
+
+    await searchAcrossLanguagesAndLabels(
+      octokit,
+      ["typescript"],
+      false,
+      ["good first issue"],
+      (langQ) => `is:issue is:open ${langQ} no:assignee`,
+      10,
+    );
+
+    expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
+    const call = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(call.q).toContain("language:typescript");
+  });
+
+  it("fans out one call per language when 2+ languages combine with labels", async () => {
+    // Regression guard for oss-autopilot#1331: GitHub Search returns 0 results
+    // when multi-`language:` AND combines with a label OR-group. We must issue
+    // one query per language and union the results instead.
+    const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+    const octokit = makeMockOctokit(items);
+
+    await searchAcrossLanguagesAndLabels(
+      octokit,
+      ["typescript", "python", "rust"],
+      false,
+      ["good first issue", "help wanted"],
+      (langQ) => `is:issue is:open ${langQ} no:assignee`,
+      10,
+    );
+
+    expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(3);
+    const calls = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    const queries = calls.map((c) => c[0].q);
+    expect(queries[0]).toContain("language:typescript");
+    expect(queries[0]).not.toContain("language:python");
+    expect(queries[1]).toContain("language:python");
+    expect(queries[2]).toContain("language:rust");
+  });
+
+  it("issues a single combined-language call when 2+ languages have no labels", async () => {
+    const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+    const octokit = makeMockOctokit(items);
+
+    await searchAcrossLanguagesAndLabels(
+      octokit,
+      ["typescript", "python"],
+      false,
+      [],
+      (langQ) => `is:issue is:open ${langQ} no:assignee`,
+      10,
+    );
+
+    expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
+    const call = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(call.q).toContain("language:typescript");
+    expect(call.q).toContain("language:python");
+  });
+
+  it("deduplicates issues that appear in multiple language results", async () => {
+    const sharedItem = makeItem("https://github.com/a/b/issues/1", "a/b");
+    const uniqueItem = makeItem("https://github.com/c/d/issues/2", "c/d");
+
+    let callCount = 0;
+    const octokit = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1)
+            return { data: { total_count: 1, items: [sharedItem] } };
+          return {
+            data: { total_count: 2, items: [sharedItem, uniqueItem] },
+          };
+        }),
+      },
+    } as unknown as Octokit;
+
+    const result = await searchAcrossLanguagesAndLabels(
+      octokit,
+      ["typescript", "python"],
+      false,
+      ["good first issue"],
+      (langQ) => `is:issue is:open ${langQ} no:assignee`,
+      10,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => i.html_url)).toEqual([
+      "https://github.com/a/b/issues/1",
+      "https://github.com/c/d/issues/2",
+    ]);
+  });
+
+  it("skips language qualifiers entirely when isAnyLanguage is true", async () => {
+    const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+    const octokit = makeMockOctokit(items);
+
+    await searchAcrossLanguagesAndLabels(
+      octokit,
+      ["typescript", "python"],
+      true,
+      ["good first issue"],
+      (langQ) => `is:issue is:open ${langQ} no:assignee`,
+      10,
+    );
+
+    expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
+    const call = (octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(call.q).not.toContain("language:");
   });
 });
 

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -395,6 +395,78 @@ export async function searchWithChunkedLabels(
 }
 
 /**
+ * Build per-call language qualifier strings, fanning out across languages
+ * when a multi-language + labels combination would trip GitHub Search's
+ * empty-result edge case (multi-`language:` AND with a label OR-group
+ * silently returns 0 — see https://github.com/costajohnt/oss-autopilot/issues/1331).
+ */
+export function buildLanguageVariants(
+  languages: string[],
+  isAnyLanguage: boolean,
+  hasLabels: boolean,
+): string[] {
+  if (isAnyLanguage || languages.length === 0) return [""];
+  if (languages.length === 1) return [`language:${languages[0]}`];
+  if (!hasLabels) return [languages.map((l) => `language:${l}`).join(" ")];
+  return languages.map((l) => `language:${l}`);
+}
+
+/**
+ * Search across languages with label chunking, deduplicating results.
+ *
+ * Fans out one query per language when 2+ languages are paired with labels
+ * (works around a GitHub Search backend edge case where the multi-language
+ * AND combined with a label OR-group returns 0). For each language variant,
+ * delegates to searchWithChunkedLabels to keep within GitHub's 5-operator limit.
+ *
+ * @param octokit         Authenticated Octokit instance
+ * @param languages       Configured languages (used as `language:X` qualifiers)
+ * @param isAnyLanguage   When true, skip language qualifiers entirely
+ * @param labels          Label list passed to searchWithChunkedLabels
+ * @param buildBaseQuery  Builds the query prefix from a language qualifier string;
+ *                        e.g. `(langQ) => `is:issue is:open ${langQ} no:assignee`.trim()`
+ * @param perPage         Results per API call
+ */
+export async function searchAcrossLanguagesAndLabels(
+  octokit: Octokit,
+  languages: string[],
+  isAnyLanguage: boolean,
+  labels: string[],
+  buildBaseQuery: (langQuery: string) => string,
+  perPage: number,
+): Promise<GitHubSearchItem[]> {
+  const langVariants = buildLanguageVariants(
+    languages,
+    isAnyLanguage,
+    labels.length > 0,
+  );
+  const seenUrls = new Set<string>();
+  const allItems: GitHubSearchItem[] = [];
+
+  for (let i = 0; i < langVariants.length; i++) {
+    if (i > 0) await sleep(INTER_QUERY_DELAY_MS);
+    const items = await searchWithChunkedLabels(
+      octokit,
+      labels,
+      0,
+      (labelQ) =>
+        `${buildBaseQuery(langVariants[i])} ${labelQ}`
+          .replace(/  +/g, " ")
+          .trim(),
+      perPage,
+    );
+    for (const item of items) {
+      if (!seenUrls.has(item.html_url)) {
+        seenUrls.add(item.html_url);
+        allItems.push(item);
+      }
+    }
+  }
+
+  return allItems;
+}
+
+/**
  * Shared pipeline: spam-filter, repo-exclusion, vetting, and star-count filter.
  * Used by Phases 2 and 3 to convert raw search results into vetted candidates.
  */


### PR DESCRIPTION
## Summary

Fixes the silent-zero-results bug in Phase 2 (broad discovery) where GitHub's
Search API returns 0 items whenever multiple `language:` qualifiers combine
with a label OR-group.

Reported in costajohnt/oss-autopilot#1331 with a bisection table:

| Query shape | `total_count` |
|---|---|
| 5 languages + label OR-group | **0** |
| 5 languages + single `label:"X"` | 144,955 |
| 5 languages + `no:assignee` only | 16,051,561 |

The Search backend silently empties the result set on that exact shape, so
on a typical multi-language config (e.g. `typescript`, `javascript`,
`python`, `rust`, `ruby`) Phase 2 contributes nothing and search converges
on recycled candidates from the small Phase 0/1 pool.

## Fix

New `searchAcrossLanguagesAndLabels` helper in `search-phases.ts` wraps
`searchWithChunkedLabels` and fans out one query per language when
`languages.length >= 2 && labels.length > 0`. Results are deduplicated by
URL and unioned. Other shapes keep a single API call:

- `isAnyLanguage` → 1 call, no language qualifier
- 0 or 1 language → 1 call (qualifier as before)
- 2+ languages, no labels → 1 call (no backend bug to dodge)
- 2+ languages **with labels** → N calls, one per language (the fix)

`runPhase2` now takes `languages: string[]` and `isAnyLanguage: boolean`
instead of the opaque `baseQualifiers` string and builds qualifiers per
language inside the helper.

## Test plan

- [x] `searchAcrossLanguagesAndLabels` issues one call per language when 2+
  languages combine with labels (regression guard for the bug)
- [x] Issues a single call for 1 language, `isAnyLanguage`, or 2+ languages
  with no labels
- [x] Deduplicates results that appear under multiple languages
- [x] `buildLanguageVariants` returns the expected variant lists across all
  four shape combinations
- [x] Full test suite: 715 core + 19 mcp = 734 tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean