### PR TITLE
fix(core): truthful strategiesUsed and case-insensitive repo config matching

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -821,6 +821,24 @@ describe("IssueDiscovery", () => {
       );
     });
 
+    it("filterIssues matches excludeRepos case-insensitively (#130)", async () => {
+      const items: GitHubSearchItem[] = [
+        {
+          html_url: "https://github.com/excluded/repo/issues/1",
+          repository_url: "https://api.github.com/repos/excluded/repo",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ];
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue(items);
+
+      // User typed the slug with different casing than the API returns
+      const discovery = makeDiscovery({}, { excludeRepos: ["Excluded/Repo"] });
+
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(
+        "No issue candidates found",
+      );
+    });
+
     it("filterIssues excludes repos in aiPolicyBlocklist", async () => {
       // Provide a candidate so the search doesn't throw
       const c = makeCandidate("allowed/repo", "merged_pr");
@@ -888,10 +906,35 @@ describe("IssueDiscovery", () => {
         maxResults: 20,
       });
 
-      // broad should still be listed in strategiesUsed (strategy was enabled)
-      // but searchWithChunkedLabels should NOT have been called (Phase 2 body skipped)
-      expect(strategiesUsed).toContain("broad");
+      // Phase 2 body short-circuited by the skip threshold: no broad query
+      // ran, so "broad" must NOT be reported as used (#130)
+      expect(strategiesUsed).not.toContain("broad");
       expect(mockSearchAcrossLanguagesAndLabels).not.toHaveBeenCalled();
+    });
+
+    it("does not report starred when every starred repo was already covered by Phase 0", async () => {
+      const candidates = [makeCandidate("org/repo-0", "merged_pr")];
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates,
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/repo-0"]),
+        // Starred list is a subset of Phase 0 repos, so Phase 1 has nothing
+        // left to query
+        getStarredRepos: vi.fn(() => ["org/repo-0"]),
+      });
+
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 5,
+        strategies: ["merged", "starred"],
+      });
+
+      expect(strategiesUsed).toContain("merged");
+      expect(strategiesUsed).not.toContain("starred");
     });
 
     it("applies broadPhaseDelayMs before Phase 2 when previous phases found some results", async () => {

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -90,13 +90,16 @@ function buildIssueFilter(
     return items.filter((item) => {
       const repoFullName = extractRepoFromUrl(item.repository_url);
       if (!repoFullName) return false;
-      if (config.excludedRepos.has(repoFullName)) return false;
+      // Repo-name sets are lowercased at construction; compare lowercased so
+      // user-typed casing (Microsoft/TypeScript) still matches API casing.
+      const repoLower = repoFullName.toLowerCase();
+      if (config.excludedRepos.has(repoLower)) return false;
       if (config.excludeOrgs.size > 0) {
-        const orgName = repoFullName.split("/")[0]?.toLowerCase();
+        const orgName = repoLower.split("/")[0];
         if (orgName && config.excludeOrgs.has(orgName)) return false;
       }
-      if (config.aiBlocklisted.has(repoFullName)) return false;
-      if (config.lowScoringRepos.has(repoFullName)) return false;
+      if (config.aiBlocklisted.has(repoLower)) return false;
+      if (config.lowScoringRepos.has(repoLower)) return false;
       if (config.skippedUrls.has(item.html_url)) return false;
       const updatedAt = new Date(item.updated_at);
       const ageDays = daysBetween(updatedAt, config.now);
@@ -588,7 +591,9 @@ export class IssueDiscovery {
     const starredRepos = this.getStarredRepos();
     const starredRepoSet = new Set(starredRepos);
     const lowScoringRepos = new Set(
-      this.deriveLowScoringRepos(config.minRepoScoreThreshold),
+      this.deriveLowScoringRepos(config.minRepoScoreThreshold).map((r) =>
+        r.toLowerCase(),
+      ),
     );
 
     // Build query parts
@@ -597,8 +602,10 @@ export class IssueDiscovery {
       ? ""
       : languages.map((l) => `language:${l}`).join(" ");
 
-    // Build reusable filter
-    const aiBlocklisted = new Set(config.aiPolicyBlocklist);
+    // Build reusable filter (repo-name sets lowercased; see buildIssueFilter)
+    const aiBlocklisted = new Set(
+      config.aiPolicyBlocklist.map((r) => r.toLowerCase()),
+    );
     if (aiBlocklisted.size > 0) {
       debug(
         MODULE,
@@ -606,7 +613,7 @@ export class IssueDiscovery {
       );
     }
     const filterIssues = buildIssueFilter({
-      excludedRepos: new Set(config.excludeRepos),
+      excludedRepos: new Set(config.excludeRepos.map((r) => r.toLowerCase())),
       excludeOrgs: new Set(
         (config.excludeOrgs ?? []).map((o) => o.toLowerCase()),
       ),
@@ -677,9 +684,10 @@ export class IssueDiscovery {
           allCandidates.push(...result.candidates);
           phaseErrors["1"] = result.error;
           if (result.rateLimitHit) rateLimitHitDuringSearch = true;
+          // Recorded only when the phase actually queried (#130)
+          strategiesUsed.push("starred");
         }
       }
-      strategiesUsed.push("starred");
     }
 
     // Phase 2: General search (with rate limit mitigation)
@@ -748,8 +756,10 @@ export class IssueDiscovery {
         allCandidates.push(...result.candidates);
         phaseErrors["2"] = result.error;
         if (result.rateLimitHit) rateLimitHitDuringSearch = true;
+        // Recorded only when the phase actually queried, not when the
+        // skip-threshold branch short-circuited it (#130)
+        strategiesUsed.push("broad");
       }
-      strategiesUsed.push("broad");
     }
 
     // Phase 3: Actively maintained repos

--- a/packages/core/src/core/personalization.test.ts
+++ b/packages/core/src/core/personalization.test.ts
@@ -119,6 +119,17 @@ describe("annotateBoost", () => {
     ]);
   });
 
+  it("matches repo slug case-insensitively (#130)", () => {
+    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
+
+    annotateBoost(candidates, undefined, ["Vercel/Next.js"]);
+
+    expect(candidates[0].boostScore).toBe(REPO_BOOST);
+    expect(candidates[0].boostReasons).toEqual([
+      "repo affinity: vercel/next.js",
+    ]);
+  });
+
   it("stacks repo and language boosts when both match", () => {
     const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
 

--- a/packages/core/src/core/personalization.ts
+++ b/packages/core/src/core/personalization.ts
@@ -51,7 +51,7 @@ export function annotateBoost(
     (preferLanguages ?? []).map((l) => l.trim().toLowerCase()).filter(Boolean),
   );
   const repoSet = new Set(
-    (preferRepos ?? []).map((r) => r.trim()).filter(Boolean),
+    (preferRepos ?? []).map((r) => r.trim().toLowerCase()).filter(Boolean),
   );
   if (langSet.size === 0 && repoSet.size === 0) return;
 
@@ -59,7 +59,7 @@ export function annotateBoost(
     let score = 0;
     const reasons: string[] = [];
 
-    if (repoSet.size > 0 && repoSet.has(c.issue.repo)) {
+    if (repoSet.size > 0 && repoSet.has(c.issue.repo.toLowerCase())) {
       score += REPO_BOOST;
       reasons.push(`repo affinity: ${c.issue.repo}`);
     }


### PR DESCRIPTION
## Summary
- `strategiesUsed` now records only phases that actually executed queries: the starred push moved inside the has-repos-to-search branch, the broad push inside the not-skipped branch (merged/maintained unchanged: their gates already guarantee execution). Verified pass-through-only consumers, so the semantic change is safe.
- `excludeRepos`, `aiPolicyBlocklist`, `lowScoringRepos`, and `preferRepos` now match case-insensitively (sets lowercased at construction, lowercased slug at comparison), consistent with the existing `excludeOrgs` normalization. API-derived dedup sets (phase0/starred) stay untouched since both sides share GitHub casing.

## Test plan
- [x] Inverted the old skip-threshold expectation (broad no longer reported when short-circuited), new starred-all-deduped test, case-insensitive excludeRepos filter test, case-insensitive preferRepos boost test
- [x] lint, format:check, typecheck, 790 core + 22 mcp green

Closes #130