### PR TITLE
fix(mcp): report the real server version and manage versions via release-please

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-scout",
-  "version": "0.2.1",
+  "version": "0.11.0",
   "description": "Find open source issues personalized to your contribution history. Three-strategy search, deep vetting, and viability scoring.",
   "author": {
     "name": "John Costa",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Branch naming: `feature/description`, `fix/description`, `chore/description`.
 
 - **CI:** GitHub Actions on Node 20, 22, 24. Runs: audit, lint, format, typecheck, test, bundle.
 - **Release:** release-please auto-creates version bump PRs from conventional commits.
+- **Version coupling (deliberate):** `.claude-plugin/plugin.json` version tracks the **core** component, and the MCP server's announced version (`packages/mcp-server/src/index.ts`, `x-release-please-version` annotation) tracks **mcp-server** — both via `extra-files` in `release-please-config.json`. Don't hand-edit these versions; release PRs bump them.
 - **Publish:** Merging a release-please PR auto-publishes to npm via granular token.
 
 ## Code Style

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -18,7 +18,7 @@ async function main(): Promise<void> {
   const scout = await createScout({ githubToken: token });
 
   const server = new McpServer(
-    { name: "oss-scout-mcp", version: "0.2.1" },
+    { name: "oss-scout-mcp", version: "0.8.0" }, // x-release-please-version
     { capabilities: { resources: {}, tools: {} } },
   );
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,11 +3,24 @@
   "packages": {
     "packages/core": {
       "release-type": "node",
-      "component": "core"
+      "component": "core",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "../../.claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     },
     "packages/mcp-server": {
       "release-type": "node",
-      "component": "mcp-server"
+      "component": "mcp-server",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "src/index.ts"
+        }
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "../../.claude-plugin/plugin.json",
+          "path": "/.claude-plugin/plugin.json",
           "jsonpath": "$.version"
         }
       ]


### PR DESCRIPTION
## Summary
- MCP server constant bumped 0.2.1 to 0.8.0 with an `x-release-please-version` annotation
- `.claude-plugin/plugin.json` bumped 0.2.1 to 0.11.0, now tracks the core component
- `release-please-config.json` gains `extra-files` entries for both, so release PRs keep them in sync
- CLAUDE.md documents the coupling so nobody hand-edits these again

## Why
Three version sources had drifted (server announced 0.2.1 while shipping 0.8.0; plugin manifest unmanaged). See #147.

## Verification
- [x] `release-please release-pr --dry-run --target-branch=fix/147-version-drift` lists both files among the proposed release updates (GenericJson for plugin.json, Generic for index.ts); a `../../` path variant was rejected by release-please and replaced with the repo-root-relative `/` form
- [x] lint, typecheck, 747 tests green

Closes #147