### PR TITLE
fix(mcp): add shebang to server entry so the published bin runs under npx

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createScout, getGitHubToken } from "@oss-scout/core";


### PR DESCRIPTION
## Summary
Adds `#!/usr/bin/env node` to `packages/mcp-server/src/index.ts`. esbuild preserves the entry-file hashbang, so the published `dist/mcp-server.bundle.cjs` is now directly executable and `npx @oss-scout/mcp` works on Unix.

## Why
The bin symlink pointed at a bundle with no shebang, so the shell tried to execute it as a script and failed. The core CLI already uses this exact pattern (`packages/core/src/cli.ts:1`).

## Test plan
- [x] `pnpm --filter @oss-scout/mcp run bundle` output starts with `#!/usr/bin/env node`
- [x] lint, typecheck, full test suite green (747 tests)

Closes #114