### PR TITLE
feat(cli): surface boost reasons and diversity slot in non-JSON output

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -218,8 +218,17 @@ program
             const stalledTag = c.linkedPR?.isStalled
               ? " (stalled PR, revive opportunity)"
               : "";
+            // Personalization tag (#1244). A candidate is either boosted
+            // (matched a preference) or a diversity slot (matched none and
+            // filled a reserved slot); never both.
+            let personalizationTag = "";
+            if (c.boostScore && c.boostReasons && c.boostReasons.length > 0) {
+              personalizationTag = ` [boosted: ${c.boostReasons.join("; ")}]`;
+            } else if (c.diversitySlot) {
+              personalizationTag = " [diversity slot]";
+            }
             console.log(
-              `  ${icon} ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100]${stalledTag}`,
+              `  ${icon} ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100]${personalizationTag}${stalledTag}`,
             );
             console.log(`     ${c.issue.title}`);
             console.log(`     ${c.issue.url}`);


### PR DESCRIPTION
## Summary

Closes the loop on `#1244`'s personalization work. The `boostScore`, `boostReasons`, and `diversitySlot` fields land on every search candidate, but until now they were only visible to consumers parsing `--json`. The human-readable `oss-scout search` output gave no hint why results were ordered the way they were.

This adds an inline tag on each candidate line so users see exactly why a result moved up or down.

## Output samples

Before:
```
  ✅ vercel/next.js#1234 [85/100]
     fix: hydration mismatch
     https://github.com/vercel/next.js/issues/1234
     Repo: 8/10, 4 merged PRs
```

After (with `--prefer-languages typescript --prefer-repos vercel/next.js`):
```
  ✅ vercel/next.js#1234 [85/100] [boosted: repo affinity: vercel/next.js; language match: TypeScript]
     fix: hydration mismatch
     https://github.com/vercel/next.js/issues/1234
     Repo: 8/10, 4 merged PRs

  ⚠️ tanstack/router#999 [72/100] [diversity slot]
     docs: clarify nested routes
     https://github.com/tanstack/router/issues/999
```

Mirrors the example output sketched in the original `#1244` body.

## Mutual exclusion

By construction in `applyDiversityRatio`, a candidate is either boosted or a diversity slot, never both — so each line shows at most one tag. Candidates that matched no preference and didn't fill a diversity slot show nothing (no noise in the default no-preferences case).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] Full suite: 728 core + 19 mcp = **747 passing** (unchanged; this is a display-only edit)
- [ ] Manual smoke: run `oss-scout search 5 --prefer-languages typescript` and verify tags render

## Why no new tests

The personalization fields' semantics already have full coverage in `personalization.test.ts` (annotation logic) and the diversity counterweight tests (slot tagging). This PR adds zero new behavior — just visibility. A snapshot test of CLI output would couple the test to display formatting (icon emoji, indentation), which is more brittle than the change is worth.