### PR TITLE
fix(core): replenish the external search budget when GitHub's window resets

### DIFF
--- a/packages/core/src/core/search-budget.test.ts
+++ b/packages/core/src/core/search-budget.test.ts
@@ -99,11 +99,59 @@ describe("SearchBudgetTracker", () => {
     expect(tracker.canAfford(1)).toBe(false);
   });
 
-  it("waitForBudget returns immediately when external budget exhausted but no local timestamps", async () => {
-    // Edge case: init with 0 remaining but no local calls.
-    // Should return immediately (no timestamps to wait on) rather than looping forever.
-    tracker.init(0, new Date(Date.now() + 60000).toISOString());
-    await tracker.waitForBudget(); // should not hang
+  it("waitForBudget waits for the quota reset when external budget exhausted with no local timestamps", async () => {
+    const { sleep } = await import("./utils.js");
+    const realNow = Date.now();
+    tracker.init(0, new Date(realNow + 5_000).toISOString());
+
+    // Sleep advances the clock past the reset; the loop then replenishes
+    // and returns instead of proceeding into a guaranteed 403 (#119)
+    vi.mocked(sleep).mockImplementation(async () => {
+      vi.spyOn(Date, "now").mockReturnValue(realNow + 6_000);
+    });
+
+    await tracker.waitForBudget();
+    expect(sleep).toHaveBeenCalled();
+    expect(tracker.canAfford(1)).toBe(true);
+    vi.restoreAllMocks();
+  });
+
+  it("waitForBudget returns immediately when external budget exhausted and no reset is known", async () => {
+    const { sleep } = await import("./utils.js");
+    vi.mocked(sleep).mockClear();
+    // No init: resetAt is unknown (0). Simulate external exhaustion by
+    // filling the local window instead is not possible without timestamps,
+    // so construct the unknown-reset path directly via init with epoch 0.
+    tracker.init(0, new Date(0).toISOString());
+    await tracker.waitForBudget(); // must not hang
+  });
+
+  describe("external budget replenishment (#119)", () => {
+    it("replenishes once resetAt passes and keeps the diagnostics counter", () => {
+      const realNow = Date.now();
+      tracker.init(1, new Date(realNow + 30_000).toISOString());
+      tracker.recordCall();
+      expect(tracker.canAfford(1)).toBe(false); // external quota spent
+
+      vi.spyOn(Date, "now").mockReturnValue(realNow + 31_000);
+      expect(tracker.canAfford(1)).toBe(true); // window reset, replenished
+      expect(tracker.getTotalCalls()).toBe(1); // diagnostics untouched
+      vi.restoreAllMocks();
+    });
+
+    it("replenishes repeatedly across multiple windows", () => {
+      const realNow = Date.now();
+      tracker.init(1, new Date(realNow + 10_000).toISOString());
+      tracker.recordCall();
+      expect(tracker.canAfford(1)).toBe(false);
+
+      // Two windows later: resetAt advances past now, budget available again
+      vi.spyOn(Date, "now").mockReturnValue(realNow + 140_000);
+      expect(tracker.canAfford(1)).toBe(true);
+      tracker.recordCall();
+      expect(tracker.canAfford(1)).toBe(true); // 30 - 1 external remains
+      vi.restoreAllMocks();
+    });
   });
 });
 

--- a/packages/core/src/core/search-budget.ts
+++ b/packages/core/src/core/search-budget.ts
@@ -40,6 +40,9 @@ export class SearchBudgetTracker {
   /** Total calls recorded since init (for diagnostics). */
   private totalCalls: number = 0;
 
+  /** Calls made since the last known quota reset (external accounting). */
+  private callsSinceReset: number = 0;
+
   /**
    * Initialize with pre-flight rate limit data from GitHub.
    */
@@ -48,6 +51,7 @@ export class SearchBudgetTracker {
     this.resetAt = new Date(resetAt).getTime();
     this.callTimestamps = [];
     this.totalCalls = 0;
+    this.callsSinceReset = 0;
     debug(
       MODULE,
       `Initialized: ${remaining} remaining, resets at ${new Date(this.resetAt).toLocaleTimeString()}`,
@@ -60,7 +64,26 @@ export class SearchBudgetTracker {
   recordCall(): void {
     this.callTimestamps.push(Date.now());
     this.totalCalls++;
+    this.callsSinceReset++;
     this.pruneOldTimestamps();
+  }
+
+  /**
+   * Replenish the external budget once GitHub's quota window has reset.
+   * Without this, the pre-flight remaining acted as a never-replenishing
+   * run-lifetime total, throttling long multi-phase runs to ~1 call/min
+   * even though GitHub fully resets every 60 seconds (#119).
+   */
+  private refreshExternalBudget(): void {
+    if (this.resetAt <= 0) return;
+    const now = Date.now();
+    if (now < this.resetAt) return;
+    this.knownRemaining = SEARCH_RATE_LIMIT;
+    this.callsSinceReset = 0;
+    while (this.resetAt <= now) {
+      this.resetAt += SEARCH_WINDOW_MS;
+    }
+    debug(MODULE, "Quota window reset; external search budget replenished");
   }
 
   /**
@@ -86,9 +109,11 @@ export class SearchBudgetTracker {
    * and the pre-flight remaining quota from GitHub.
    */
   private getEffectiveBudget(): number {
-    // Use the stricter of: local window limit vs. pre-flight remaining minus calls made
+    this.refreshExternalBudget();
+    // Use the stricter of: local window limit vs. known remaining quota
+    // minus calls made since the last reset
     const localBudget = EFFECTIVE_BUDGET - this.callTimestamps.length;
-    const externalBudget = this.knownRemaining - this.totalCalls;
+    const externalBudget = this.knownRemaining - this.callsSinceReset;
     return Math.max(0, Math.min(localBudget, externalBudget));
   }
 
@@ -118,7 +143,18 @@ export class SearchBudgetTracker {
       // Wait until the oldest call in the window ages out
       const oldestInWindow = this.callTimestamps[0];
       if (!oldestInWindow) {
-        return; // No calls in window — budget exhausted by external consumption, can't wait it out
+        // No calls in window — the external quota is exhausted. Wait for
+        // GitHub's reset when we know it, otherwise proceed (#119).
+        const untilReset = this.resetAt - Date.now();
+        if (this.resetAt > 0 && untilReset > 0) {
+          debug(
+            MODULE,
+            `External quota exhausted, waiting ${untilReset}ms for reset`,
+          );
+          await sleep(untilReset + 100);
+          continue;
+        }
+        return;
       }
       const waitUntil = oldestInWindow + SEARCH_WINDOW_MS;
       const waitMs = waitUntil - Date.now();


### PR DESCRIPTION
## Summary
- `refreshExternalBudget()` (called from the budget calculation) resets `knownRemaining` to the full 30 and zeroes a new `callsSinceReset` counter once `Date.now() >= resetAt`, advancing `resetAt` in window increments; `totalCalls` is now purely diagnostic
- `waitForBudget` with an empty window and exhausted external quota now sleeps until the known reset (+100ms) and loops, instead of returning into a guaranteed 403; returns immediately only when no reset is known
- Throughput stays gated by the sliding-window cap (26), so replenishing to the full limit cannot exceed the safety margin; cross-process quota sharing degrades softly and re-syncs on the next preflight

## Test plan
- [x] 3 new tests (single-window replenish with diagnostics preserved, multi-window replenish, wait-for-reset path) + the old immediate-return expectation updated to the new wait behavior + unknown-reset no-hang case
- [x] lint, format:check, typecheck, 831 core + 22 mcp green

Closes #119