### PR TITLE
chore(ci): make the security audit advisory instead of blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Security audit
-        run: pnpm audit --audit-level=high
-
       - name: Lint
         run: pnpm run lint
 
@@ -42,3 +39,23 @@ jobs:
 
       - name: Bundle
         run: pnpm --filter @oss-scout/core run bundle
+
+  # Advisory-only: a new transitive advisory should not block unrelated PRs.
+  # Failures surface as a red job here without failing required checks.
+  audit:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Security audit
+        run: pnpm audit --audit-level=high


### PR DESCRIPTION
## Summary
Removes `pnpm audit --audit-level=high` from the Node 20/22/24 matrix and adds a standalone single-version `audit` job with `continue-on-error: true`.

## Why
A new transitive advisory previously turned every PR red regardless of the change, and the same lockfile was audited three times per run. Advisory results stay visible in the checks UI; they just no longer gate merges. See #172.

## Test plan
- [x] lint + full suite green locally
- [x] reviewed continue-on-error semantics: workflow concludes success while the audit job surfaces its own status

Closes #172