### PR TITLE
fix(core): clause-based claim detection instead of substring matching

### DIFF
--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -31,6 +31,7 @@ import {
   checkNotClaimed,
   checkUserMergedPRsInRepo,
   analyzeRequirements,
+  commentClaimsIssue,
 } from "./issue-eligibility.js";
 import { paginateAll } from "./pagination.js";
 import type { Octokit } from "@octokit/rest";
@@ -308,6 +309,63 @@ describe("checkNoExistingPR", () => {
     const result = await checkNoExistingPR(octokit, "owner", "repo", 5);
     expect(result.linkedPR).not.toBeNull();
     expect(result.linkedPR?.updatedAt).toBeUndefined();
+  });
+});
+
+// ── commentClaimsIssue ────────────────────────────────────────────
+
+describe("commentClaimsIssue", () => {
+  it.each([
+    ["I'm working on this already"],
+    ["I am working on it right now"],
+    ["I'll take this issue"],
+    ["I will take this"],
+    ["I'd like to work on this feature"],
+    ["I would love to work on this"],
+    ["Can I work on this?"],
+    ["May I work on it please?"],
+    ["could i work on this one"],
+    ["I'm on it"],
+    ["I'll submit a PR shortly"],
+    ["This should be assigned to me"],
+    ["Bob is working on it"],
+    ["Started working on a fix yesterday."],
+    ["Thanks for the report. I'm working on this."],
+    ["Can I work on the parser bug?"],
+    ["can i work on #126"],
+    ["May I take this issue?"],
+    ["I would like to work on the auth module"],
+    ["I'd like to work on issue 42"],
+  ])("claims: %s", (body) => {
+    expect(commentClaimsIssue(body)).toBe(true);
+  });
+
+  it.each([
+    ["Is anyone working on this?"],
+    ["is anyone working on it currently"],
+    ["Who is working on this?"],
+    ["Can I work on a repro?"],
+    ["Are you still working on it?"],
+    ["No one is working on this as far as I know"],
+    ["Nobody is working on a fix yet"],
+    ["I'm not working on this anymore"],
+    ["This would be a nice feature."],
+    ["I agree, we should add this."],
+    ["Someone should be working on a fix for the upstream bug"],
+    ["Could I work on a similar feature in another repo?"],
+    ["Can I take 5 minutes to explain the design?"],
+    ["I will take 2 weeks off starting Monday"],
+  ])("does not claim: %s", (body) => {
+    expect(commentClaimsIssue(body)).toBe(false);
+  });
+
+  it("evaluates clauses independently within one comment", () => {
+    expect(
+      commentClaimsIssue("Is anyone working on this? If not, I'll take this."),
+    ).toBe(true);
+    expect(commentClaimsIssue("Is anyone working on this? Just curious.")).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -89,24 +89,70 @@ function buildLinkedPRFromTimelineEvent(
 
 const MODULE = "issue-eligibility";
 
-/** Phrases that indicate someone has already claimed an issue. */
-const CLAIM_PHRASES = [
-  "i'm working on this",
-  "i am working on this",
-  "i'll take this",
-  "i will take this",
-  "working on it",
-  "i'd like to work on",
-  "i would like to work on",
-  "can i work on",
-  "may i work on",
-  "assigned to me",
-  "i'm on it",
-  "i'll submit a pr",
-  "i will submit a pr",
-  "working on a fix",
-  "working on a pr",
-] as const;
+/**
+ * Claim detection, applied per clause (sentence). Plain substring matching
+ * flagged questions ("is anyone working on it?") and negations ("no one is
+ * working on this") as claims. Rules:
+ *
+ * - A clause ending in "?" is never a claim, EXCEPT a permission request
+ *   ("can I work on this?"), which is the author asking to take the issue.
+ * - A declarative clause with an indefinite or negated subject (anyone,
+ *   someone, nobody, not, ...) is never a claim.
+ * - Otherwise declarative claim patterns match, including third-person
+ *   ("Bob is working on it" means the issue is taken).
+ */
+/**
+ * Object that refers to the issue at hand: this/it/that, "the <thing>",
+ * "#123", "issue ...". Deliberately excludes "a <thing>" ("can I work on a
+ * repro?" introduces new work, it does not claim the issue). The numeric
+ * branch requires the # prefix: a bare number collides with quantity idioms
+ * ("can I take 5 minutes"). Residual misses: gerund objects ("work on
+ * fixing the bug") and bare numbers ("work on 126").
+ */
+const ISSUE_OBJECT = String.raw`(?:this\b|it\b|that\b|the\b|#\d+|issue\b)`;
+
+/** Explicit first-person claims; not subject to the subject guard. */
+const FIRST_PERSON_CLAIM_PATTERNS: readonly RegExp[] = [
+  new RegExp(String.raw`\bi\s*(?:'ll|will) take ${ISSUE_OBJECT}`),
+  new RegExp(
+    String.raw`\bi\s*(?:'d|would) (?:like|love) to work on ${ISSUE_OBJECT}`,
+  ),
+  /\bi\s*(?:'m|am) on it\b/,
+  /\bi\s*(?:'ll|will) submit a pr\b/,
+  /\bassigned to me\b/,
+];
+
+/**
+ * Generic "working on ..." phrasings. These also match third-person claims
+ * ("Bob is working on it"), so they need the subject guard below to avoid
+ * flagging indefinite or negated subjects.
+ */
+const GENERIC_WORKING_PATTERNS: readonly RegExp[] = [
+  /\bworking on (?:this|it)\b/,
+  /\bworking on a (?:fix|pr)\b/,
+];
+
+/** Asking to take the issue counts as a claim even phrased as a question. */
+const PERMISSION_CLAIM_PATTERN = new RegExp(
+  String.raw`\b(?:can|may|could) i (?:work on|take) ${ISSUE_OBJECT}`,
+);
+
+/** Subjects/negations that make a "working on ..." clause a non-claim. */
+const NON_CLAIM_SUBJECTS =
+  /\b(?:anyone|anybody|someone|somebody|who|whoever|nobody|no[- ]?one|not)\b/;
+
+/** True when a single comment body claims the issue. */
+export function commentClaimsIssue(body: string): boolean {
+  const clauses = body.toLowerCase().split(/(?<=[.!?])|\n+/);
+  for (const clause of clauses) {
+    if (PERMISSION_CLAIM_PATTERN.test(clause)) return true;
+    if (clause.trimEnd().endsWith("?")) continue;
+    if (FIRST_PERSON_CLAIM_PATTERNS.some((p) => p.test(clause))) return true;
+    if (NON_CLAIM_SUBJECTS.test(clause)) continue;
+    if (GENERIC_WORKING_PATTERNS.some((p) => p.test(clause))) return true;
+  }
+  return false;
+}
 
 /**
  * Check whether an open PR already exists for the given issue.
@@ -249,8 +295,7 @@ export async function checkNotClaimed(
     const recentComments = comments.slice(-100);
 
     for (const comment of recentComments) {
-      const body = (comment.body || "").toLowerCase();
-      if (CLAIM_PHRASES.some((phrase) => body.includes(phrase))) {
+      if (commentClaimsIssue(comment.body || "")) {
         return { passed: false };
       }
     }


### PR DESCRIPTION
## Summary
Replaces the CLAIM_PHRASES substring scan with an exported `commentClaimsIssue` clause matcher:
- question clauses never claim, except permission requests ("can/may/could I work on/take <issue object>"), which are asks to take the issue
- indefinite/negated subjects (anyone, someone, nobody, not, ...) guard the generic "working on ..." patterns; explicit first-person claims bypass the guard ("If not, I'll take this")
- third-person declaratives still claim ("Bob is working on it")
- issue objects use a determiner heuristic (this/it/that/the X/#123/issue N); "a X" forms ("a repro") and bare numbers ("take 5 minutes") stay non-claims

## Test plan
- [x] 34 new table cases across claims / non-claims / cross-clause behavior; existing checkNotClaimed contract preserved
- [x] 3 review passes converged (pass 2 widened over-narrow objects, pass 3 fixed the bare-number idiom collision)
- [x] lint, format:check, typecheck, 787 core + 22 mcp green

Closes #126