### PR TITLE
feat(search): add diversityRatio counterweight to avoid echo-chamber bias

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -116,6 +116,10 @@ program
     "--prefer-repos <list>",
     "Comma-separated `owner/repo` slugs to soft-boost in ranking (#1244). Stronger weight than language match. Does not filter results.",
   )
+  .option(
+    "--diversity-ratio <n>",
+    "Fraction of result slots (0-1) reserved for candidates that matched NEITHER preference list (#1244). Counterweights echo-chamber bias as boosts accumulate. Default 0 (disabled).",
+  )
   .action(
     async (
       count: string | undefined,
@@ -124,6 +128,7 @@ program
         strategy?: string;
         preferLanguages?: string;
         preferRepos?: string;
+        diversityRatio?: string;
       },
     ) => {
       try {
@@ -177,12 +182,24 @@ program
             .filter(Boolean);
           return parts.length > 0 ? parts : undefined;
         };
+        let diversityRatio: number | undefined;
+        if (options.diversityRatio !== undefined) {
+          const parsed = Number(options.diversityRatio);
+          if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+            console.error(
+              `Error: --diversity-ratio must be a number in [0, 1] (got "${options.diversityRatio}")`,
+            );
+            process.exit(1);
+          }
+          diversityRatio = parsed;
+        }
         const results = await runSearch({
           maxResults,
           state,
           strategies,
           preferLanguages: splitCsv(options.preferLanguages),
           preferRepos: splitCsv(options.preferRepos),
+          diversityRatio,
         });
         if (options.json) {
           console.log(formatJsonSuccess(results));

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -51,6 +51,11 @@ export interface SearchOutput {
      */
     boostScore?: number;
     boostReasons?: string[];
+    /**
+     * Marks a candidate that filled a reserved diversity slot (#1244).
+     * Mutually exclusive with a non-zero `boostScore`.
+     */
+    diversitySlot?: boolean;
   }>;
   excludedRepos: string[];
   aiPolicyBlocklist: string[];
@@ -66,6 +71,8 @@ interface SearchCommandOptions {
   preferLanguages?: string[];
   /** Soft sort boost for candidates in these `owner/repo` slugs (#1244). */
   preferRepos?: string[];
+  /** Diversity counterweight: fraction of slots reserved for unboosted candidates (#1244). */
+  diversityRatio?: number;
 }
 
 export async function runSearch(
@@ -84,6 +91,7 @@ export async function runSearch(
     strategies: options.strategies,
     preferLanguages: options.preferLanguages,
     preferRepos: options.preferRepos,
+    diversityRatio: options.diversityRatio,
   });
 
   // Persist results to local state and gist
@@ -131,6 +139,7 @@ export async function runSearch(
           : undefined,
         boostScore: c.boostScore,
         boostReasons: c.boostReasons,
+        diversitySlot: c.diversitySlot,
       };
     }),
     excludedRepos: result.excludedRepos,

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -51,7 +51,7 @@ import {
   fetchIssuesFromKnownRepos,
   searchAcrossLanguagesAndLabels,
 } from "./search-phases.js";
-import { annotateBoost } from "./personalization.js";
+import { annotateBoost, applyDiversityRatio } from "./personalization.js";
 
 const MODULE = "issue-discovery";
 
