### PR TITLE
fix(core): unique tmp path for atomic state saves

### DIFF
--- a/packages/core/src/core/local-state.test.ts
+++ b/packages/core/src/core/local-state.test.ts
@@ -112,12 +112,28 @@ describe("local-state", () => {
       expect(loaded.preferences.githubUsername).toBe("saved-user");
     });
 
-    it("performs atomic write (no .tmp file left behind)", () => {
+    it("performs atomic write (no tmp files left behind)", () => {
       const state = ScoutStateSchema.parse({ version: 1 });
+      saveLocalState(state);
       saveLocalState(state);
 
       expect(fs.existsSync(path.join(tmpDir, "state.json"))).toBe(true);
-      expect(fs.existsSync(path.join(tmpDir, "state.json.tmp"))).toBe(false);
+      const leftovers = fs
+        .readdirSync(tmpDir)
+        .filter((f) => f.includes(".tmp"));
+      expect(leftovers).toEqual([]);
+    });
+
+    it("cleans up the unique tmp file when the rename fails", () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      // Force a real rename failure: a file cannot replace a directory
+      fs.mkdirSync(path.join(tmpDir, "state.json"));
+
+      expect(() => saveLocalState(state)).toThrow();
+      const leftovers = fs
+        .readdirSync(tmpDir)
+        .filter((f) => f.includes(".tmp"));
+      expect(leftovers).toEqual([]);
     });
 
     it("overwrites existing state", () => {

--- a/packages/core/src/core/local-state.ts
+++ b/packages/core/src/core/local-state.ts
@@ -56,15 +56,32 @@ export function loadLocalState(): ScoutState {
   }
 }
 
+/** Monotonic counter so two saves in one process never share a tmp path. */
+let tmpCounter = 0;
+
 /**
- * Save state to local file using atomic write (write to .tmp, then rename).
+ * Save state to local file using atomic write (write to a unique tmp file,
+ * then rename). A fixed ".tmp" path let two concurrent processes interleave
+ * write/rename and crash one of them with ENOENT. The load-mutate-save cycle
+ * is still last-writer-wins (no lock), but each save is now atomic and
+ * crash-free on its own.
  */
 export function saveLocalState(state: ScoutState): void {
   const statePath = getStatePath();
-  const tmpPath = statePath + ".tmp";
+  const tmpPath = `${statePath}.tmp.${process.pid}.${tmpCounter++}`;
 
   const data = JSON.stringify(state, null, 2) + "\n";
   fs.writeFileSync(tmpPath, data, { mode: 0o600 });
-  fs.renameSync(tmpPath, statePath);
+  try {
+    fs.renameSync(tmpPath, statePath);
+  } catch (err) {
+    // Do not leave an orphan tmp file behind on a failed rename
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // already gone
+    }
+    throw err;
+  }
   debug(MODULE, "State saved");
 }


### PR DESCRIPTION
## Summary
- Tmp file suffix is now `.tmp.<pid>.<counter>`, so concurrent processes can't interleave on a shared path; a failed rename unlinks its own tmp file before rethrowing (cleanup errors never mask the original)
- Rename-onto-directory failure semantics verified on macOS and POSIX (EISDIR), so the new no-mock failure test is portable

Known limitation worth noting: a hard crash (SIGKILL/power loss) between write and rename still orphans one tiny tmp file, and unique names mean such orphans accumulate rather than being clobbered. Rare in practice; a load-time sweep of stale `state.json.tmp.*` would be a small follow-up if wanted.

## Test plan
- [x] Atomic-write test broadened to assert zero `.tmp` leftovers after multiple saves
- [x] New test: real rename failure (file cannot replace a directory) → throws and leaves no tmp file
- [x] lint, format:check, typecheck, 822 core + 22 mcp green

Closes #140