### PR TITLE
fix(core): per-label queries restore any-of semantics in starred search

### DIFF
--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -833,7 +833,7 @@ describe("fetchIssuesFromKnownRepos", () => {
     expect(result.rateLimitHit).toBe(true);
   });
 
-  it("passes labels as comma-joined string to listForRepo", async () => {
+  it("queries once per label (any-of semantics, not the AND comma-join) (#118)", async () => {
     const octokit = makeMockOctokitWithRest([]);
     const vetter = makeMockVetter([]);
 
@@ -847,20 +847,62 @@ describe("fetchIssuesFromKnownRepos", () => {
       (items) => items,
     );
 
-    expect(
-      (
-        octokit as unknown as {
-          issues: { listForRepo: ReturnType<typeof vi.fn> };
-        }
-      ).issues.listForRepo,
-    ).toHaveBeenCalledWith(
-      expect.objectContaining({
-        owner: "owner",
-        repo: "repo",
-        state: "open",
-        labels: "good first issue,help wanted",
-      }),
+    const listForRepo = (
+      octokit as unknown as {
+        issues: { listForRepo: ReturnType<typeof vi.fn> };
+      }
+    ).issues.listForRepo;
+    expect(listForRepo).toHaveBeenCalledTimes(2);
+    expect(listForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: "good first issue" }),
     );
+    expect(listForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: "help wanted" }),
+    );
+  });
+
+  it("merges per-label results and dedups issues carrying multiple labels (#118)", async () => {
+    const issueA = {
+      html_url: "https://github.com/owner/repo/issues/1",
+      title: "A",
+      updated_at: "2026-01-01T00:00:00Z",
+      labels: [{ name: "good first issue" }, { name: "help wanted" }],
+    };
+    const issueB = {
+      html_url: "https://github.com/owner/repo/issues/2",
+      title: "B",
+      updated_at: "2026-01-01T00:00:00Z",
+      labels: [{ name: "help wanted" }],
+    };
+    const listForRepo = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [issueA] })
+      .mockResolvedValueOnce({ data: [issueA, issueB] });
+    const octokit = {
+      issues: { listForRepo },
+    } as unknown as Octokit;
+    const seen: string[] = [];
+    const vetter = {
+      vetIssuesParallel: vi.fn(async (urls: string[]) => {
+        seen.push(...urls);
+        return { candidates: [], allFailed: false, rateLimitHit: false };
+      }),
+    } as unknown as IssueVetter;
+
+    await fetchIssuesFromKnownRepos(
+      octokit,
+      vetter,
+      ["owner/repo"],
+      ["good first issue", "help wanted"],
+      10,
+      "starred",
+      (items) => items,
+    );
+
+    expect(seen).toEqual([
+      "https://github.com/owner/repo/issues/1",
+      "https://github.com/owner/repo/issues/2",
+    ]);
   });
 
   it("omits labels param when labels array is empty", async () => {

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -282,18 +282,35 @@ export async function fetchIssuesFromKnownRepos(
     const [owner, repo] = repoFullName.split("/");
 
     try {
-      const response = await octokit.issues.listForRepo({
-        owner,
-        repo,
-        state: "open",
-        sort: "created",
-        direction: "desc",
-        per_page: 5,
-        ...(labels.length > 0 ? { labels: labels.join(",") } : {}),
-      });
+      // One query per label: the REST `labels` parameter is AND semantics
+      // (issues carrying ALL listed labels), so a comma-joined list like
+      // "good first issue,help wanted" returned ~nothing (#118). Querying
+      // per label and merging restores the intended any-of behavior.
+      const labelFilters: Array<string | undefined> =
+        labels.length > 0 ? labels : [undefined];
+      const seenUrls = new Set<string>();
+      const rawIssues: Awaited<
+        ReturnType<typeof octokit.issues.listForRepo>
+      >["data"] = [];
+      for (const label of labelFilters) {
+        const response = await octokit.issues.listForRepo({
+          owner,
+          repo,
+          state: "open",
+          sort: "created",
+          direction: "desc",
+          per_page: 5,
+          ...(label !== undefined ? { labels: label } : {}),
+        });
+        for (const issue of response.data) {
+          if (seenUrls.has(issue.html_url)) continue;
+          seenUrls.add(issue.html_url);
+          rawIssues.push(issue);
+        }
+      }
 
       // Filter out pull requests (REST issues endpoint returns both) and assigned issues
-      const issuesOnly = response.data.filter(
+      const issuesOnly = rawIssues.filter(
         (item) => !("pull_request" in item) && !item.assignee,
       );
 


### PR DESCRIPTION
## Summary
`fetchIssuesFromKnownRepos` now issues one `listForRepo` call per label and merges results with insertion-order dedup by `html_url`. The old comma-join hit the REST `labels` param's ALL-labels semantics, so the default label set effectively zeroed out Phase 1. Phase 0 (empty labels, single unlabeled call) is byte-identical.

Cost and behavior notes from review:
- Worst case 10 repos x 3 labels = 30 Core-API calls per search (vs 5000/h); the inter-repo 2s delay still applies, intra-repo label calls run back-to-back (a per-label sleep is the lever if secondary limits ever bite)
- Mild first-label ordering bias in the merged feed (good first issue before help wanted), bounded downstream by the existing vetting slice
- A label-query failure mid-repo still counts the whole repo as failed; sensible since label queries differ only by label string

## Test plan
- [x] Replaced the comma-join expectation with a per-label-call test; new merge/dedup test (issue carrying both labels appears once, single-label issue still found)
- [x] lint, format:check, typecheck, 828 core + 22 mcp green

Closes #118