@@ -500,6 +500,7 @@ export class IssueDiscovery {
       skippedUrls?: Set<string>;
       preferLanguages?: string[];
       preferRepos?: string[];
+      diversityRatio?: number;
     } = {},
   ): Promise<{
     candidates: IssueCandidate[];
@@ -849,11 +850,21 @@ export class IssueDiscovery {
 
     const capped = applyPerRepoCap(allCandidates, 2);
 
+    // Diversity counterweight (#1244): when `diversityRatio > 0`, reserve
+    // a fraction of the final slots for candidates that matched neither
+    // preference list. No-op when the ratio is 0 or absent — collapses to
+    // the original `slice(0, maxResults)` behavior.
+    const finalPicks = applyDiversityRatio(
+      capped,
+      maxResults,
+      options.diversityRatio ?? 0,
+    );
+
     info(
       MODULE,
-      `Search complete: ${tracker.getTotalCalls()} Search API calls used, ${capped.length} candidates returned`,
+      `Search complete: ${tracker.getTotalCalls()} Search API calls used, ${finalPicks.length} candidates returned`,
     );
-    return { candidates: capped.slice(0, maxResults), strategiesUsed };
+    return { candidates: finalPicks, strategiesUsed };
   }
 
   /**

--- a/packages/core/src/core/personalization.test.ts
+++ b/packages/core/src/core/personalization.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vitest";
 import {
   annotateBoost,
+  applyDiversityRatio,
   LANGUAGE_BOOST,
   REPO_BOOST,
 } from "./personalization.js";
@@ -165,5 +166,102 @@ describe("annotateBoost", () => {
     );
 
     expect(candidates[0].boostScore).toBe(REPO_BOOST + LANGUAGE_BOOST);
+  });
+});
+
+describe("applyDiversityRatio", () => {
+  function boosted(repo: string): IssueCandidate {
+    const c = makeCandidate(repo, "TypeScript");
+    c.boostScore = REPO_BOOST;
+    c.boostReasons = [`repo affinity: ${repo}`];
+    return c;
+  }
+
+  it("collapses to slice(0, maxResults) when ratio is 0", () => {
+    const candidates = [
+      boosted("a/b"),
+      makeCandidate("c/d", "Go"),
+      makeCandidate("e/f", "Python"),
+    ];
+
+    const picks = applyDiversityRatio(candidates, 2, 0);
+
+    expect(picks).toHaveLength(2);
+    expect(picks[0].issue.repo).toBe("a/b");
+    expect(picks[1].issue.repo).toBe("c/d");
+    expect(picks.some((p) => p.diversitySlot)).toBe(false);
+  });
+
+  it("reserves diversity slots for unboosted candidates", () => {
+    const candidates = [
+      boosted("a/b"),
+      boosted("c/d"),
+      boosted("e/f"),
+      boosted("g/h"),
+      makeCandidate("i/j", "Rust"),
+      makeCandidate("k/l", "Elixir"),
+    ];
+
+    // 5 results, 40% diversity -> 2 reserve slots, 3 main slots.
+    const picks = applyDiversityRatio(candidates, 5, 0.4);
+
+    expect(picks).toHaveLength(5);
+    expect(picks.slice(0, 3).every((p) => p.boostScore === REPO_BOOST)).toBe(
+      true,
+    );
+    expect(picks.slice(3).every((p) => p.diversitySlot === true)).toBe(true);
+    expect(picks.slice(3).every((p) => !p.boostScore)).toBe(true);
+    expect(picks[3].issue.repo).toBe("i/j");
+    expect(picks[4].issue.repo).toBe("k/l");
+  });
+
+  it("tops up from main pool when diversity pool is too small", () => {
+    const candidates = [
+      boosted("a/b"),
+      boosted("c/d"),
+      boosted("e/f"),
+      makeCandidate("i/j", "Rust"),
+    ];
+
+    // 4 results, 50% diversity -> 2 reserve, 2 main. Only 1 unboosted
+    // candidate exists, so the second reserve slot falls back to main.
+    const picks = applyDiversityRatio(candidates, 4, 0.5);
+
+    expect(picks).toHaveLength(4);
+    expect(picks[0].issue.repo).toBe("a/b");
+    expect(picks[1].issue.repo).toBe("c/d");
+    expect(picks[2].issue.repo).toBe("i/j");
+    expect(picks[2].diversitySlot).toBe(true);
+    expect(picks[3].issue.repo).toBe("e/f");
+    expect(picks[3].diversitySlot).toBeUndefined();
+  });
+
+  it("clamps ratio above 1 to a full diversity pass", () => {
+    const candidates = [
+      boosted("a/b"),
+      boosted("c/d"),
+      makeCandidate("i/j", "Rust"),
+      makeCandidate("k/l", "Elixir"),
+    ];
+
+    // ratio clamped to 1: reserve all slots for diversity. With 2
+    // unboosted candidates and 4 main, they fill 2 slots first; the
+    // remaining 2 fall back to main pool.
+    const picks = applyDiversityRatio(candidates, 4, 1.5);
+
+    expect(picks).toHaveLength(4);
+    expect(picks[0].issue.repo).toBe("i/j");
+    expect(picks[0].diversitySlot).toBe(true);
+    expect(picks[1].issue.repo).toBe("k/l");
+    expect(picks[1].diversitySlot).toBe(true);
+    expect(picks[2].issue.repo).toBe("a/b");
+    expect(picks[3].issue.repo).toBe("c/d");
+  });
+
+  it("returns empty for maxResults <= 0", () => {
+    const candidates = [boosted("a/b"), makeCandidate("c/d", "Go")];
+
+    expect(applyDiversityRatio(candidates, 0, 0.5)).toEqual([]);
+    expect(applyDiversityRatio(candidates, -1, 0.5)).toEqual([]);
   });
 });

--- a/packages/core/src/core/personalization.ts
+++ b/packages/core/src/core/personalization.ts
@@ -1,15 +1,18 @@
 /**
  * Personalization signals for search ranking (#1244).
  *
- * Translates caller-supplied `preferLanguages` / `preferRepos` lists
- * into a soft `boostScore` on each `IssueCandidate`. The final search
- * sort consults this score between the `recommendation` tier and the
- * raw `viabilityScore`, so personalization reorders ties without
- * changing which candidates pass vetting.
+ * Two passes:
  *
- * This is the minimum-viable subset of Option A in #1244: only language
- * and repo bias, no `boostIssueTypes` / `avoidRepos` / `diversityRatio`
- * yet. Those follow up in separate PRs.
+ *   - `annotateBoost` translates `preferLanguages` / `preferRepos`
+ *     into a soft `boostScore` consumed by issue-discovery's final
+ *     sort tier between `recommendation` and `viabilityScore`.
+ *   - `applyDiversityRatio` reserves a fraction of the final slot
+ *     budget for candidates that matched no preference, counterweighting
+ *     echo-chamber bias as recommendations accumulate over time.
+ *
+ * Still out of scope for #1244: `boostIssueTypes`, `avoidRepos`, and
+ * render-time annotation of `boostReasons` / `diversitySlot` in the CLI
+ * non-JSON output. Those follow up in separate PRs.
  */
 
 import type { IssueCandidate } from "./types.js";
@@ -72,4 +75,69 @@ export function annotateBoost(
       c.boostReasons = reasons;
     }
   }
