### PR TITLE
fix(core): dedup input URLs in parallel vetting

### DIFF
--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -505,6 +505,20 @@ describe("IssueVetter", () => {
   // ── vetIssuesParallel ─────────────────────────────────────────────
 
   describe("vetIssuesParallel", () => {
+    it("dedups duplicate input URLs instead of corrupting the pending map (#129)", async () => {
+      const vetter = makeVetter();
+      const vetSpy = vi.spyOn(vetter, "vetIssue");
+      const urls = [
+        "https://github.com/owner/repo/issues/1",
+        "https://github.com/owner/repo/issues/1",
+        "https://github.com/owner/repo/issues/2",
+      ];
+      const result = await vetter.vetIssuesParallel(urls, 10);
+      expect(vetSpy).toHaveBeenCalledTimes(2);
+      expect(result.candidates.length).toBe(2);
+      expect(result.allFailed).toBe(false);
+    });
+
     it("returns multiple candidates on success", async () => {
       const vetter = makeVetter();
       const urls = [

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -448,7 +448,13 @@ export class IssueVetter {
     // continuing to log per-issue warnings buries the actual problem.
     let firstAuthError: unknown = null;
 
-    for (const url of urls) {
+    // Dedup defensively: the pending map is keyed by URL, so a duplicate
+    // input would overwrite the in-flight entry and its finally-cleanup
+    // would deregister the second task, letting allSettled return while a
+    // vet still runs (#129). Callers dedup today, but nothing enforced it.
+    const uniqueUrls = [...new Set(urls)];
+
+    for (const url of uniqueUrls) {
       if (candidates.length >= maxResults) break;
       if (firstAuthError) break; // stop scheduling once auth has failed
       attemptedCount++;


### PR DESCRIPTION
## Summary
`vetIssuesParallel` now dedups its URL list at entry (`[...new Set(urls)]`, insertion order preserved). All counters (attemptedCount, failedVettingCount, the pending map) now count the same unique set, so `allFailed` stays consistent. Reviewer verified all three search-phase callers already dedup upstream and none relies on duplicates yielding duplicate candidates.

## Test plan
- [x] Regression test: duplicate input URL → vetIssue called once per unique URL, two candidates returned
- [x] lint, format:check, typecheck, 814 core + 22 mcp green

Closes #129