### PR TITLE
fix(cli,mcp): validate issue URLs on skip add

### DIFF
--- a/packages/core/src/commands/skip.test.ts
+++ b/packages/core/src/commands/skip.test.ts
@@ -82,6 +82,39 @@ describe("skip command", () => {
       expect(state.skippedIssues[0].number).toBe(1);
     });
 
+    it.each([
+      ["banana"],
+      ["https://github.com/owner/repo/issues/1/"],
+      ["https://github.com/owner/repo/issues/1?tab=comments"],
+      ["https://github.com/owner/repo/pull/1"],
+      ["https://notgithub.com/owner/repo/issues/1"],
+    ])("rejects invalid or near-miss URL %s", async (badUrl) => {
+      await expect(runSkip({ issueUrl: badUrl })).rejects.toThrow(
+        "Invalid issue URL",
+      );
+      const state = await getMockState();
+      expect(state.skippedIssues ?? []).toHaveLength(0);
+    });
+
+    it("removes legacy junk entries without validation", async () => {
+      const fresh = ScoutStateSchema.parse({ version: 1 });
+      fresh.skippedIssues = [
+        {
+          url: "banana",
+          repo: "",
+          number: 0,
+          title: "",
+          skippedAt: new Date().toISOString(),
+        },
+      ];
+      await setMockState(fresh);
+
+      const result = await runSkipRemove({ issueUrl: "banana" });
+      expect(result.removed).toBe(true);
+      const state = await getMockState();
+      expect(state.skippedIssues).toHaveLength(0);
+    });
+
     it("deduplicates — same URL not added twice", async () => {
       const url = "https://github.com/owner/repo/issues/1";
       await runSkip({ issueUrl: url });

--- a/packages/core/src/commands/skip.ts
+++ b/packages/core/src/commands/skip.ts
@@ -6,6 +6,11 @@ import { loadLocalState, saveLocalState } from "../core/local-state.js";
 import type { SkippedIssue, ScoutState } from "../core/schemas.js";
 import { createScout } from "../scout.js";
 import { getGitHubToken } from "../core/utils.js";
+import {
+  ISSUE_URL_PATTERN,
+  validateGitHubUrl,
+  validateUrl,
+} from "./validation.js";
 
 /**
  * Create an OssScout instance for skip operations.
@@ -38,6 +43,12 @@ export async function runSkip(options: {
   skipped: boolean;
   alreadySkipped: boolean;
 }> {
+  // Validate up front: skip matching is exact-URL, so a junk or near-miss
+  // URL (trailing slash, query string) would be stored but never exclude
+  // anything — a silent no-op. Reject it with the expected format instead.
+  validateUrl(options.issueUrl);
+  validateGitHubUrl(options.issueUrl, ISSUE_URL_PATTERN, "issue");
+
   const state = options.state ?? loadLocalState();
   const scout = await createSkipScout(state);
 
@@ -83,6 +94,10 @@ export async function runSkipClear(): Promise<void> {
 
 /**
  * Remove a specific issue from the skip list (unskip).
+ *
+ * Deliberately does NOT validate the URL: entries stored before skip-add
+ * validation existed may be junk, and exact-match removal is the only way
+ * to clean them up short of `skip clear`.
  */
 export async function runSkipRemove(options: { issueUrl: string }): Promise<{
   removed: boolean;
@@ -103,7 +118,9 @@ export async function runSkipRemove(options: { issueUrl: string }): Promise<{
 function parseIssueUrl(
   url: string,
 ): { repo: string; number: number; title: string } | undefined {
-  const match = url.match(/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/);
+  const match = url.match(
+    /^https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)$/,
+  );
   if (!match) return undefined;
   return { repo: match[1], number: parseInt(match[2], 10), title: "" };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,3 +111,10 @@ export {
   fetchRoadmapIssueRefs,
   parseRoadmapIssueRefs,
 } from "./core/roadmap.js";
+
+// Issue-URL validation (shared by the CLI and the MCP server)
+export {
+  ISSUE_URL_PATTERN,
+  validateGitHubUrl,
+  validateUrl,
+} from "./commands/validation.js";

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -83,6 +83,57 @@ describe("registerTools", () => {
     expect(names).toContain("scout-features");
   });
 
+  describe("skip tool execution", () => {
+    it("rejects invalid issue URLs on add and surfaces isError", async () => {
+      const handler = getToolHandler(server, "skip");
+      const result = (await handler(
+        { action: "add", issueUrl: "banana" },
+        {},
+      )) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Invalid issue URL");
+      expect(scout.skipIssue).not.toHaveBeenCalled();
+    });
+
+    it("accepts a canonical issue URL on add", async () => {
+      const handler = getToolHandler(server, "skip");
+      const result = (await handler(
+        {
+          action: "add",
+          issueUrl: "https://github.com/owner/repo/issues/12",
+        },
+        {},
+      )) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+
+      expect(result.isError).toBeUndefined();
+      expect(scout.skipIssue).toHaveBeenCalledWith(
+        "https://github.com/owner/repo/issues/12",
+        undefined,
+      );
+    });
+
+    it("remove stays unvalidated so legacy junk entries can be cleaned", async () => {
+      const handler = getToolHandler(server, "skip");
+      const result = (await handler(
+        { action: "remove", issueUrl: "banana" },
+        {},
+      )) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+
+      expect(result.isError).toBeUndefined();
+      expect(scout.unskipIssue).toHaveBeenCalledWith("banana");
+    });
+  });
+
   describe("search tool execution", () => {
     it("returns JSON text content on success", async () => {
       const handler = getToolHandler(server, "search");

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OssScout } from "@oss-scout/core";
-import { SearchStrategySchema, ScoutPreferencesSchema } from "@oss-scout/core";
+import {
+  SearchStrategySchema,
+  ScoutPreferencesSchema,
+  ISSUE_URL_PATTERN,
+  validateGitHubUrl,
+  validateUrl,
+} from "@oss-scout/core";
 
 const TOOL_TIMEOUT_MS = 60000;
 
@@ -250,6 +256,11 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         }
 
         // action === "add"
+        // Same validation as the CLI's runSkip: skip matching is exact-URL,
+        // so junk or near-miss URLs would be stored but never match anything.
+        // The throw is caught below and surfaced as isError.
+        validateUrl(issueUrl!);
+        validateGitHubUrl(issueUrl!, ISSUE_URL_PATTERN, "issue");
         const alreadySkipped = scout
           .getSkippedIssues()
           .some((s) => s.url === issueUrl);


### PR DESCRIPTION
## Summary
- `runSkip` (CLI) and the MCP `skip` tool's add branch validate against `ISSUE_URL_PATTERN` before storing; junk ("banana") and near-miss URLs (trailing slash, query string, /pull/, wrong host) are rejected with the expected format instead of becoming silent no-ops
- `skip remove` deliberately stays unvalidated (documented) so junk entries stored before this fix remain removable
- Validation helpers exported from core's index so both surfaces share one implementation; `parseIssueUrl` regex anchored

## Test plan
- [x] 6 new CLI tests (5-case rejection matrix + legacy-junk removal) and 3 new MCP tests (isError on junk, canonical accepted, remove unvalidated)
- [x] 2 review passes converged (pass 1 caught the MCP bypass)
- [x] lint, format:check, typecheck, 752 core + 22 mcp green

Closes #134