### PR TITLE
fix(core): round-trip unknown state keys and add a migration entry point

### DIFF
--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -951,3 +951,25 @@ describe("mergeStates", () => {
     expect(merged.gistId).toBe("remote-gist");
   });
 });
+
+describe("mergeStates unknown-key round-trip (#137)", () => {
+  it("carries unknown top-level keys through a merge, remote wins on conflict", () => {
+    const local = makeState() as Record<string, unknown>;
+    local.futureLocalOnly = "from-local";
+    local.futureShared = "local-value";
+    const remote = makeState() as Record<string, unknown>;
+    remote.futureRemoteOnly = "from-remote";
+    remote.futureShared = "remote-value";
+
+    const merged = mergeStates(
+      local as unknown as ScoutState,
+      remote as unknown as ScoutState,
+    ) as Record<string, unknown>;
+
+    expect(merged.futureLocalOnly).toBe("from-local");
+    expect(merged.futureRemoteOnly).toBe("from-remote");
+    expect(merged.futureShared).toBe("remote-value");
+    // Known merged fields are still computed, not blindly overwritten
+    expect(merged.version).toBe(1);
+  });
+});

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -7,7 +7,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { ScoutStateSchema } from "./schemas.js";
+import { ScoutStateSchema, parseScoutState } from "./schemas.js";
 import type {
   ScoutState,
   RepoScore,
@@ -285,7 +285,7 @@ export class GistStateStore {
 
     try {
       const parsed = JSON.parse(file.content);
-      return ScoutStateSchema.parse(parsed);
+      return parseScoutState(parsed);
     } catch (err) {
       warn(MODULE, `Gist content failed validation: ${errorMessage(err)}`);
       return null;
@@ -351,7 +351,7 @@ export class GistStateStore {
   private readCache(): ScoutState | null {
     try {
       const raw = fs.readFileSync(getCachePath(), "utf-8");
-      return ScoutStateSchema.parse(JSON.parse(raw));
+      return parseScoutState(JSON.parse(raw));
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code !== "ENOENT") {
@@ -381,9 +381,13 @@ export class GistStateStore {
  * - preferences: remote wins
  * - starredRepos: keep the list with the fresher timestamp
  * - savedResults: union by issueUrl, keep newer lastSeenAt
+ * - unknown top-level keys (from a newer binary, #137): carried over via
+ *   spreads, remote wins on conflicts to mirror the preferences rule
  */
 export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
   return {
+    ...local,
+    ...remote,
     version: 1,
     preferences: remote.preferences,
     repoScores: mergeRepoScores(local.repoScores, remote.repoScores),

--- a/packages/core/src/core/local-state.test.ts
+++ b/packages/core/src/core/local-state.test.ts
@@ -154,3 +154,24 @@ describe("local-state", () => {
     });
   });
 });
+
+describe("unknown-key round-trip (#137)", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oss-scout-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("save then load preserves fields this binary does not know about", () => {
+    const state = ScoutStateSchema.parse({ version: 1 });
+    (state as Record<string, unknown>).futureField = { keep: "me" };
+    saveLocalState(state);
+
+    const loaded = loadLocalState();
+    expect((loaded as Record<string, unknown>).futureField).toEqual({
+      keep: "me",
+    });
+  });
+});

--- a/packages/core/src/core/local-state.ts
+++ b/packages/core/src/core/local-state.ts
@@ -4,7 +4,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { ScoutStateSchema } from "./schemas.js";
+import { ScoutStateSchema, parseScoutState } from "./schemas.js";
 import type { ScoutState } from "./schemas.js";
 import { getDataDir } from "./utils.js";
 import { debug, warn } from "./logger.js";
@@ -30,7 +30,7 @@ export function loadLocalState(): ScoutState {
   const statePath = getStatePath();
   try {
     const raw = fs.readFileSync(statePath, "utf-8");
-    return ScoutStateSchema.parse(JSON.parse(raw));
+    return parseScoutState(JSON.parse(raw));
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === "ENOENT") {

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   ScoutStateSchema,
   ScoutPreferencesSchema,
+  parseScoutState,
   RepoScoreSchema,
   SavedCandidateSchema,
   HorizonSchema,
@@ -323,5 +324,52 @@ describe("SavedCandidateSchema horizon field", () => {
     expect(() =>
       SavedCandidateSchema.parse({ ...base, horizon: "quick-win" }),
     ).not.toThrow();
+  });
+});
+
+// ── parseScoutState / unknown-key round-trip (#137) ─────────────────
+
+describe("parseScoutState", () => {
+  it("round-trips unknown top-level keys instead of stripping them", () => {
+    const parsed = parseScoutState({
+      version: 1,
+      futureTopLevelField: { from: "a newer binary" },
+    });
+    expect((parsed as Record<string, unknown>).futureTopLevelField).toEqual({
+      from: "a newer binary",
+    });
+  });
+
+  it("round-trips unknown keys on nested persisted objects", () => {
+    const parsed = parseScoutState({
+      version: 1,
+      preferences: { futurePref: true },
+      savedResults: [
+        {
+          issueUrl: "https://github.com/o/r/issues/1",
+          repo: "o/r",
+          number: 1,
+          title: "t",
+          labels: [],
+          recommendation: "approve",
+          viabilityScore: 80,
+          searchPriority: "normal",
+          firstSeenAt: "2026-05-08T00:00:00Z",
+          lastSeenAt: "2026-05-08T00:00:00Z",
+          lastScore: 80,
+          futureCandidateField: "kept",
+        },
+      ],
+    });
+    expect((parsed.preferences as Record<string, unknown>).futurePref).toBe(
+      true,
+    );
+    expect(
+      (parsed.savedResults[0] as Record<string, unknown>).futureCandidateField,
+    ).toBe("kept");
+  });
+
+  it("still rejects an unknown version", () => {
+    expect(() => parseScoutState({ version: 2 })).toThrow();
   });
 });

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -48,13 +48,13 @@ export const CONCRETE_STRATEGIES = [
 
 // ── Leaf schemas ────────────────────────────────────────────────────
 
-export const RepoSignalsSchema = z.object({
+export const RepoSignalsSchema = z.looseObject({
   hasActiveMaintainers: z.boolean(),
   isResponsive: z.boolean(),
   hasHostileComments: z.boolean(),
 });
 
-export const RepoScoreSchema = z.object({
+export const RepoScoreSchema = z.looseObject({
   repo: z.string(),
   score: z.number(),
   mergedPRCount: z.number(),
@@ -67,19 +67,19 @@ export const RepoScoreSchema = z.object({
   language: z.string().nullable().optional(),
 });
 
-export const StoredMergedPRSchema = z.object({
+export const StoredMergedPRSchema = z.looseObject({
   url: z.string(),
   title: z.string(),
   mergedAt: z.string(),
 });
 
-export const StoredClosedPRSchema = z.object({
+export const StoredClosedPRSchema = z.looseObject({
   url: z.string(),
   title: z.string(),
   closedAt: z.string(),
 });
 
-export const StoredOpenPRSchema = z.object({
+export const StoredOpenPRSchema = z.looseObject({
   url: z.string(),
   title: z.string(),
   openedAt: z.string(),
@@ -148,7 +148,7 @@ export const TrackedIssueSchema = z.object({
 
 // ── Skipped issue schema ──────────────────────────────────────────
 
-export const SkippedIssueSchema = z.object({
+export const SkippedIssueSchema = z.looseObject({
   url: z.string(),
   repo: z.string(),
   number: z.number(),
@@ -160,7 +160,7 @@ export const SkippedIssueSchema = z.object({
 
 export const HorizonSchema = z.enum(["quick-win", "bigger-bet"]);
 
-export const SavedCandidateSchema = z.object({
+export const SavedCandidateSchema = z.looseObject({
   issueUrl: z.string(),
   repo: z.string(),
   number: z.number(),
@@ -179,7 +179,7 @@ export const SavedCandidateSchema = z.object({
 
 export const PersistenceModeSchema = z.enum(["local", "gist"]);
 
-export const ScoutPreferencesSchema = z.object({
+export const ScoutPreferencesSchema = z.looseObject({
   githubUsername: z.string().default(""),
   languages: z.array(z.string()).default(["any"]),
   labels: z.array(z.string()).default(["good first issue", "help wanted"]),
@@ -231,7 +231,10 @@ export const ScoutPreferencesSchema = z.object({
 
 // ── Root state schema ───────────────────────────────────────────────
 
-export const ScoutStateSchema = z.object({
+// Persisted schemas are loose (unknown keys round-trip) so an older binary
+// loading state written by a newer one cannot silently strip and then
+// persist away the newer fields (#137).
+export const ScoutStateSchema = z.looseObject({
   version: z.literal(1),
 
   preferences: ScoutPreferencesSchema.default(() =>
@@ -255,6 +258,17 @@ export const ScoutStateSchema = z.object({
 
   gistId: z.string().optional(),
 });
+
+/**
+ * Single entry point for parsing persisted state (local file, gist, gist
+ * cache). Version migrations belong here: when a version 2 ships, transform
+ * older raw shapes before validation so no load site ever sees unmigrated
+ * data. Unknown keys round-trip via the loose schemas above.
+ */
+export function parseScoutState(raw: unknown): ScoutState {
+  // No migrations yet; version 1 is current.
+  return ScoutStateSchema.parse(raw);
+}
 
 // ── Inferred types ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Nine persisted schemas (state root, preferences, repo score/signals, PR records, skipped issues, saved candidates) are `z.looseObject`: unknown keys round-trip instead of being stripped and destroyed on the next save. Ephemeral schemas (LinkedPR, TrackedIssue, vetting results, guidelines) stay strict.
- `parseScoutState()` is the single entry point for all three persisted-state load sites (local file, gist fetch, gist cache), documented as where version-2 migrations will land. `version: z.literal(1)` still rejects unknown versions.
- `mergeStates` spreads local-then-remote before the explicit computed fields, so unknown top-level keys also survive gist merges (remote wins, mirroring the preferences rule). This was a reviewer catch: the merge previously rebuilt the object from known fields only, which would have reintroduced the exact failure for gist users.
- Reviewer verified zod 4 looseObject semantics under .default() materialization, .shape-driven config validation (CLI and MCP key lists unaffected), and that the additive index signature on the exported types is non-breaking downstream.

## Test plan
- [x] 5 new tests: top-level and nested round-trip via parseScoutState, save/load round-trip, merge round-trip (local-only/remote-only/conflict), unknown version rejected
- [x] 2 review passes converged
- [x] lint, format:check, typecheck, 827 core + 22 mcp green

Closes #137