### PR TITLE
fix(core): evict stale http-cache entries on every cache-burning entry point

### DIFF
--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -22,8 +22,7 @@ vi.mock("../core/local-state.js", () => {
 // Stub the shared cache singleton so vetList's stale-entry eviction never
 // touches the real ~/.oss-scout/cache in tests.
 vi.mock("../core/http-cache.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../core/http-cache.js")>();
+  const actual = await importOriginal<typeof import("../core/http-cache.js")>();
   return {
     ...actual,
     getHttpCache: () =>

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -19,6 +19,20 @@ vi.mock("../core/local-state.js", () => {
   };
 });
 
+// Stub the shared cache singleton so vetList's stale-entry eviction never
+// touches the real ~/.oss-scout/cache in tests.
+vi.mock("../core/http-cache.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../core/http-cache.js")>();
+  return {
+    ...actual,
+    getHttpCache: () =>
+      ({ evictStale: () => 0 }) as unknown as ReturnType<
+        typeof actual.getHttpCache
+      >,
+  };
+});
+
 async function setMockState(state: any) {
   const mod = (await import("../core/local-state.js")) as any;
   mod._setMockState(state);

--- a/packages/core/src/e2e/search-flow.test.ts
+++ b/packages/core/src/e2e/search-flow.test.ts
@@ -81,8 +81,7 @@ const { evictStaleMock } = vi.hoisted(() => ({
   evictStaleMock: vi.fn(() => 0),
 }));
 vi.mock("../core/http-cache.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../core/http-cache.js")>();
+  const actual = await importOriginal<typeof import("../core/http-cache.js")>();
   return {
     ...actual,
     getHttpCache: () =>

--- a/packages/core/src/e2e/search-flow.test.ts
+++ b/packages/core/src/e2e/search-flow.test.ts
@@ -75,6 +75,23 @@ vi.mock("../core/issue-discovery.js", () => {
   };
 });
 
+// Stub the shared cache singleton so search()'s evictStale call never
+// touches the real ~/.oss-scout/cache during tests.
+const { evictStaleMock } = vi.hoisted(() => ({
+  evictStaleMock: vi.fn(() => 0),
+}));
+vi.mock("../core/http-cache.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../core/http-cache.js")>();
+  return {
+    ...actual,
+    getHttpCache: () =>
+      ({ evictStale: evictStaleMock }) as unknown as ReturnType<
+        typeof actual.getHttpCache
+      >,
+  };
+});
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function makeState(overrides: Partial<ScoutState> = {}): ScoutState {
@@ -88,6 +105,12 @@ describe("E2E: search flow", () => {
 
   beforeEach(() => {
     scout = new OssScout("fake-token", makeState());
+  });
+
+  it("search evicts stale cache entries exactly once per invocation", async () => {
+    evictStaleMock.mockClear();
+    await scout.search({ maxResults: 5 });
+    expect(evictStaleMock).toHaveBeenCalledTimes(1);
   });
 
   it("search returns candidates", async () => {

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -14,6 +14,19 @@ vi.mock("./core/feature-discovery.js", async (importOriginal) => {
 
 import { discoverFeatures } from "./core/feature-discovery.js";
 
+// Stub the shared cache singleton so cache-burning entry points
+// (search/features/vetList) never touch the real ~/.oss-scout/cache in tests.
+vi.mock("./core/http-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./core/http-cache.js")>();
+  return {
+    ...actual,
+    getHttpCache: () =>
+      ({ evictStale: () => 0 }) as unknown as ReturnType<
+        typeof actual.getHttpCache
+      >,
+  };
+});
+
 function makeState(overrides: Partial<ScoutState> = {}): ScoutState {
   return ScoutStateSchema.parse({ version: 1, ...overrides });
 }

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -51,6 +51,7 @@ import {
   getHttpStatusCode,
   isRateLimitError,
 } from "./core/errors.js";
+import { getHttpCache } from "./core/http-cache.js";
 
 /** Cause-specific user-facing message for degraded (offline) mode. */
 function offlineModeMessage(reason: DegradedReason | undefined): string {
@@ -181,10 +182,21 @@ export class OssScout implements ScoutStateReader {
   // ── Search ──────────────────────────────────────────────────────────
 
   /**
+   * Drop stale disk-cache entries. Called at the top of every cache-burning
+   * entry point (search, features, vetList); without it ~/.oss-scout/cache
+   * grows without bound. evictStale never throws (fs errors degrade to warn).
+   */
+  private evictStaleCacheEntries(): void {
+    getHttpCache().evictStale();
+  }
+
+  /**
    * Multi-strategy issue search. Returns scored, sorted candidates.
    * Automatically culls expired skip entries and filters skipped issues.
    */
   async search(options?: SearchOptions): Promise<SearchResult> {
+    this.evictStaleCacheEntries();
+
     // Auto-cull expired skips before searching
     this.cullExpiredSkips();
 
@@ -249,6 +261,7 @@ export class OssScout implements ScoutStateReader {
     splitRatio?: number;
     broad?: boolean;
   }): Promise<FeatureSearchResult> {
+    this.evictStaleCacheEntries();
     const count = options?.count ?? 10;
     const octokit = getOctokit(this.githubToken);
     const vetter = new IssueVetter(octokit, this);
@@ -290,6 +303,7 @@ export class OssScout implements ScoutStateReader {
    * Optionally prunes unavailable issues from saved results.
    */
   async vetList(options?: VetListOptions): Promise<VetListResult> {
+    this.evictStaleCacheEntries();
     const saved = this.getSavedResults();
     const concurrency = options?.concurrency ?? 5;
     const results: VetListEntry[] = [];


### PR DESCRIPTION
## Summary
`HttpCache.evictStale()` had zero production call sites, so the disk cache grew forever. A private `evictStaleCacheEntries()` helper now runs at the top of `search()`, `features()`, and `vetList()` (standalone `vetIssue` deliberately excluded: single-issue traffic, and it runs inside vetList anyway). `evictStale` never throws; fs errors degrade to a warn internally.

Tests: the e2e suite asserts eviction runs exactly once per search, and the cache singleton is stubbed in the three affected test files so suites no longer touch the developer's real `~/.oss-scout/cache`.

## Test plan
- [x] lint, typecheck, 740 core + 19 mcp tests green
- [x] two review passes converged (entry-point coverage finding addressed; JSDoc placement finding addressed)

Closes #139