### PR TITLE
fix(core): detect closed issues during vetting

### DIFF
--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -221,6 +221,25 @@ describe("vetList", () => {
     await expect(scout.vetList()).rejects.toThrow("rate limit");
   });
 
+  it("classifies closed-but-200 issues via issueState (#120)", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()];
+    const scout = new OssScout("fake-token", state);
+
+    // GitHub returns 200 for closed issues; only issueState reveals it
+    vi.spyOn(scout, "vetIssue").mockResolvedValue({
+      ...makeIssueCandidate({ recommendation: "skip" }),
+      issueState: "closed" as const,
+    });
+
+    const result = await scout.vetList({ prune: true });
+    expect(result.results[0].status).toBe("closed");
+    expect(result.summary.closed).toBe(1);
+    expect(result.prunedCount).toBe(1);
+    expect(scout.getSavedResults()).toHaveLength(0);
+  });
+
   it("classifies closed issues from 410 (gone) errors", async () => {
     const { OssScout } = await import("../scout.js");
     const state = ScoutStateSchema.parse({ version: 1 });

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -285,6 +285,34 @@ describe("IssueVetter", () => {
       expect(result.recommendation).toBe("approve");
       expect(result.vettingResult.passedAllChecks).toBe(true);
       expect(result.viabilityScore).toBeGreaterThan(0);
+      expect(result.issueState).toBe("open");
+    });
+
+    it("marks a closed issue as skip with issueState closed (#120)", async () => {
+      const octokit = makeMockOctokit();
+      (
+        octokit as unknown as {
+          issues: { get: ReturnType<typeof vi.fn> };
+        }
+      ).issues.get.mockResolvedValueOnce({
+        data: {
+          id: 123,
+          html_url: "https://github.com/owner/repo/issues/1",
+          title: "Already fixed",
+          body: "done",
+          state: "closed",
+          comments: 0,
+          labels: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-03-01T00:00:00Z",
+        },
+      });
+      const vetter = new IssueVetter(octokit, makeStubStateReader());
+
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.issueState).toBe("closed");
+      expect(result.recommendation).toBe("skip");
+      expect(result.reasonsToSkip).toContain("Issue is closed");
     });
 
     it("recommends skip when an existing PR is found", async () => {

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -322,8 +322,17 @@ export class IssueVetter {
       reasonsToApprove.push("Matches preferred project category");
     }
 
+    // GitHub answers 200 for closed issues, so without an explicit state
+    // check a closed issue would vet as still available (#120).
+    const issueClosed = ghIssue.state === "closed";
+    if (issueClosed) {
+      reasonsToSkip.push("Issue is closed");
+    }
+
     let recommendation: "approve" | "skip" | "needs_review";
-    if (vettingResult.passedAllChecks) {
+    if (issueClosed) {
+      recommendation = "skip";
+    } else if (vettingResult.passedAllChecks) {
       recommendation = "approve";
     } else if (reasonsToSkip.length > 2) {
       recommendation = "skip";
@@ -402,6 +411,7 @@ export class IssueVetter {
 
     const result: IssueCandidate = {
       issue: trackedIssue,
+      issueState: issueClosed ? "closed" : "open",
       vettingResult,
       projectHealth,
       antiLLMPolicy,

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -79,6 +79,13 @@ export interface SLMTriageSummary {
 /** A fully vetted issue candidate with scoring. */
 export interface IssueCandidate {
   issue: TrackedIssue;
+  /**
+   * GitHub issue state at vet time (#120). GitHub answers 200 for closed
+   * issues, so without this vet-list classified them still_available and
+   * --prune kept them. Optional: cached candidates from older versions
+   * lack it and read as open.
+   */
+  issueState?: "open" | "closed";
   vettingResult: IssueVettingResult;
   projectHealth: ProjectHealth;
   antiLLMPolicy: AntiLLMPolicyResult;

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -395,6 +395,10 @@ export class OssScout implements ScoutStateReader {
   }
 
   private classifyVetResult(candidate: IssueCandidate): VetListEntry["status"] {
+    // Closed wins over everything: GitHub returns 200 for closed issues, so
+    // the 404/410 catch path alone never saw them (#120). Candidates cached
+    // by older versions lack issueState and read as open.
+    if (candidate.issueState === "closed") return "closed";
     const checks = candidate.vettingResult.checks;
     if (!checks.noExistingPR) return "has_pr";
     if (!checks.notClaimed) return "claimed";


### PR DESCRIPTION
## Summary
- New optional `IssueCandidate.issueState` ("open" | "closed"; additive, older cached candidates read as open)
- `vetIssue` sets it from the fetched issue, adds the "Issue is closed" skip reason, and forces `recommendation: skip` ahead of the passed-all-checks branch (the inconclusive downgrade can't override it since it only fires on approve)
- `classifyVetResult` returns "closed" on the explicit marker first, so `vet-list --prune` finally removes closed issues
- Interactions verified in review: search and features pipelines only feed open issues; the MCP vet tool serializes the whole candidate so the new field surfaces automatically; a reopened issue self-heals after the existing 15-min vet cache TTL

## Test plan
- [x] New vetting test (closed 200 → issueState closed, skip, reason) and vet-list test (closed-but-200 → status closed, counted, pruned); approve happy path asserts issueState open
- [x] lint, format:check, typecheck, 833 core + 22 mcp green

Closes #120