### PR TITLE
fix(core): make the broad-phase skip threshold satisfiable

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -948,6 +948,30 @@ describe("IssueDiscovery", () => {
       expect(sleepCalls).not.toContain(90000);
     });
 
+    it("clamps an unsatisfiable threshold to maxResults - 1 (old persisted default 15 vs maxResults 10)", async () => {
+      // 9 candidates from Phase 0: under maxResults (10), so Phase 2's gate
+      // is open; threshold 15 would never fire unclamped, but clamped to 9
+      // it skips the broad phase.
+      const candidates = Array.from({ length: 9 }, (_, i) =>
+        makeCandidate(`org/clamp-${i}`, "merged_pr"),
+      );
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates,
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery(
+        { getReposWithMergedPRs: vi.fn(() => ["org/clamp-0"]) },
+        { skipBroadWhenSufficientResults: 15 },
+      );
+
+      await discovery.searchIssues({ maxResults: 10 });
+
+      expect(mockSearchAcrossLanguagesAndLabels).not.toHaveBeenCalled();
+    });
+
     it("skipBroadWhenSufficientResults=0 means never skip Phase 2", async () => {
       // Phase 0 returns many candidates
       const candidates = Array.from({ length: 20 }, (_, i) =>

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -677,7 +677,15 @@ export class IssueDiscovery {
 
     // Phase 2: General search (with rate limit mitigation)
     const broadDelay = config.broadPhaseDelayMs ?? 90000;
-    const skipThreshold = config.skipBroadWhenSufficientResults ?? 15;
+    // Clamp to maxResults - 1: the phase gate below already skips the whole
+    // phase at >= maxResults, so any larger threshold would be unsatisfiable
+    // (the default 15 vs default maxResults 10 made this dead config). 0
+    // stays "never skip".
+    const configuredSkipThreshold = config.skipBroadWhenSufficientResults ?? 8;
+    const skipThreshold =
+      configuredSkipThreshold > 0
+        ? Math.min(configuredSkipThreshold, maxResults - 1)
+        : 0;
 
     if (
       allCandidates.length < maxResults &&

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -156,9 +156,9 @@ describe("ScoutPreferencesSchema", () => {
     expect(prefs.broadPhaseDelayMs).toBe(90000);
   });
 
-  it("applies skipBroadWhenSufficientResults default of 15", () => {
+  it("applies skipBroadWhenSufficientResults default of 8 (below default maxResults)", () => {
     const prefs = ScoutPreferencesSchema.parse({});
-    expect(prefs.skipBroadWhenSufficientResults).toBe(15);
+    expect(prefs.skipBroadWhenSufficientResults).toBe(8);
   });
 
   it("accepts custom broadPhaseDelayMs", () => {

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -196,7 +196,12 @@ export const ScoutPreferencesSchema = z.object({
   persistence: PersistenceModeSchema.default("local"),
   defaultStrategy: z.array(SearchStrategySchema).optional(),
   broadPhaseDelayMs: z.number().min(0).max(300000).default(90000),
-  skipBroadWhenSufficientResults: z.number().int().min(0).max(100).default(15),
+  /**
+   * Skip the expensive broad phase once this many candidates were found by
+   * the cheaper phases. Clamped at runtime to maxResults - 1 so it stays
+   * satisfiable; 0 disables skipping entirely.
+   */
+  skipBroadWhenSufficientResults: z.number().int().min(0).max(100).default(8),
   /**
    * Optional Ollama model id used for SLM pre-triage during vetting
    * (oss-autopilot#1122). Empty disables the feature. Recommended values:


### PR DESCRIPTION
## Summary
- Schema default for `skipBroadWhenSufficientResults` drops 15 → 8 (below the default `maxResults` of 10)
- Runtime clamp `min(threshold, maxResults - 1)` keeps any configured value satisfiable, including the 15 already materialized into old persisted states; `0` remains the documented never-skip opt-out
- Edge cases verified: `maxResults` can never be < 1 (`|| 10` coercion), and at `maxResults = 1` the clamp degrades to disabled, where skipping is meaningless anyway

## Test plan
- [x] New regression test: threshold 15 + maxResults 10 + 9 cheap-phase candidates → broad phase skipped (unsatisfiable before)
- [x] Schema default test updated; lint, format:check, typecheck, 744 core + 19 mcp green

Closes #123