+}
+
+/**
+ * Apply a diversity-counterweight pass over a pre-sorted candidate list
+ * (#1244). Returns the first `maxResults` picks in priority order:
+ *
+ *   1. Main slots: `maxResults - floor(maxResults * diversityRatio)`
+ *      top candidates from the input. Personalization-biased candidates
+ *      win these slots when present (since the input is already sorted
+ *      by the personalization tier).
+ *   2. Diversity slots: the highest-ranked candidates that carry NO
+ *      `boostScore` — i.e. they matched neither `preferLanguages` nor
+ *      `preferRepos`. Tagged with `diversitySlot: true` for caller
+ *      transparency.
+ *   3. Top-up: if the diversity pool was thinner than the reserve, fall
+ *      back to the remaining sorted candidates so the user gets
+ *      `maxResults` slots whenever the source has enough material.
+ *
+ * `diversityRatio` is clamped to [0, 1]. 0 is a no-op (just slices the
+ * input). 1 means every slot is a diversity slot — useful for
+ * deliberately suppressing personalization without disabling it.
+ *
+ * @param candidates    Pre-sorted candidate list (output of issue-discovery)
+ * @param maxResults    Total slots to fill
+ * @param diversityRatio Fraction of slots reserved for unboosted candidates
+ */
+export function applyDiversityRatio(
+  candidates: IssueCandidate[],
+  maxResults: number,
+  diversityRatio: number,
+): IssueCandidate[] {
+  if (maxResults <= 0) return [];
+  const ratio = Math.max(0, Math.min(1, diversityRatio));
+  if (ratio === 0) return candidates.slice(0, maxResults);
+
+  const diversityReserve = Math.min(Math.floor(maxResults * ratio), maxResults);
+  if (diversityReserve === 0) return candidates.slice(0, maxResults);
+
+  const mainBudget = maxResults - diversityReserve;
+  const picks: IssueCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const c of candidates) {
+    if (picks.length >= mainBudget) break;
+    picks.push(c);
+    seen.add(c.issue.url);
+  }
+
+  for (const c of candidates) {
+    if (picks.length >= maxResults) break;
+    if (seen.has(c.issue.url)) continue;
+    if (c.boostScore && c.boostScore > 0) continue;
+    c.diversitySlot = true;
+    picks.push(c);
+    seen.add(c.issue.url);
+  }
+
+  for (const c of candidates) {
+    if (picks.length >= maxResults) break;
+    if (seen.has(c.issue.url)) continue;
+    picks.push(c);
+    seen.add(c.issue.url);
+  }
+
+  return picks;
 }

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -102,6 +102,14 @@ export interface IssueCandidate {
    * symmetry with the existing surface.
    */
   boostReasons?: string[];
+  /**
+   * Marks a candidate that filled a reserved diversity slot (#1244).
+   * Populated only when `diversityRatio > 0` was passed AND the
+   * candidate matched no personalization bias. Mutually exclusive with
+   * a non-zero `boostScore` (a candidate cannot be both biased-toward
+   * and a diversity slot in the same result set).
+   */
+  diversitySlot?: boolean;
 }
 
 /** Subset of RepoScore fields that callers may update. */
