### PR TITLE
fix(core): parse GitHub URLs with the URL class instead of unanchored regexes

### DIFF
--- a/packages/core/src/core/utils.test.ts
+++ b/packages/core/src/core/utils.test.ts
@@ -57,6 +57,34 @@ describe("extractRepoFromUrl", () => {
   it("returns null for malformed URL", () => {
     expect(extractRepoFromUrl("not-a-url")).toBeNull();
   });
+
+  it("rejects hosts that merely contain github.com", () => {
+    expect(extractRepoFromUrl("https://notgithub.com/owner/repo")).toBeNull();
+    expect(
+      extractRepoFromUrl("https://github.com.evil.com/owner/repo"),
+    ).toBeNull();
+    expect(
+      extractRepoFromUrl("https://evil.com/github.com/owner/repo"),
+    ).toBeNull();
+  });
+
+  it("does not leak query or fragment into the repo segment", () => {
+    expect(extractRepoFromUrl("https://github.com/owner/repo?tab=readme")).toBe(
+      "owner/repo",
+    );
+    expect(extractRepoFromUrl("https://github.com/owner/repo#readme")).toBe(
+      "owner/repo",
+    );
+    expect(
+      extractRepoFromUrl("https://api.github.com/repos/owner/repo?page=2"),
+    ).toBe("owner/repo");
+  });
+
+  it("accepts the www form", () => {
+    expect(extractRepoFromUrl("https://www.github.com/owner/repo")).toBe(
+      "owner/repo",
+    );
+  });
 });
 
 // ── parseGitHubUrl ──
@@ -93,6 +121,39 @@ describe("parseGitHubUrl", () => {
   it("returns null for invalid owner characters", () => {
     expect(
       parseGitHubUrl("https://github.com/bad owner/repo/issues/1"),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["http://github.com/owner/repo/issues/7"],
+    ["https://www.github.com/owner/repo/issues/7"],
+    ["github.com/owner/repo/issues/7"],
+    ["www.github.com/owner/repo/issues/7"],
+    ["https://github.com/owner/repo/issues/7/"],
+  ])("accepts pasteable variant %s", (url) => {
+    expect(parseGitHubUrl(url)).toEqual({
+      owner: "owner",
+      repo: "repo",
+      number: 7,
+      type: "issues",
+    });
+  });
+
+  it("rejects a malformed number segment instead of half-parsing it", () => {
+    expect(
+      parseGitHubUrl("https://github.com/owner/repo/pull/123abc"),
+    ).toBeNull();
+  });
+
+  it("rejects extra path segments after the number", () => {
+    expect(
+      parseGitHubUrl("https://github.com/owner/repo/pull/123/files"),
+    ).toBeNull();
+  });
+
+  it("rejects spoofed hosts", () => {
+    expect(
+      parseGitHubUrl("https://github.com.evil.com/owner/repo/issues/1"),
     ).toBeNull();
   });
 });

--- a/packages/core/src/core/utils.ts
+++ b/packages/core/src/core/utils.ts
@@ -43,13 +43,30 @@ export function getCacheDir(): string {
  * - https://api.github.com/repos/owner/repo/...
  */
 export function extractRepoFromUrl(url: string): string | null {
+  // Real URL parsing: the previous regexes were unanchored (any host
+  // containing "github.com" matched) and leaked query/fragment text into
+  // the repo segment ("repo?tab=readme").
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  const segments = parsed.pathname.split("/").filter(Boolean);
+
   // API URLs: https://api.github.com/repos/owner/repo[/...]
-  const apiMatch = url.match(/api\.github\.com\/repos\/([^/]+\/[^/]+)/);
-  if (apiMatch) return apiMatch[1];
+  if (host === "api.github.com") {
+    if (segments[0] === "repos" && segments.length >= 3) {
+      return `${segments[1]}/${segments[2]}`;
+    }
+    return null;
+  }
 
   // Web URLs: https://github.com/owner/repo[/...]
-  const webMatch = url.match(/github\.com\/([^/]+\/[^/]+)/);
-  if (webMatch) return webMatch[1];
+  if (host === "github.com" && segments.length >= 2) {
+    return `${segments[0]}/${segments[1]}`;
+  }
 
   return null;
 }
@@ -69,25 +86,32 @@ function isValidOwnerRepo(owner: string, repo: string): boolean {
 }
 
 export function parseGitHubUrl(url: string): ParsedGitHubUrl | null {
-  if (!url.startsWith("https://github.com/")) return null;
-
-  const prMatch = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
-  if (prMatch) {
-    const owner = prMatch[1];
-    const repo = prMatch[2];
-    if (!isValidOwnerRepo(owner, repo)) return null;
-    return { owner, repo, number: parseInt(prMatch[3], 10), type: "pull" };
+  // Accept pasteable variants: http://, www., and bare github.com/... forms
+  // normalize to a parseable URL. Strict canonical-form validation for
+  // command input lives in commands/validation.ts; this parser is lenient.
+  const normalized = /^(?:www\.)?github\.com\//i.test(url)
+    ? `https://${url}`
+    : url;
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    return null;
   }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  if (host !== "github.com") return null;
 
-  const issueMatch = url.match(/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
-  if (issueMatch) {
-    const owner = issueMatch[1];
-    const repo = issueMatch[2];
-    if (!isValidOwnerRepo(owner, repo)) return null;
-    return { owner, repo, number: parseInt(issueMatch[3], 10), type: "issues" };
-  }
-
-  return null;
+  // Exactly owner/repo/(pull|issues)/<digits>; trailing slash tolerated via
+  // filter(Boolean), query/fragment excluded by pathname. A malformed number
+  // segment ("123abc") no longer half-parses to 123.
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length !== 4) return null;
+  const [owner, repo, type, num] = segments;
+  if (type !== "pull" && type !== "issues") return null;
+  if (!isValidOwnerRepo(owner, repo)) return null;
+  if (!/^\d+$/.test(num)) return null;
+  return { owner, repo, number: parseInt(num, 10), type };
 }
 
 export function daysBetween(from: Date, to: Date = new Date()): number {


### PR DESCRIPTION
## Summary
- `extractRepoFromUrl`: anchored hostname matching (github.com / api.github.com, single leading www stripped), no query/fragment leakage into repo slugs
- `parseGitHubUrl`: accepts pasteable variants (http, www, bare github.com, trailing slash), rejects malformed numbers ("123abc") and extra path segments, keeps charset validation; documented as the lenient parser vs the strict canonical validation in commands/validation.ts
- Reviewer traced all production callers: state only ever stores API `html_url` values, so no scheme-less inputs exist in real state; percent-encoding behavior unchanged; spoofed-host bypasses verified closed

## Test plan
- [x] 15 new tests: spoofed hosts, query/fragment, www, pasteable variant matrix, malformed number, extra segments
- [x] lint, format:check, typecheck, 801 core + 22 mcp green

Closes #135