### PR TITLE
fix(cli): let the defaultStrategy preference take effect

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -105,8 +105,7 @@ program
   .option("--json", "Output as JSON")
   .option(
     "--strategy <strategies>",
-    `Search strategies (${CONCRETE_STRATEGIES.join(",")},all)`,
-    "all",
+    `Search strategies (${CONCRETE_STRATEGIES.join(",")},all). Defaults to the defaultStrategy preference, or all.`,
   )
   .option(
     "--prefer-languages <list>",
@@ -153,25 +152,29 @@ program
             "Run `oss-scout bootstrap` to import your starred repos and PR history for better results.\n",
           );
         }
-        // Parse --strategy option
-        const strategyTokens = (options.strategy ?? "all")
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean);
-        const strategies: SearchStrategy[] = [];
-        for (const token of strategyTokens) {
-          const parsed = SearchStrategySchema.safeParse(token);
-          if (!parsed.success) {
-            const valid = [...CONCRETE_STRATEGIES, "all"].join(", ");
-            console.error(
-              'Error: unknown strategy "' +
-                token +
-                '". Valid strategies: ' +
-                valid,
-            );
-            process.exit(1);
+        // Parse --strategy. Absent means undefined so the stored
+        // defaultStrategy preference applies (discovery falls back to "all").
+        let strategies: SearchStrategy[] | undefined;
+        if (options.strategy !== undefined) {
+          const strategyTokens = options.strategy
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          strategies = [];
+          for (const token of strategyTokens) {
+            const parsed = SearchStrategySchema.safeParse(token);
+            if (!parsed.success) {
+              const valid = [...CONCRETE_STRATEGIES, "all"].join(", ");
+              console.error(
+                'Error: unknown strategy "' +
+                  token +
+                  '". Valid strategies: ' +
+                  valid,
+              );
+              process.exit(1);
+            }
+            strategies.push(parsed.data);
           }
-          strategies.push(parsed.data);
         }
 
         const splitCsv = (raw: string | undefined): string[] | undefined => {

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -516,10 +516,17 @@ export class IssueDiscovery {
     const minStars = config.minStars ?? 50;
     const interPhaseDelay = config.interPhaseDelayMs ?? 30000;
 
-    // Strategy selection
+    // Strategy selection. Empty arrays count as "unset" so a stored
+    // defaultStrategy of [] can't silently produce zero-strategy searches.
     const ALL_STRATEGIES: readonly SearchStrategy[] = CONCRETE_STRATEGIES;
-    const rawStrategies = options.strategies ??
-      config.defaultStrategy ?? ["all"];
+    const pickStrategies = (
+      ...candidates: Array<readonly SearchStrategy[] | undefined>
+    ): readonly SearchStrategy[] =>
+      candidates.find((c) => c && c.length > 0) ?? ["all"];
+    const rawStrategies = pickStrategies(
+      options.strategies,
+      config.defaultStrategy,
+    );
     const enabledStrategies = new Set<SearchStrategy>(
       rawStrategies.includes("all") ? ALL_STRATEGIES : rawStrategies,
     );

--- a/packages/core/src/core/strategy-selection.test.ts
+++ b/packages/core/src/core/strategy-selection.test.ts
@@ -262,6 +262,37 @@ describe("Strategy Selection", () => {
     expect(fetchIssuesFromKnownRepos).toHaveBeenCalledTimes(1);
   });
 
+  it("treats an empty defaultStrategy as unset and falls back to all", async () => {
+    const prefs = {
+      ...basePreferences,
+      defaultStrategy: [] as SearchStrategy[],
+    };
+    const stateReader = {
+      ...baseStateReader,
+      getReposWithMergedPRs: () => ["owner/repo"],
+      getStarredRepos: () => ["owner/starred"],
+    };
+    const discovery = new IssueDiscovery("token", prefs, stateReader);
+    const result = await discovery.searchIssues({});
+    // [] must not produce a zero-strategy (silently empty) search
+    expect(result.strategiesUsed.length).toBeGreaterThan(0);
+  });
+
+  it("treats empty options.strategies as unset and applies defaultStrategy", async () => {
+    const prefs = {
+      ...basePreferences,
+      defaultStrategy: ["merged"] as SearchStrategy[],
+    };
+    const stateReader = {
+      ...baseStateReader,
+      getReposWithMergedPRs: () => ["owner/repo"],
+      getStarredRepos: () => ["owner/starred"],
+    };
+    const discovery = new IssueDiscovery("token", prefs, stateReader);
+    const result = await discovery.searchIssues({ strategies: [] });
+    expect(result.strategiesUsed).toEqual(["merged"]);
+  });
+
   it("can combine multiple strategies", async () => {
     const stateReader = {
       ...baseStateReader,


### PR DESCRIPTION
## Summary
- `--strategy` no longer has a commander default; when absent, discovery applies `options.strategies → defaultStrategy preference → all`
- Empty arrays count as unset in that chain (a stored `defaultStrategy: []` previously yielded a silent zero-strategy search)
- Explicit `--strategy` values parse byte-identically to before

## Test plan
- [x] 2 new tests: empty defaultStrategy falls back to all; empty options.strategies applies defaultStrategy
- [x] lint, format:check, typecheck, 746 core + 19 mcp green

Closes #133