### PR TITLE
fix(core): classify abuse-detection 403s as rate-limit errors everywhere

### DIFF
--- a/packages/core/src/core/errors.test.ts
+++ b/packages/core/src/core/errors.test.ts
@@ -5,8 +5,13 @@ import {
   ValidationError,
   errorMessage,
   getHttpStatusCode,
+  isRateLimitError,
   resolveErrorCode,
 } from "./errors.js";
+
+function withStatus(message: string, status: number): Error {
+  return Object.assign(new Error(message), { status });
+}
 
 describe("Custom Error Hierarchy", () => {
   describe("OssScoutError", () => {
@@ -133,6 +138,23 @@ describe("getHttpStatusCode", () => {
   it("returns undefined for primitives", () => {
     expect(getHttpStatusCode("string")).toBeUndefined();
     expect(getHttpStatusCode(42)).toBeUndefined();
+  });
+});
+
+describe("isRateLimitError", () => {
+  it.each([
+    [429, "anything", true],
+    [403, "API rate limit exceeded", true],
+    [403, "You have exceeded a secondary rate limit", true],
+    [403, "You have triggered an abuse detection mechanism", true],
+    [403, "Forbidden: resource not accessible", false],
+    [500, "Internal server error", false],
+  ])("status %s with message %j classifies as %s", (status, msg, expected) => {
+    expect(isRateLimitError(withStatus(msg, status))).toBe(expected);
+  });
+
+  it("returns false for an error with no status", () => {
+    expect(isRateLimitError(new Error("no status at all"))).toBe(false);
   });
 });
 

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -52,7 +52,10 @@ export function isRateLimitError(error: unknown): boolean {
   if (status === 429) return true;
   if (status === 403) {
     const msg = errorMessage(error).toLowerCase();
-    return msg.includes("rate limit");
+    // "rate limit" also covers GitHub's "secondary rate limit" wording;
+    // abuse-detection 403s carry neither substring but are the same
+    // back-off-and-retry condition, so they must propagate too (#138).
+    return msg.includes("rate limit") || msg.includes("abuse detection");
   }
   return false;
 }
@@ -78,10 +81,8 @@ export function resolveErrorCode(err: unknown): ErrorCode {
   const status = getHttpStatusCode(err);
   if (status === 401) return "AUTH_REQUIRED";
   if (status === 403) {
-    const msg = errorMessage(err).toLowerCase();
-    if (msg.includes("rate limit") || msg.includes("abuse detection"))
-      return "RATE_LIMITED";
-    return "AUTH_REQUIRED";
+    // Single source of truth for the 403 rate-limit/abuse classification
+    return isRateLimitError(err) ? "RATE_LIMITED" : "AUTH_REQUIRED";
   }
   if (status === 404) return "NOT_FOUND";
   if (status === 429) return "RATE_LIMITED";

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -65,17 +65,10 @@ export interface BootstrapResult {
 
 /** Classify an unknown error into a DegradedReason for user-facing messaging. */
 function classifyDegradedReason(err: unknown): DegradedReason {
+  // isRateLimitError covers 429, 403 + "rate limit" (including secondary),
+  // and 403 + "abuse detection" (#138) — single source of truth.
   if (isRateLimitError(err)) return "rate_limit";
   const status = getHttpStatusCode(err);
-  // GitHub's abuse-detection responses arrive as 403 with "abuse detection"
-  // in the message but no "rate limit" substring — match resolveErrorCode's
-  // logic in errors.ts so we don't misclassify as 'unknown'.
-  if (
-    status === 403 &&
-    errorMessage(err).toLowerCase().includes("abuse detection")
-  ) {
-    return "rate_limit";
-  }
   if (status !== undefined && status >= 500 && status < 600) return "server";
   if (err && typeof err === "object" && "code" in err) {
     const code = (err as { code: unknown }).code;


### PR DESCRIPTION
## Summary
- `isRateLimitError` now matches 403 + "abuse detection" ("secondary rate limit" was already covered via the "rate limit" substring)
- `resolveErrorCode` and `classifyDegradedReason` delegate to it: one source of truth for the 403 classification
- Blast radius reviewed guard-by-guard: every propagate-direction site now treats abuse 403s as fatal per the errors.ts strategy doc, and the one deliberate degrade path (gist bootstrap offline fallback) is unchanged since its catch sits outside the guards

## Test plan
- [x] 7-case isRateLimitError table test (429, primary/secondary rate limit, abuse detection, plain 403, 500, no status)
- [x] Existing gist abuse-classification tests still green
- [x] lint, format:check, typecheck, 821 core + 22 mcp green

Closes #138