### PR TITLE
fix(core): fetch only the newest comment pages in claim detection

### DIFF
--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -382,41 +382,87 @@ describe("checkNotClaimed", () => {
     expect(result.passed).toBe(true);
   });
 
-  it('returns passed:false when a comment says "i\'m working on this"', async () => {
-    const octokit = makeMockOctokit({
-      paginate: vi
-        .fn()
-        .mockResolvedValue([{ body: "I'm working on this already" }]),
+  function makeCommentsOctokit(
+    listComments: ReturnType<typeof vi.fn>,
+  ): Octokit {
+    return makeMockOctokit({
+      issues: {
+        listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
+        listComments,
+      },
     });
+  }
+
+  it('returns passed:false when a comment says "i\'m working on this"', async () => {
+    const octokit = makeCommentsOctokit(
+      vi.fn().mockResolvedValue({
+        data: [{ body: "I'm working on this already" }],
+      }),
+    );
     const result = await checkNotClaimed(octokit, "owner", "repo", 1, 3);
     expect(result.passed).toBe(false);
   });
 
   it('returns passed:false when a comment says "i\'ll take this"', async () => {
-    const octokit = makeMockOctokit({
-      paginate: vi.fn().mockResolvedValue([{ body: "I'll take this issue" }]),
-    });
+    const octokit = makeCommentsOctokit(
+      vi.fn().mockResolvedValue({ data: [{ body: "I'll take this issue" }] }),
+    );
     const result = await checkNotClaimed(octokit, "owner", "repo", 1, 2);
     expect(result.passed).toBe(false);
   });
 
   it("returns passed:true when comments are normal discussion", async () => {
-    const octokit = makeMockOctokit({
-      paginate: vi
-        .fn()
-        .mockResolvedValue([
+    const octokit = makeCommentsOctokit(
+      vi.fn().mockResolvedValue({
+        data: [
           { body: "This would be a nice feature." },
           { body: "I agree, we should add this." },
-        ]),
-    });
+        ],
+      }),
+    );
     const result = await checkNotClaimed(octokit, "owner", "repo", 1, 2);
     expect(result.passed).toBe(true);
   });
 
+  it("fetches only the first page for small comment counts", async () => {
+    const listComments = vi.fn().mockResolvedValue({ data: [] });
+    const octokit = makeCommentsOctokit(listComments);
+    await checkNotClaimed(octokit, "owner", "repo", 1, 50);
+    expect(listComments).toHaveBeenCalledTimes(1);
+    expect(listComments).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, per_page: 100 }),
+    );
+  });
+
+  it("fetches only the two newest pages for large comment counts", async () => {
+    const listComments = vi.fn().mockResolvedValue({ data: [] });
+    const octokit = makeCommentsOctokit(listComments);
+    await checkNotClaimed(octokit, "owner", "repo", 1, 250);
+    expect(listComments).toHaveBeenCalledTimes(2);
+    expect(listComments).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2 }),
+    );
+    expect(listComments).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3 }),
+    );
+  });
+
+  it("detects a claim on the second-to-last page", async () => {
+    const listComments = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ body: "I'm working on this already" }],
+      })
+      .mockResolvedValueOnce({ data: [{ body: "Any update?" }] });
+    const octokit = makeCommentsOctokit(listComments);
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 150);
+    expect(result.passed).toBe(false);
+  });
+
   it("returns passed:true and inconclusive:true on API error", async () => {
-    const octokit = makeMockOctokit({
-      paginate: vi.fn().mockRejectedValue(new Error("Network error")),
-    });
+    const octokit = makeCommentsOctokit(
+      vi.fn().mockRejectedValue(new Error("Network error")),
+    );
     const result = await checkNotClaimed(octokit, "owner", "repo", 1, 5);
     expect(result.passed).toBe(true);
     expect(result.inconclusive).toBe(true);
@@ -424,39 +470,37 @@ describe("checkNotClaimed", () => {
   });
 
   it("propagates 401 auth errors instead of swallowing", async () => {
-    const octokit = makeMockOctokit({
-      paginate: vi.fn().mockRejectedValue(httpError(401, "Unauthorized")),
-    });
+    const octokit = makeCommentsOctokit(
+      vi.fn().mockRejectedValue(httpError(401, "Unauthorized")),
+    );
     await expect(
       checkNotClaimed(octokit, "owner", "repo", 1, 3),
     ).rejects.toThrow("Unauthorized");
   });
 
   it("propagates 429 rate-limit errors instead of swallowing", async () => {
-    const octokit = makeMockOctokit({
-      paginate: vi
-        .fn()
-        .mockRejectedValue(httpError(429, "API rate limit exceeded")),
-    });
+    const octokit = makeCommentsOctokit(
+      vi.fn().mockRejectedValue(httpError(429, "API rate limit exceeded")),
+    );
     await expect(
       checkNotClaimed(octokit, "owner", "repo", 1, 3),
     ).rejects.toThrow("rate limit");
   });
 
   it("returns passed:true when commentCount is zero (skips API)", async () => {
-    const paginateFn = vi.fn();
-    const octokit = makeMockOctokit({ paginate: paginateFn });
+    const listComments = vi.fn();
+    const octokit = makeCommentsOctokit(listComments);
     const result = await checkNotClaimed(octokit, "owner", "repo", 1, 0);
     expect(result.passed).toBe(true);
-    expect(paginateFn).not.toHaveBeenCalled();
+    expect(listComments).not.toHaveBeenCalled();
   });
 
   it("performs case insensitive matching on claim phrases", async () => {
-    const octokit = makeMockOctokit({
-      paginate: vi
+    const octokit = makeCommentsOctokit(
+      vi
         .fn()
-        .mockResolvedValue([{ body: "WORKING ON IT right now" }]),
-    });
+        .mockResolvedValue({ data: [{ body: "WORKING ON IT right now" }] }),
+    );
     const result = await checkNotClaimed(octokit, "owner", "repo", 1, 1);
     expect(result.passed).toBe(false);
   });

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -279,20 +279,26 @@ export async function checkNotClaimed(
   if (commentCount === 0) return { passed: true };
 
   try {
-    // Paginate through all comments
-    const comments = await octokit.paginate(
-      octokit.issues.listComments,
-      {
+    // Fetch only the newest comments. Walking every page cost a
+    // 2,000-comment issue 20 list calls per vet, then discarded all but the
+    // tail anyway. Claims live in recent activity, so fetch the last page
+    // (plus its predecessor so a short last page still yields ~100+
+    // comments): at most 2 calls.
+    const PER_PAGE = 100;
+    const lastPage = Math.max(1, Math.ceil(commentCount / PER_PAGE));
+    const pagesToFetch = lastPage > 1 ? [lastPage - 1, lastPage] : [1];
+
+    const recentComments: Array<{ body?: string | null }> = [];
+    for (const page of pagesToFetch) {
+      const response = await octokit.issues.listComments({
         owner,
         repo,
         issue_number: issueNumber,
-        per_page: 100,
-      },
-      (response) => response.data,
-    );
-
-    // Limit to last 100 comments to avoid excessive processing
-    const recentComments = comments.slice(-100);
+        per_page: PER_PAGE,
+        page,
+      });
+      recentComments.push(...response.data);
+    }
 
     for (const comment of recentComments) {
       if (commentClaimsIssue(comment.body || "")) {


### PR DESCRIPTION
## Summary
`checkNotClaimed` now computes `lastPage = ceil(commentCount/100)` from the fresh `issues.get` count (fetched milliseconds earlier in the same vet batch, so no staleness window) and fetches at most `[lastPage-1, lastPage]`. Worst case drops from N pages to 2; the page-1-only path covers counts up to 100. Everything fetched is scanned (max 200 comments), which strictly widens claim detection vs the old slice(-100).

## Test plan
- [x] Page-math boundaries verified in review (100 → one call; 101/200 → pages 1+2; 250 → pages 2+3)
- [x] 3 new tests: single-page small counts, two newest pages for 250, claim detected on second-to-last page; mocks migrated from octokit.paginate to direct listComments
- [x] lint, format:check, typecheck, 805 core + 22 mcp green

Closes #127