### PR TITLE
fix(core): never cache vetting results built on inconclusive checks

### DIFF
--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -537,7 +537,7 @@ describe("checkUserMergedPRsInRepo", () => {
     expect(result).toBe(0);
   });
 
-  it("returns 0 on API error (non-fatal, not cached)", async () => {
+  it("returns null on API error (non-fatal, not cached, distinguishable from a real zero)", async () => {
     const octokit = makeMockOctokit({
       search: {
         issuesAndPullRequests: vi
@@ -546,7 +546,7 @@ describe("checkUserMergedPRsInRepo", () => {
       },
     });
     const result = await checkUserMergedPRsInRepo(octokit, "owner", "repo");
-    expect(result).toBe(0);
+    expect(result).toBeNull();
   });
 
   it("propagates 401 auth errors instead of returning 0", async () => {

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -224,7 +224,7 @@ export async function checkUserMergedPRsInRepo(
   octokit: Octokit,
   owner: string,
   repo: string,
-): Promise<number> {
+): Promise<number | null> {
   const cache = getHttpCache();
   const cacheKey = `merged-prs:${owner}/${repo}`;
 
@@ -259,9 +259,11 @@ export async function checkUserMergedPRsInRepo(
     const errMsg = errorMessage(error);
     warn(
       MODULE,
-      `Could not check merged PRs in ${owner}/${repo}: ${errMsg}. Defaulting to 0.`,
+      `Could not check merged PRs in ${owner}/${repo}: ${errMsg}. Treating as unknown.`,
     );
-    return 0; // Not cached — next call will retry
+    // null (not 0) so callers can tell a transient failure from a real zero
+    // and avoid caching verdicts built on it. Not cached — next call retries.
+    return null;
   }
 }
 

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -201,6 +201,64 @@ describe("IssueVetter", () => {
   });
 
   describe("vetIssue", () => {
+    function installCacheSpy(): ReturnType<typeof vi.fn> {
+      const cacheSet = vi.fn();
+      vi.mocked(getHttpCache).mockReturnValue({
+        getIfFresh: vi.fn(() => null),
+        set: cacheSet,
+      } as unknown as ReturnType<typeof getHttpCache>);
+      return cacheSet;
+    }
+
+    it("caches the result when all checks are conclusive", async () => {
+      const cacheSet = installCacheSpy();
+      const vetter = makeVetter();
+      await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(cacheSet).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not cache a result built on an inconclusive claim check", async () => {
+      const cacheSet = installCacheSpy();
+      vi.mocked(checkNotClaimed).mockResolvedValueOnce({
+        passed: true,
+        inconclusive: true,
+        reason: "Network error",
+      });
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      // The degraded verdict must not be pinned for the cache TTL
+      expect(result.recommendation).toBe("needs_review");
+      expect(cacheSet).not.toHaveBeenCalled();
+    });
+
+    it("does not cache when the merged-PR count check transiently failed", async () => {
+      const cacheSet = installCacheSpy();
+      vi.mocked(checkUserMergedPRsInRepo).mockResolvedValueOnce(null);
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      // Scored as zero merged PRs, but the verdict must not be pinned
+      expect(result.recommendation).toBe("needs_review");
+      expect(cacheSet).not.toHaveBeenCalled();
+    });
+
+    it("does not cache a result when the project health check failed", async () => {
+      const cacheSet = installCacheSpy();
+      vi.mocked(checkProjectHealth).mockResolvedValueOnce({
+        repo: "owner/repo",
+        lastCommitAt: null,
+        daysSinceLastCommit: null,
+        openIssuesCount: 0,
+        avgIssueResponseDays: null,
+        ciStatus: "unknown",
+        isActive: false,
+        checkFailed: true,
+        failureReason: "Server error",
+      });
+      const vetter = makeVetter();
+      await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(cacheSet).not.toHaveBeenCalled();
+    });
+
     it("recommends approve when all checks pass", async () => {
       const vetter = makeVetter();
       const result = await vetter.vetIssue(VALID_ISSUE_URL);

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -279,8 +279,14 @@ export class IssueVetter {
       reasonsToApprove.push("Has contribution guidelines");
 
     // Determine effective merged PR count: prefer local state (authoritative if present),
-    // fall back to live GitHub API count to detect contributions made before using oss-scout
-    const effectiveMergedCount = hasMergedPRsInRepo ? 1 : userMergedPRCount;
+    // fall back to live GitHub API count to detect contributions made before
+    // using oss-scout. null means the live check transiently failed: score as
+    // 0 but treat the result as inconclusive so it is not cached.
+    const mergedCountInconclusive =
+      !hasMergedPRsInRepo && userMergedPRCount === null;
+    const effectiveMergedCount = hasMergedPRsInRepo
+      ? 1
+      : (userMergedPRCount ?? 0);
     if (effectiveMergedCount > 0) {
       reasonsToApprove.push(
         `Trusted project (${effectiveMergedCount} PR${effectiveMergedCount > 1 ? "s" : ""} merged)`,
@@ -325,7 +331,8 @@ export class IssueVetter {
     const hasInconclusiveChecks =
       projectHealth.checkFailed ||
       existingPRCheck.inconclusive ||
-      claimCheck.inconclusive;
+      claimCheck.inconclusive ||
+      mergedCountInconclusive;
     if (recommendation === "approve" && hasInconclusiveChecks) {
       recommendation = "needs_review";
       vettingResult.notes.push(
@@ -400,8 +407,14 @@ export class IssueVetter {
       searchPriority,
     };
 
-    // Cache the vetting result to avoid redundant API calls on repeated searches
-    cache.set(cacheKey, "", result);
+    // Cache the vetting result to avoid redundant API calls on repeated
+    // searches — but never cache results built on inconclusive/failed checks
+    // (e.g. a transient 5xx): that would pin a degraded verdict for the whole
+    // TTL. Next vet retries instead. Mirrors the error-path rule in
+    // issue-eligibility's checkUserMergedPRsInRepo.
+    if (!hasInconclusiveChecks) {
+      cache.set(cacheKey, "", result);
+    }
 
     return result;
   }


### PR DESCRIPTION
## Summary
- `vetIssue`'s cache write is guarded by `hasInconclusiveChecks` (the flag already powering the approve → needs_review downgrade): transient 5xx-degraded verdicts are no longer pinned for the TTL; the next vet retries
- `checkUserMergedPRsInRepo` returns `number | null` (null = transient failure, distinguishable from a real zero; internal-only function, not in public exports); `vetIssue` scores null as 0, downgrades the recommendation, and blocks the cache write
- Thundering-herd risk reviewed and bounded: the inner Search call is budget-gated, sibling caches (anti-LLM 1h, guidelines 1h) still apply, vetting concurrency capped at 3

## Test plan
- [x] 4 new tests: conclusive → cached once; inconclusive claim check, failed health check, transient merged-count → not cached (+ recommendation downgraded); eligibility error-path test updated to expect null
- [x] 2 review passes converged (pass 1 caught the merged-count gap)
- [x] lint, format:check, typecheck, 809 core + 22 mcp green

Closes #122