### PR TITLE
fix(core): require a word boundary for CLA detection in CONTRIBUTING parsing

### DIFF
--- a/packages/core/src/core/repo-health.test.ts
+++ b/packages/core/src/core/repo-health.test.ts
@@ -167,6 +167,63 @@ describe("fetchContributionGuidelines", () => {
     expect(guidelines!.linter).toBe("ESLint");
   });
 
+  it("does not flag CLA from incidental substrings like class/clang/clarify", async () => {
+    const content =
+      "# Contributing\n\nAdd a test class for each module. We use clang-format. " +
+      "Please clarify your change in the PR declaration.";
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockResolvedValue({
+          data: { content: Buffer.from(content).toString("base64") },
+        }),
+      },
+    } as unknown as Octokit;
+
+    const guidelines = await fetchContributionGuidelines(
+      octokit,
+      "cla-substr-org",
+      "cla-substr-repo",
+    );
+    expect(guidelines!.claRequired).toBeUndefined();
+  });
+
+  it("flags CLA when CLA appears as a standalone word", async () => {
+    const content = "# Contributing\n\nYou must sign the CLA before we merge.";
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockResolvedValue({
+          data: { content: Buffer.from(content).toString("base64") },
+        }),
+      },
+    } as unknown as Octokit;
+
+    const guidelines = await fetchContributionGuidelines(
+      octokit,
+      "cla-word-org",
+      "cla-word-repo",
+    );
+    expect(guidelines!.claRequired).toBe(true);
+  });
+
+  it("flags CLA on the full contributor license agreement phrase", async () => {
+    const content =
+      "# Contributing\n\nSign our Contributor License Agreement first.";
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockResolvedValue({
+          data: { content: Buffer.from(content).toString("base64") },
+        }),
+      },
+    } as unknown as Octokit;
+
+    const guidelines = await fetchContributionGuidelines(
+      octokit,
+      "cla-phrase-org",
+      "cla-phrase-repo",
+    );
+    expect(guidelines!.claRequired).toBe(true);
+  });
+
   it("returns undefined when no CONTRIBUTING.md found (404)", async () => {
     const err = new Error("Not Found") as Error & { status: number };
     err.status = 404;

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -265,9 +265,10 @@ function parseContributionGuidelines(content: string): ContributionGuidelines {
   else if (lowerContent.includes("rubocop")) guidelines.linter = "RuboCop";
   else if (lowerContent.includes("prettier")) guidelines.formatter = "Prettier";
 
-  // Detect CLA requirement
+  // Detect CLA requirement. Word boundary matters: a bare substring check
+  // matches "class", "clang", "clarify", etc. and flags nearly every doc.
   if (
-    lowerContent.includes("cla") ||
+    /\bcla\b/.test(lowerContent) ||
     lowerContent.includes("contributor license agreement")
   ) {
     guidelines.claRequired = true;


### PR DESCRIPTION
## Summary
`parseContributionGuidelines` flagged `claRequired` for any document containing the letters "cla" (class, clang, clarify, declaration). Now uses `/\bcla\b/` on the lowercased content alongside the existing full-phrase check.

## Test plan
- [x] 3 new regression tests: incidental substrings stay unflagged, standalone CLA flags, full phrase flags (unique repo names per test to avoid the module-level guidelines cache)
- [x] lint, typecheck, 750 tests green

Closes #128