### PR TITLE
fix(core): treat cached falsy bodies as hits and recover from orphaned 304s

### DIFF
--- a/packages/core/src/core/http-cache.test.ts
+++ b/packages/core/src/core/http-cache.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as crypto from "crypto";
-import { HttpCache } from "./http-cache.js";
+import { HttpCache, cachedRequest, cachedTimeBased } from "./http-cache.js";
 
 vi.mock("./logger.js", () => ({
   debug: vi.fn(),
@@ -57,6 +57,121 @@ describe("HttpCache", () => {
     const evicted = cache.evictStale(24 * 60 * 60 * 1000); // max age 1 day
     expect(evicted).toBe(1);
     expect(cache.get(url)).toBeNull();
+  });
+
+  it.each([[false], [0], [""], [null]])(
+    "cachedTimeBased treats a cached falsy body (%j) as a hit",
+    async (falsyBody) => {
+      const cache = new HttpCache(tmpDir);
+      const key = `falsy-key-${JSON.stringify(falsyBody)}`;
+      const fetcher = vi.fn().mockResolvedValue(falsyBody);
+
+      const first = await cachedTimeBased(cache, key, 60_000, fetcher);
+      const second = await cachedTimeBased(cache, key, 60_000, fetcher);
+
+      expect(first).toEqual(falsyBody);
+      expect(second).toEqual(falsyBody);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("cachedTimeBased refetches once the entry is older than maxAgeMs", async () => {
+    const cache = new HttpCache(tmpDir);
+    const key = "expiring-key";
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({ v: 1 })
+      .mockResolvedValueOnce({ v: 2 });
+
+    await cachedTimeBased(cache, key, 60_000, fetcher);
+
+    // Backdate the entry past the max age
+    const hash = crypto.createHash("sha256").update(key).digest("hex");
+    const filePath = path.join(tmpDir, `${hash}.json`);
+    const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    entry.cachedAt = new Date(Date.now() - 120_000).toISOString();
+    fs.writeFileSync(filePath, JSON.stringify(entry));
+
+    const result = await cachedTimeBased(cache, key, 60_000, fetcher);
+    expect(result).toEqual({ v: 2 });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("cachedRequest refetches unconditionally when a 304 arrives but the entry vanished", async () => {
+    const cache = new HttpCache(tmpDir);
+    const url = "https://api.github.com/repos/orphaned/304";
+    cache.set(url, "stale-etag", { old: true });
+
+    const notModified = new Error("Not Modified") as Error & {
+      status: number;
+    };
+    notModified.status = 304;
+
+    const fetcher = vi
+      .fn()
+      .mockImplementationOnce((headers: Record<string, string>) => {
+        expect(headers["if-none-match"]).toBe("stale-etag");
+        // Simulate a concurrent process wiping the entry mid-flight
+        cache.clear();
+        return Promise.reject(notModified);
+      })
+      .mockImplementationOnce((headers: Record<string, string>) => {
+        expect(headers["if-none-match"]).toBeUndefined();
+        return Promise.resolve({
+          data: { fresh: true },
+          headers: { etag: "new-etag" },
+        });
+      });
+
+    const result = await cachedRequest(cache, url, fetcher);
+
+    expect(result).toEqual({ fresh: true });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(cache.get(url)!.etag).toBe("new-etag");
+  });
+
+  it("cachedRequest propagates a failure from the post-304 refetch", async () => {
+    const cache = new HttpCache(tmpDir);
+    const url = "https://api.github.com/repos/orphaned/304-then-403";
+    cache.set(url, "stale-etag", { old: true });
+
+    const notModified = new Error("Not Modified") as Error & {
+      status: number;
+    };
+    notModified.status = 304;
+    const rateLimited = new Error("API rate limit exceeded") as Error & {
+      status: number;
+    };
+    rateLimited.status = 403;
+
+    const fetcher = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        cache.clear();
+        return Promise.reject(notModified);
+      })
+      .mockRejectedValueOnce(rateLimited);
+
+    await expect(cachedRequest(cache, url, fetcher)).rejects.toThrow(
+      "API rate limit exceeded",
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("cachedRequest returns the cached body on 304 when the entry is present", async () => {
+    const cache = new HttpCache(tmpDir);
+    const url = "https://api.github.com/repos/present/304";
+    cache.set(url, "etag-live", { cached: true });
+
+    const notModified = new Error("Not Modified") as Error & {
+      status: number;
+    };
+    notModified.status = 304;
+    const fetcher = vi.fn().mockRejectedValue(notModified);
+
+    const result = await cachedRequest(cache, url, fetcher);
+    expect(result).toEqual({ cached: true });
+    expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
   it("deletes corrupt entries on read", () => {

--- a/packages/core/src/core/http-cache.ts
+++ b/packages/core/src/core/http-cache.ts
@@ -20,7 +20,7 @@ import { errorMessage, getHttpStatusCode } from "./errors.js";
 const MODULE = "http-cache";
 
 /** Shape of a single cache entry on disk. */
-interface CacheEntry {
+export interface CacheEntry {
   etag: string;
   url: string;
   body: unknown;
@@ -68,11 +68,20 @@ export class HttpCache {
    * (e.g., caching aggregated results from paginated API calls).
    */
   getIfFresh(key: string, maxAgeMs: number): unknown | null {
+    return this.getEntryIfFresh(key, maxAgeMs)?.body ?? null;
+  }
+
+  /**
+   * Like {@link getIfFresh}, but returns the whole entry so callers can
+   * distinguish "no fresh entry" (null) from a legitimately cached falsy
+   * body (`0`, `""`, `false`, `null`).
+   */
+  getEntryIfFresh(key: string, maxAgeMs: number): CacheEntry | null {
     const entry = this.get(key);
     if (!entry) return null;
     const age = Date.now() - new Date(entry.cachedAt).getTime();
     if (!Number.isFinite(age) || age < 0 || age > maxAgeMs) return null;
-    return entry.body;
+    return entry;
   }
 
   /**
@@ -308,6 +317,16 @@ export async function cachedRequest<T>(
           debug(MODULE, `304 cache hit for ${url}`);
           return freshCached.body as T;
         }
+        // The entry that supplied If-None-Match vanished mid-flight (e.g. a
+        // concurrent process deleted it). Refetch unconditionally; without
+        // the conditional header the server cannot answer 304 again.
+        debug(MODULE, `304 but cache entry vanished for ${url}, refetching`);
+        const response = await fetcher({});
+        const etag = response.headers?.["etag"];
+        if (etag) {
+          cache.set(url, etag, response.data);
+        }
+        return response.data;
       }
       throw err;
     }
@@ -339,10 +358,10 @@ export async function cachedTimeBased<T>(
   maxAgeMs: number,
   fetcher: () => Promise<T>,
 ): Promise<T> {
-  const cached = cache.getIfFresh(key, maxAgeMs);
+  const cached = cache.getEntryIfFresh(key, maxAgeMs);
   if (cached) {
     debug(MODULE, `Time-based cache hit for ${key}`);
-    return cached as T;
+    return cached.body as T;
   }
 
   const result = await fetcher();


### PR DESCRIPTION
## Summary
- New `HttpCache.getEntryIfFresh` returns the whole entry, so `cachedTimeBased` can distinguish "no fresh entry" from a cached falsy body (`0`, `""`, `false`, `null`). `getIfFresh` delegates and is behavior-identical for its existing callers (verified each one re-guards its own value).
- `cachedRequest` now refetches unconditionally when a 304 arrives but the cache entry vanished mid-flight, instead of throwing a raw 304 error nothing downstream classifies. At most two fetches: the retry carries no `If-None-Match`, so the server cannot 304 again. The retry runs inside the registered in-flight promise, so dedup waiters share its outcome.

## Test plan
- [x] 8 new tests: falsy-body hit matrix, expiry refetch, orphaned-304 refetch (asserts conditional header present then absent, new etag persisted), post-304 failure propagation, 304 happy path
- [x] lint, typecheck, full suite green (739 core + 19 mcp)

Closes #142