### PR TITLE
fix(core): trim GITHUB_TOKEN and stop logging the raw gh error object

### DIFF
--- a/packages/core/src/core/utils.test.ts
+++ b/packages/core/src/core/utils.test.ts
@@ -185,6 +185,75 @@ describe("getGitHubToken", () => {
       }
     }
   });
+
+  it("trims whitespace from GITHUB_TOKEN", async () => {
+    vi.resetModules();
+    vi.doMock("child_process", () => ({
+      execFileSync: vi.fn().mockReturnValue(""),
+    }));
+
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = "  ghp_padded_token\n";
+    try {
+      const { getGitHubToken } = await import("./utils.js");
+      expect(getGitHubToken()).toBe("ghp_padded_token");
+    } finally {
+      if (originalToken !== undefined) {
+        process.env.GITHUB_TOKEN = originalToken;
+      } else {
+        delete process.env.GITHUB_TOKEN;
+      }
+    }
+  });
+
+  it("falls through to the gh CLI when GITHUB_TOKEN is whitespace-only", async () => {
+    vi.resetModules();
+    vi.doMock("child_process", () => ({
+      execFileSync: vi.fn().mockReturnValue("ghp_from_gh_cli\n"),
+    }));
+
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = "   \n";
+    try {
+      const { getGitHubToken } = await import("./utils.js");
+      expect(getGitHubToken()).toBe("ghp_from_gh_cli");
+    } finally {
+      if (originalToken !== undefined) {
+        process.env.GITHUB_TOKEN = originalToken;
+      } else {
+        delete process.env.GITHUB_TOKEN;
+      }
+    }
+  });
+
+  it("does not include the raw error object when gh fails", async () => {
+    vi.resetModules();
+    const stderrCarryingError = Object.assign(new Error("exit 1"), {
+      stdout: "ghp_leaked_token",
+      stderr: "boom",
+    });
+    vi.doMock("child_process", () => ({
+      execFileSync: vi.fn().mockImplementation(() => {
+        throw stderrCarryingError;
+      }),
+    }));
+
+    const originalToken = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    try {
+      const { getGitHubToken } = await import("./utils.js");
+      const { debug } = await import("./logger.js");
+      expect(getGitHubToken()).toBeNull();
+      const debugCalls = vi.mocked(debug).mock.calls.flat();
+      expect(JSON.stringify(debugCalls)).not.toContain("ghp_leaked_token");
+    } finally {
+      if (originalToken !== undefined) {
+        process.env.GITHUB_TOKEN = originalToken;
+      } else {
+        delete process.env.GITHUB_TOKEN;
+      }
+    }
+  });
 });
 
 // ── requireGitHubToken ──

--- a/packages/core/src/core/utils.ts
+++ b/packages/core/src/core/utils.ts
@@ -116,8 +116,12 @@ export function getGitHubToken(): string | null {
   if (tokenFetchAttempted) return null;
   tokenFetchAttempted = true;
 
-  if (process.env.GITHUB_TOKEN) {
-    cachedGitHubToken = process.env.GITHUB_TOKEN;
+  // Trim: a trailing newline (e.g. GITHUB_TOKEN=$(cat file)) produces a
+  // malformed Authorization header with confusing 401s. A whitespace-only
+  // value falls through to the gh CLI.
+  const envToken = process.env.GITHUB_TOKEN?.trim();
+  if (envToken) {
+    cachedGitHubToken = envToken;
     return cachedGitHubToken;
   }
 
@@ -133,7 +137,9 @@ export function getGitHubToken(): string | null {
       return cachedGitHubToken;
     }
   } catch (err) {
-    debug(MODULE, "gh auth token failed", err);
+    // Log only the message: the raw execFileSync error carries stdout/stderr
+    // buffers that could include a token if gh half-succeeded.
+    debug(MODULE, `gh auth token failed: ${errorMessage(err)}`);
   }
 
   return null;


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` is trimmed before caching; whitespace-only values fall through to the `gh auth token` path instead of producing a broken header
- The gh-failure debug log now emits `errorMessage(err)` instead of the raw execFileSync error object (whose stdout/stderr buffers could contain a token)

## Test plan
- [x] 3 new tests: trim, whitespace-only fall-through, and a leak guard asserting a token planted in `err.stdout` never reaches the debug log
- [x] lint, format:check, typecheck, 743 core + 19 mcp tests green

Closes #136