@@ -219,6 +227,16 @@ export interface SearchOptions {
    * disables the boost.
    */
   preferRepos?: string[];
+  /**
+   * Counterweight against echo-chamber bias as `preferLanguages` /
+   * `preferRepos` boosts accumulate over time (#1244). A value of 0.2
+   * means "reserve roughly 20% of the final slots for candidates that
+   * matched NEITHER preference list," filling them from the same sorted
+   * pool but skipping any candidate carrying a `boostScore`. 0 disables
+   * the counterweight; 1 makes every slot a diversity slot. Range
+   * clamped to [0, 1].
+   */
+  diversityRatio?: number;
 }
 
 /** Result of a search operation. */

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -202,6 +202,7 @@ export class OssScout implements ScoutStateReader {
       skippedUrls,
       preferLanguages: options?.preferLanguages,
       preferRepos: options?.preferRepos,
+      diversityRatio: options?.diversityRatio,
     });
 
     this.state.lastSearchAt = new Date().toISOString();

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -46,8 +46,22 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         .describe(
           "Soft-boost ranking for candidates in one of these `owner/repo` slugs. Stronger weight than language match (#1244). Not a filter; only reorders.",
         ),
+      diversityRatio: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe(
+          "Diversity counterweight (#1244): fraction of result slots reserved for candidates that matched NEITHER preference list. Counters echo-chamber bias when boosts accumulate over time. 0 disables, 1 reserves every slot for diversity. Default 0.",
+        ),
     },
-    async ({ maxResults, strategies, preferLanguages, preferRepos }) => {
+    async ({
+      maxResults,
+      strategies,
+      preferLanguages,
+      preferRepos,
+      diversityRatio,
+    }) => {
       try {
         const parsedStrategies = strategies
           ? strategies
@@ -61,6 +75,7 @@ export function registerTools(server: McpServer, scout: OssScout): void {
             strategies: parsedStrategies,
             preferLanguages,
             preferRepos,
+            diversityRatio,
           }),
         );
 


### PR DESCRIPTION
## Summary

Follow-up to `#107` on `costajohnt/oss-autopilot#1244`. As `preferLanguages` / `preferRepos` boosts accumulate, the user's search results calcify around what they already merge. This adds a per-call `diversityRatio` knob that reserves a fraction of final slots for candidates matching NEITHER preference list.

## Algorithm

`applyDiversityRatio(candidates, maxResults, diversityRatio)`:

1. **Main slots:** top `maxResults * (1 - diversityRatio)` from the sorted candidate list. Personalization-biased candidates win these slots when present (since the input is already sorted by the personalization tier from `#107`).
2. **Diversity slots:** highest-ranked candidates with no `boostScore` (matched neither preference). Tagged `diversitySlot: true` for caller transparency.
3. **Top-up:** if the diversity pool is thinner than the reserve, fall back to remaining sorted candidates so the user gets `maxResults` slots whenever the source has enough material.

## Ratio semantics

Clamped to `[0, 1]`:
- `0` disables the counterweight (no-op, original `slice(0, maxResults)` behavior)
- `0.2` (suggested in the issue): roughly 20% diversity reservation
- `1` reserves every slot for diversity, deliberately suppressing personalization without removing the boosts

## Mutual exclusion

A candidate is either biased-toward (`boostScore > 0`) or a potential diversity slot (`!boostScore`), never both. This keeps the output unambiguous: callers can read `diversitySlot` and know the candidate matched no preference list.

## Surfaces

CLI:
```
oss-scout search --prefer-languages typescript --prefer-repos vercel/next.js --diversity-ratio 0.2
```

MCP:
```ts
scout.search({
  preferLanguages: ['typescript'],
  preferRepos: ['vercel/next.js'],
  diversityRatio: 0.2,
});
```

Output:
```json
{
  "candidates": [
    { "issue": { "repo": "vercel/next.js", ... }, "boostScore": 30, "boostReasons": [...] },
    { "issue": { "repo": "tanstack/router", ... }, "diversitySlot": true }
  ]
}
```

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] 728 core + 19 mcp = **747 passing** (was 723 + 19 = 742; +5 new tests)
- [x] Tests cover: ratio=0 no-op, normal reservation, top-up fallback when diversity pool too small, ratio clamped above 1, maxResults<=0 edge
- [ ] End-to-end smoke against a real local state before tagging the next release

## Out of scope (still open on #1244)

- `boostIssueTypes` MCP param (boost candidates whose labels match an issue-type pattern)
- `avoidRepos` MCP param (negative-boost specific repos without filtering them out)
- Render-time annotation of `boostReasons` / `diversitySlot` in the non-JSON CLI output
- Cross-plugin: oss-autopilot's `search` could compute and pass `diversityRatio` automatically from a future config knob (currently the user has to pass it explicitly)