### PR TITLE
fix(core): detect truncated gist scans and warn before creating a possible duplicate

### DIFF
--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -12,11 +12,12 @@ vi.mock("./utils.js", () => ({
 }));
 
 vi.mock("./logger.js", () => ({
-  debug: () => {},
-  warn: () => {},
+  debug: vi.fn(),
+  warn: vi.fn(),
 }));
 
 const { GistStateStore, mergeStates } = await import("./gist-state-store.js");
+const logger = await import("./logger.js");
 
 function makeState(overrides: Partial<ScoutState> = {}): ScoutState {
   return ScoutStateSchema.parse({ version: 1, ...overrides });
@@ -132,33 +133,47 @@ describe("GistStateStore", () => {
       expect(octokit.gists.list).toHaveBeenCalled();
     });
 
-    it("paginates gist search up to 5 pages", async () => {
+    it("stops searching after a short page (account fully scanned)", async () => {
       const octokit = makeOctokit({
-        list: vi
-          .fn()
-          .mockResolvedValueOnce({
-            data: [{ id: "g1", description: "other1" }],
-          })
-          .mockResolvedValueOnce({
-            data: [{ id: "g2", description: "other2" }],
-          })
-          .mockResolvedValueOnce({
-            data: [{ id: "g3", description: "other3" }],
-          })
-          .mockResolvedValueOnce({
-            data: [{ id: "g4", description: "other4" }],
-          })
-          .mockResolvedValueOnce({
-            data: [{ id: "g5", description: "other5" }],
-          }),
+        list: vi.fn().mockResolvedValue({
+          data: [{ id: "g1", description: "other1" }],
+        }),
         create: vi.fn().mockResolvedValue({ data: { id: "new-id" } }),
       });
 
       const store = new GistStateStore(octokit);
       const result = await store.bootstrap();
 
-      expect(octokit.gists.list).toHaveBeenCalledTimes(5);
+      // One short page proves every gist was seen; no duplicate-risk warning
+      expect(octokit.gists.list).toHaveBeenCalledTimes(1);
       expect(result.created).toBe(true);
+      expect(vi.mocked(logger.warn)).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining("the account has more"),
+      );
+    });
+
+    it("scans 10 full pages, then warns about duplicate risk before creating", async () => {
+      const fullPage = {
+        data: Array.from({ length: 100 }, (_, i) => ({
+          id: `g${i}`,
+          description: "other",
+        })),
+      };
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue(fullPage),
+        create: vi.fn().mockResolvedValue({ data: { id: "new-id" } }),
+      });
+
+      const store = new GistStateStore(octokit);
+      const result = await store.bootstrap();
+
+      expect(octokit.gists.list).toHaveBeenCalledTimes(10);
+      expect(result.created).toBe(true);
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining("the account has more"),
+      );
     });
 
     it("writes gist ID to local cache on bootstrap", async () => {

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -24,7 +24,7 @@ const GIST_DESCRIPTION = "oss-scout-state";
 const GIST_FILENAME = "state.json";
 const GIST_ID_FILE = "gist-id";
 const CACHE_FILE = "state-cache.json";
-const SEARCH_MAX_PAGES = 5;
+const SEARCH_MAX_PAGES = 10;
 
 /** Minimal Octokit interface for gist operations — keeps the class testable. */
 export interface GistOctokitLike {
@@ -219,23 +219,32 @@ export class GistStateStore {
     }
 
     // 2. Search user's gists
-    const foundId = await this.searchForGist();
-    if (foundId) {
-      debug(MODULE, `Found gist via search: ${foundId}`);
-      this.saveGistId(foundId);
-      this.gistId = foundId;
-      const state = await this.fetchGistState(foundId);
+    const search = await this.searchForGist();
+    if (search.id) {
+      debug(MODULE, `Found gist via search: ${search.id}`);
+      this.saveGistId(search.id);
+      this.gistId = search.id;
+      const state = await this.fetchGistState(search.id);
       if (state) {
         this.writeCache(state);
-        return { gistId: foundId, state, created: false };
+        return { gistId: search.id, state, created: false };
       }
       // Gist exists but content failed validation — fall back to cache
       // to avoid overwriting the user's data by creating a new gist.
       warn(
         MODULE,
-        `Found existing gist ${foundId} but content failed validation. Using local cache to avoid data loss.`,
+        `Found existing gist ${search.id} but content failed validation. Using local cache to avoid data loss.`,
       );
       return this.bootstrapFromCache("unknown");
+    }
+    if (!search.exhaustive) {
+      // The account has more gists than we scanned; an existing state gist
+      // may sit beyond the scan window, and creating a new one would fork
+      // state across machines.
+      warn(
+        MODULE,
+        `Scanned the first ${SEARCH_MAX_PAGES * 100} gists without finding an oss-scout state gist, but the account has more. Creating a new state gist; if one already exists, copy its id into the gist-id file in the oss-scout data directory to avoid a duplicate.`,
+      );
     }
 
     // 3. Create new gist
@@ -290,19 +299,30 @@ export class GistStateStore {
     }
   }
 
-  private async searchForGist(): Promise<string | null> {
+  /**
+   * Scan the user's gists for the state gist. `exhaustive: false` means the
+   * page cap was hit while pages were still full, so the account may hold
+   * the state gist beyond the scan window.
+   */
+  private async searchForGist(): Promise<{
+    id: string | null;
+    exhaustive: boolean;
+  }> {
     for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
       const { data: gists } = await this.octokit.gists.list({
         per_page: 100,
         page,
       });
 
-      if (gists.length === 0) break;
+      if (gists.length === 0) return { id: null, exhaustive: true };
 
       const match = gists.find((g) => g.description === GIST_DESCRIPTION);
-      if (match) return match.id;
+      if (match) return { id: match.id, exhaustive: true };
+
+      // A short page means we have seen every gist
+      if (gists.length < 100) return { id: null, exhaustive: true };
     }
-    return null;
+    return { id: null, exhaustive: false };
   }
 
   private async createGist(state: ScoutState): Promise<string> {


### PR DESCRIPTION
## Summary
- `searchForGist` returns `{id, exhaustive}`: a short page proves the whole account was scanned; hitting the page cap on full pages means truncation
- Page cap 5 → 10 (zero extra cost for typical accounts: short pages now short-circuit, so most accounts pay a single list call)
- When the scan was truncated and no state gist was found, bootstrap warns about duplicate-gist risk and names the real remedy (paste the existing gist id into the `gist-id` file in the data directory, which `readCachedGistId` picks up before any search on the next run)

## Test plan
- [x] New tests: short-page early stop (1 list call, no warning) and 10-full-pages truncation (10 calls + duplicate-risk warning); logger test mock upgraded to vi.fn()s
- [x] lint, format:check, typecheck, 802 core + 22 mcp green

Closes #141