### PR TITLE
fix(core): score the real closed-without-merge count in live vetting

### DIFF
--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -259,6 +259,26 @@ describe("IssueVetter", () => {
       expect(cacheSet).not.toHaveBeenCalled();
     });
 
+    it("passes the stored closed-without-merge count into scoring (#125)", async () => {
+      installCacheSpy();
+      const vetter = makeVetter({
+        getClosedWithoutMergeCount: vi.fn(() => 2),
+      });
+      await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(vi.mocked(calculateViabilityScore)).toHaveBeenCalledWith(
+        expect.objectContaining({ closedWithoutMergeCount: 2 }),
+      );
+    });
+
+    it("defaults the closed-without-merge count to 0 when the reader lacks the method", async () => {
+      installCacheSpy();
+      const vetter = makeVetter();
+      await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(vi.mocked(calculateViabilityScore)).toHaveBeenCalledWith(
+        expect.objectContaining({ closedWithoutMergeCount: 0 }),
+      );
+    });
+
     it("recommends approve when all checks pass", async () => {
       const vetter = makeVetter();
       const result = await vetter.vetIssue(VALID_ISSUE_URL);

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -98,6 +98,11 @@ export interface ScoutStateReader {
    * vetIssue treats either of these as "skip the SLM call".
    */
   getSLMTriageConfig?(): { model: string; host: string };
+  /**
+   * Number of the user's PRs closed without merge in this repo (#125).
+   * Optional so existing implementations keep compiling; absent reads as 0.
+   */
+  getClosedWithoutMergeCount?(repo: string): number;
 }
 
 export class IssueVetter {
@@ -359,7 +364,8 @@ export class IssueVetter {
       clearRequirements,
       hasContributionGuidelines: !!contributionGuidelines,
       issueUpdatedAt: ghIssue.updated_at,
-      closedWithoutMergeCount: 0,
+      closedWithoutMergeCount:
+        this.stateReader.getClosedWithoutMergeCount?.(repoFullName) ?? 0,
       mergedPRCount: effectiveMergedCount,
       orgHasMergedPRs,
       repoQualityBonus,

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -218,6 +218,40 @@ describe("OssScout", () => {
     });
   });
 
+  describe("getClosedWithoutMergeCount", () => {
+    it("returns the tracked repo-score count when a score record exists", () => {
+      const scout = makeScout();
+      scout.recordClosedPR({
+        url: "https://github.com/owner/repo/pull/1",
+        title: "Rejected PR",
+        closedAt: "2025-01-01T00:00:00Z",
+        repo: "owner/repo",
+      });
+      scout.recordClosedPR({
+        url: "https://github.com/owner/repo/pull/2",
+        title: "Also rejected",
+        closedAt: "2025-02-01T00:00:00Z",
+        repo: "owner/repo",
+      });
+      expect(scout.getClosedWithoutMergeCount("owner/repo")).toBe(2);
+    });
+
+    it("falls back to counting closedPRs when no score record exists", () => {
+      const state = makeState({
+        closedPRs: [
+          {
+            url: "https://github.com/owner/repo/pull/9",
+            title: "Old rejection",
+            closedAt: "2024-01-01T00:00:00Z",
+          },
+        ],
+      });
+      const scout = new OssScout("fake-token", state);
+      expect(scout.getClosedWithoutMergeCount("owner/repo")).toBe(1);
+      expect(scout.getClosedWithoutMergeCount("other/repo")).toBe(0);
+    });
+  });
+
   describe("updatePreferences", () => {
     it("updates specific preferences", () => {
       const scout = makeScout();

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -444,6 +444,19 @@ export class OssScout implements ScoutStateReader {
   }
 
   /**
+   * Number of the user's PRs closed without merge in this repo (#125).
+   * Prefers the tracked repo score; falls back to counting closedPRs so the
+   * scoring penalty works even before a score record exists.
+   */
+  getClosedWithoutMergeCount(repo: string): number {
+    const score = this.state.repoScores[repo];
+    if (score) return score.closedWithoutMergeCount;
+    return (this.state.closedPRs ?? []).filter(
+      (p) => extractRepoFromUrl(p.url) === repo,
+    ).length;
+  }
+
+  /**
    * Optional SLM pre-triage config read from preferences (oss-autopilot#1122).
    * Empty `model` disables the call; the vetter treats it as a no-op.
    */


### PR DESCRIPTION
## Summary
- New optional `ScoutStateReader.getClosedWithoutMergeCount?(repo)`; `vetIssue` plumbs it into `calculateViabilityScore` with `?? 0`
- `OssScout` implements it: tracked `repoScores` record first (kept fresh by `updateRepoScoreFromPRs` on every record call), `closedPRs` count fallback for repos without a score record
- Penalty interaction verified in review: `-15` only fires when `mergedPRCount === 0`, matching the README "and nothing merged" wording; the repo-score reduction alongside it is pre-existing design

## Test plan
- [x] 4 new tests: plumbed count, method-absent default, record-first path, closedPRs fallback (+ unknown repo → 0)
- [x] lint, format:check, typecheck, 813 core + 22 mcp green

Closes #125