### PR TITLE
feat(search): soft-boost ranking via preferLanguages and preferRepos

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -108,10 +108,23 @@ program
     `Search strategies (${CONCRETE_STRATEGIES.join(",")},all)`,
     "all",
   )
+  .option(
+    "--prefer-languages <list>",
+    "Comma-separated languages to soft-boost in ranking (#1244). Candidates whose repo language matches sort above equally-recommended non-matches. Does not filter results.",
+  )
+  .option(
+    "--prefer-repos <list>",
+    "Comma-separated `owner/repo` slugs to soft-boost in ranking (#1244). Stronger weight than language match. Does not filter results.",
+  )
   .action(
     async (
       count: string | undefined,
-      options: { json?: boolean; strategy?: string },
+      options: {
+        json?: boolean;
+        strategy?: string;
+        preferLanguages?: string;
+        preferRepos?: string;
+      },
     ) => {
       try {
         if (!hasLocalState()) {
@@ -156,7 +169,21 @@ program
           strategies.push(parsed.data);
         }
 
-        const results = await runSearch({ maxResults, state, strategies });
+        const splitCsv = (raw: string | undefined): string[] | undefined => {
+          if (!raw) return undefined;
+          const parts = raw
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          return parts.length > 0 ? parts : undefined;
+        };
+        const results = await runSearch({
+          maxResults,
+          state,
+          strategies,
+          preferLanguages: splitCsv(options.preferLanguages),
+          preferRepos: splitCsv(options.preferRepos),
+        });
         if (options.json) {
           console.log(formatJsonSuccess(results));
         } else {

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -43,6 +43,14 @@ export interface SearchOutput {
       updatedAt?: string;
       isStalled: boolean;
     };
+    /**
+     * Personalization sort-tier signal (#1244). Present only when the
+     * caller passed `preferLanguages` / `preferRepos` *and* this
+     * candidate matched at least one of them. `boostReasons` is the
+     * human-readable explanation (e.g. `"repo affinity: vercel/next.js"`).
+     */
+    boostScore?: number;
+    boostReasons?: string[];
   }>;
   excludedRepos: string[];
   aiPolicyBlocklist: string[];
@@ -54,6 +62,10 @@ interface SearchCommandOptions {
   maxResults: number;
   state?: ScoutState;
   strategies?: SearchStrategy[];
+  /** Soft sort boost for candidates whose repo language matches (#1244). */
+  preferLanguages?: string[];
+  /** Soft sort boost for candidates in these `owner/repo` slugs (#1244). */
+  preferRepos?: string[];
 }
 
 export async function runSearch(
@@ -70,6 +82,8 @@ export async function runSearch(
   const result = await scout.search({
     maxResults: options.maxResults,
     strategies: options.strategies,
+    preferLanguages: options.preferLanguages,
+    preferRepos: options.preferRepos,
   });
 
   // Persist results to local state and gist
@@ -115,6 +129,8 @@ export async function runSearch(
               isStalled: isLinkedPRStalled(c.vettingResult.linkedPR),
             }
           : undefined,
+        boostScore: c.boostScore,
+        boostReasons: c.boostReasons,
       };
     }),
     excludedRepos: result.excludedRepos,

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -51,6 +51,7 @@ import {
   fetchIssuesFromKnownRepos,
   searchAcrossLanguagesAndLabels,
 } from "./search-phases.js";
+import { annotateBoost } from "./personalization.js";
 
 const MODULE = "issue-discovery";
 
@@ -497,6 +498,8 @@ export class IssueDiscovery {
       maxResults?: number;
       strategies?: SearchStrategy[];
       skippedUrls?: Set<string>;
+      preferLanguages?: string[];
+      preferRepos?: string[];
     } = {},
   ): Promise<{
     candidates: IssueCandidate[];
@@ -811,7 +814,12 @@ export class IssueDiscovery {
         `Try again after the rate limit resets for complete results.`;
     }
 
-    // Sort by priority, recommendation, then viability score
+    // Personalization annotation (#1244): tag each candidate with
+    // boostScore + boostReasons before sorting so the new sort tier has
+    // values to read. No-op when neither preference list is supplied.
+    annotateBoost(allCandidates, options.preferLanguages, options.preferRepos);
+
+    // Sort by priority, recommendation, boost (#1244), then viability score
     allCandidates.sort((a, b) => {
       const priorityOrder: Record<SearchPriority, number> = {
         merged_pr: 0,
@@ -827,6 +835,14 @@ export class IssueDiscovery {
         recommendationOrder[a.recommendation] -
         recommendationOrder[b.recommendation];
       if (recDiff !== 0) return recDiff;
+
+      // Personalization tier (#1244): higher boostScore wins. Treats
+      // undefined as 0 so unboosted candidates rank below boosted peers
+      // but stay ordered among themselves by viabilityScore. No-op when
+      // `preferLanguages`/`preferRepos` are absent — all candidates carry
+      // `boostScore: undefined` and the difference collapses to 0.
+      const boostDiff = (b.boostScore ?? 0) - (a.boostScore ?? 0);
+      if (boostDiff !== 0) return boostDiff;
 
       return b.viabilityScore - a.viabilityScore;
     });

--- a/packages/core/src/core/personalization.test.ts
+++ b/packages/core/src/core/personalization.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for personalization boost (#1244).
+ *
+ * Mutation semantics: `annotateBoost` sets `boostScore`/`boostReasons`
+ * on each matched candidate. The caller (issue-discovery) re-sorts
+ * using those values; these tests just verify the annotation itself.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  annotateBoost,
+  LANGUAGE_BOOST,
+  REPO_BOOST,
+} from "./personalization.js";
+import type { IssueCandidate } from "./types.js";
+
+function makeCandidate(
+  repo: string,
+  language: string | null | undefined,
+): IssueCandidate {
+  return {
+    issue: {
+      id: 1,
+      url: `https://github.com/${repo}/issues/1`,
+      repo,
+      number: 1,
+      title: "Test issue",
+      status: "candidate",
+      labels: [],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+      vetted: true,
+      vettingResult: {
+        passedAllChecks: true,
+        checks: {
+          noExistingPR: true,
+          notClaimed: true,
+          projectActive: true,
+          clearRequirements: true,
+          contributionGuidelinesFound: true,
+        },
+        notes: [],
+      },
+    },
+    vettingResult: {
+      passedAllChecks: true,
+      checks: {
+        noExistingPR: true,
+        notClaimed: true,
+        projectActive: true,
+        clearRequirements: true,
+        contributionGuidelinesFound: true,
+      },
+      notes: [],
+    },
+    projectHealth: {
+      repo,
+      lastCommitAt: "",
+      daysSinceLastCommit: 1,
+      openIssuesCount: 10,
+      avgIssueResponseDays: 2,
+      ciStatus: "passing",
+      isActive: true,
+      stargazersCount: 500,
+      language,
+    },
+    antiLLMPolicy: { matched: false, matchedKeywords: [], sourceFile: null },
+    slmTriage: null,
+    recommendation: "approve",
+    reasonsToSkip: [],
+    reasonsToApprove: [],
+    viabilityScore: 70,
+    searchPriority: "normal",
+  };
+}
+
+describe("annotateBoost", () => {
+  it("is a no-op when no preferences are supplied", () => {
+    const candidates = [
+      makeCandidate("vercel/next.js", "TypeScript"),
+      makeCandidate("rails/rails", "Ruby"),
+    ];
+
+    annotateBoost(candidates, undefined, undefined);
+
+    for (const c of candidates) {
+      expect(c.boostScore).toBeUndefined();
+      expect(c.boostReasons).toBeUndefined();
+    }
+  });
+
+  it("is a no-op when preference lists are empty", () => {
+    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
+
+    annotateBoost(candidates, [], []);
+
+    expect(candidates[0].boostScore).toBeUndefined();
+    expect(candidates[0].boostReasons).toBeUndefined();
+  });
+
+  it("matches language case-insensitively and tags reason", () => {
+    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
+
+    annotateBoost(candidates, ["typescript"], undefined);
+
+    expect(candidates[0].boostScore).toBe(LANGUAGE_BOOST);
+    expect(candidates[0].boostReasons).toEqual(["language match: TypeScript"]);
+  });
+
+  it("matches repo slug exactly and tags reason", () => {
+    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
+
+    annotateBoost(candidates, undefined, ["vercel/next.js"]);
+
+    expect(candidates[0].boostScore).toBe(REPO_BOOST);
+    expect(candidates[0].boostReasons).toEqual([
+      "repo affinity: vercel/next.js",
+    ]);
+  });
+
+  it("stacks repo and language boosts when both match", () => {
+    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
+
+    annotateBoost(candidates, ["typescript"], ["vercel/next.js"]);
+
+    expect(candidates[0].boostScore).toBe(REPO_BOOST + LANGUAGE_BOOST);
+    expect(candidates[0].boostReasons).toEqual([
+      "repo affinity: vercel/next.js",
+      "language match: TypeScript",
+    ]);
+  });
+
+  it("leaves boostScore undefined on candidates that match nothing", () => {
+    const candidates = [
+      makeCandidate("rails/rails", "Ruby"),
+      makeCandidate("vercel/next.js", "TypeScript"),
+    ];
+
+    annotateBoost(candidates, ["typescript"], ["vercel/next.js"]);
+
+    expect(candidates[0].boostScore).toBeUndefined();
+    expect(candidates[0].boostReasons).toBeUndefined();
+    expect(candidates[1].boostScore).toBe(REPO_BOOST + LANGUAGE_BOOST);
+  });
+
+  it("handles candidates with null/undefined language without crashing", () => {
+    const candidates = [
+      makeCandidate("foo/bar", null),
+      makeCandidate("baz/qux", undefined),
+    ];
+
+    annotateBoost(candidates, ["typescript"], undefined);
+
+    expect(candidates[0].boostScore).toBeUndefined();
+    expect(candidates[1].boostScore).toBeUndefined();
+  });
+
+  it("trims whitespace and ignores empty entries in preference lists", () => {
+    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
+
+    annotateBoost(
+      candidates,
+      [" typescript ", "", "  "],
+      [" ", "vercel/next.js"],
+    );
+
+    expect(candidates[0].boostScore).toBe(REPO_BOOST + LANGUAGE_BOOST);
+  });
+});

--- a/packages/core/src/core/personalization.ts
+++ b/packages/core/src/core/personalization.ts
@@ -1,0 +1,75 @@
+/**
+ * Personalization signals for search ranking (#1244).
+ *
+ * Translates caller-supplied `preferLanguages` / `preferRepos` lists
+ * into a soft `boostScore` on each `IssueCandidate`. The final search
+ * sort consults this score between the `recommendation` tier and the
+ * raw `viabilityScore`, so personalization reorders ties without
+ * changing which candidates pass vetting.
+ *
+ * This is the minimum-viable subset of Option A in #1244: only language
+ * and repo bias, no `boostIssueTypes` / `avoidRepos` / `diversityRatio`
+ * yet. Those follow up in separate PRs.
+ */
+
+import type { IssueCandidate } from "./types.js";
+
+/**
+ * Boost weights. Tuned conservatively so personalization tips equally-
+ * scored candidates without drowning out high-viability normal results.
+ *
+ * Rationale:
+ *   - Repo affinity is the strongest signal — a candidate in a repo the
+ *     user has merged PRs into has real relationship context. Worth the
+ *     higher boost.
+ *   - Language match is broad and easy to satisfy. Lower weight.
+ */
+export const REPO_BOOST = 20;
+export const LANGUAGE_BOOST = 10;
+
+/**
+ * Annotate each candidate with `boostScore` and `boostReasons` based on
+ * the caller-supplied preference lists. Mutates the array in place; the
+ * caller is responsible for re-sorting afterwards.
+ *
+ * Mutation (rather than returning new objects) keeps the personalization
+ * step a single linear pass over the array the caller already holds —
+ * the sort step reads back from the same objects.
+ *
+ * No-op when both preference lists are empty or undefined: candidates
+ * retain `boostScore: undefined` and the sort tier collapses to 0.
+ */
+export function annotateBoost(
+  candidates: IssueCandidate[],
+  preferLanguages?: string[],
+  preferRepos?: string[],
+): void {
+  const langSet = new Set(
+    (preferLanguages ?? []).map((l) => l.trim().toLowerCase()).filter(Boolean),
+  );
+  const repoSet = new Set(
+    (preferRepos ?? []).map((r) => r.trim()).filter(Boolean),
+  );
+  if (langSet.size === 0 && repoSet.size === 0) return;
+
+  for (const c of candidates) {
+    let score = 0;
+    const reasons: string[] = [];
+
+    if (repoSet.size > 0 && repoSet.has(c.issue.repo)) {
+      score += REPO_BOOST;
+      reasons.push(`repo affinity: ${c.issue.repo}`);
+    }
+
+    const lang = c.projectHealth.language;
+    if (langSet.size > 0 && lang && langSet.has(lang.toLowerCase())) {
+      score += LANGUAGE_BOOST;
+      reasons.push(`language match: ${lang}`);
+    }
+
+    if (score > 0) {
+      c.boostScore = score;
+      c.boostReasons = reasons;
+    }
+  }
+}

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -89,6 +89,19 @@ export interface IssueCandidate {
   reasonsToApprove: string[];
   viabilityScore: number;
   searchPriority: SearchPriority;
+  /**
+   * Personalization sort tier (#1244). Populated only when the caller
+   * passes `preferLanguages` / `preferRepos` to `search()` *and* the
+   * candidate matches at least one. Affects sort order between the
+   * `recommendation` tier and `viabilityScore`; never used as a filter.
+   */
+  boostScore?: number;
+  /**
+   * Human-readable reasons the candidate matched personalization bias
+   * (#1244). Mirrors `reasonsToApprove`/`reasonsToSkip` shape for
+   * symmetry with the existing surface.
+   */
+  boostReasons?: string[];
 }
 
 /** Subset of RepoScore fields that callers may update. */
@@ -191,6 +204,21 @@ export type ScoutConfig =
 export interface SearchOptions {
   maxResults?: number;
   strategies?: SearchStrategy[];
+  /**
+   * Per-call personalization bias: candidates whose repo language matches
+   * one of these (case-insensitive) get a soft sort boost above
+   * equally-recommended non-matches (#1244). Does not filter results, does
+   * not change `viabilityScore`. Empty / undefined disables the boost.
+   */
+  preferLanguages?: string[];
+  /**
+   * Per-call personalization bias: candidates in one of these
+   * `owner/repo` slugs get a soft sort boost above equally-recommended
+   * non-matches (#1244). Stronger weight than language match. Does not
+   * filter results, does not change `viabilityScore`. Empty / undefined
+   * disables the boost.
+   */
+  preferRepos?: string[];
 }
 
 /** Result of a search operation. */

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -200,6 +200,8 @@ export class OssScout implements ScoutStateReader {
       maxResults: options?.maxResults,
       strategies: options?.strategies,
       skippedUrls,
+      preferLanguages: options?.preferLanguages,
+      preferRepos: options?.preferRepos,
     });
 
     this.state.lastSearchAt = new Date().toISOString();

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -34,8 +34,20 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         .describe(
           "Comma-separated search strategies: merged, starred, broad, maintained, all",
         ),
+      preferLanguages: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Soft-boost ranking for candidates whose repo language matches one of these (case-insensitive). Personalization tier between recommendation and viabilityScore (#1244). Not a filter; only reorders.",
+        ),
+      preferRepos: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Soft-boost ranking for candidates in one of these `owner/repo` slugs. Stronger weight than language match (#1244). Not a filter; only reorders.",
+        ),
     },
-    async ({ maxResults, strategies }) => {
+    async ({ maxResults, strategies, preferLanguages, preferRepos }) => {
       try {
         const parsedStrategies = strategies
           ? strategies
@@ -47,6 +59,8 @@ export function registerTools(server: McpServer, scout: OssScout): void {
           scout.search({
             maxResults: maxResults ?? 10,
             strategies: parsedStrategies,
+            preferLanguages,
+            preferRepos,
           }),
         );
 


### PR DESCRIPTION
## Summary

First-pass implementation of `costajohnt/oss-autopilot#1244`. Adds two per-call ranking signals to `scout.search()`:

- `preferLanguages: string[]` — candidates whose repo language matches (case-insensitive) get +10
- `preferRepos: string[]` — candidates in one of these `owner/repo` slugs get +20

These accumulate into a `boostScore` field, used as a new sort tier *between* the existing `recommendation` tier and `viabilityScore`. Personalization reorders ties; it never filters and never alters which candidates pass vetting.

This is the minimal subset of Option A from the issue. The bigger pieces (`boostIssueTypes`, `avoidRepos`, `diversityRatio`, search-render annotation, and oss-autopilot calling `strategy()` to populate these fields automatically) are deferred to follow-up PRs.

## Why a separate `boostScore` field

`viabilityScore` is documented as intrinsic suitability of the issue, shown in the UI and persisted in the saved-results schema. Mixing personalization into it would corrupt that meaning. A separate `boostScore` field stays inspectable and lines up with the issue's "transparency about why a result surfaced" requirement.

## Weights

Tuned conservatively so personalization tips equally-scored candidates without drowning out high-viability normal results:

| Signal | Weight | Reasoning |
|---|---|---|
| Repo affinity | +20 | Real relationship — user has merged PRs here |
| Language match | +10 | Broad and easy to satisfy; weaker signal |

## Surfaces

CLI:
```
oss-scout search --prefer-languages typescript,go --prefer-repos vercel/next.js,directus/directus
```

MCP:
```ts
scout.search({
  preferLanguages: ['typescript', 'go'],
  preferRepos: ['vercel/next.js', 'directus/directus'],
});
```

Both params optional. Absent / empty arrays are full no-ops (default sort unchanged).

## Output additions

Each search candidate now optionally carries:
- `boostScore?: number` — total boost applied (sum of matched weights)
- `boostReasons?: string[]` — human-readable explanations like `["repo affinity: vercel/next.js", "language match: TypeScript"]`

Both omitted when nothing matched. Not persisted to `saveResults` (per-call ephemeral).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] Full suite: 723 core + 19 mcp-server = **742 passing** (was 715 + 19 = 734; +8 new tests in `personalization.test.ts`)
- [x] Covers: no-op when no prefs supplied, no-op for empty arrays, case-insensitive language match, exact repo match, both stacking, candidates with null/undefined language, whitespace trimming
- [ ] End-to-end smoke against a real local state before tagging the next release

## Out of scope (filed for follow-up)

- `boostIssueTypes` and `avoidRepos` from Option A's full shape
- `diversityRatio` counterweight
- Render-time annotation in the CLI / MCP output (currently emitted in raw form)
- oss-autopilot calling `strategy` and threading recommendations into the search dispatch path

## Compatibility

Fully additive. All existing callers continue to work unchanged; the sort behavior collapses to current behavior when neither `preferLanguages` nor `preferRepos` is supplied.