### PR TITLE
fix(core): per-language broad feature queries via the cached search path

### DIFF
--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -9,10 +9,26 @@ import {
   discoverFeaturesBroad,
   detectWontfixNoContributor,
   buildBroadFeatureSearchQuery,
+  buildBroadFeatureSearchQueries,
   WONTFIX_MIN_AGE_DAYS,
   type FeatureCandidate,
 } from "./feature-discovery.js";
 import { _clearRoadmapCacheForTests } from "./roadmap.js";
+
+// Broad mode routes through cachedSearchIssues (#121); stub its singletons
+// so tests never touch the real ~/.oss-scout cache or budget pacing.
+vi.mock("./http-cache.js", () => ({
+  getHttpCache: vi.fn(() => ({
+    getIfFresh: vi.fn(() => null),
+    set: vi.fn(),
+  })),
+}));
+vi.mock("./search-budget.js", () => ({
+  getSearchBudgetTracker: vi.fn(() => ({
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+    recordCall: vi.fn(),
+  })),
+}));
 
 const mkScore = (repo: string, mergedPRCount: number): RepoScore => ({
   repo,
@@ -787,17 +803,25 @@ describe("buildBroadFeatureSearchQuery", () => {
     expect(q).toContain('-label:"documentation"');
   });
 
-  it("adds language filter when languages are provided", () => {
-    const q = buildBroadFeatureSearchQuery({
+  it("fans out one query per language instead of an over-limit OR clause (#121)", () => {
+    const queries = buildBroadFeatureSearchQueries({
       languages: ["typescript", "python"],
     });
-    expect(q).toContain("language:typescript OR language:python");
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain("language:typescript");
+    expect(queries[0]).not.toContain("language:python");
+    expect(queries[1]).toContain("language:python");
+    // The label clause already spends all five OR operators; no query may
+    // add more
+    for (const q of queries) {
+      expect((q.match(/ OR /g) ?? []).length).toBeLessThanOrEqual(5);
+    }
   });
 
   it("ignores 'any' language preference", () => {
-    const q = buildBroadFeatureSearchQuery({ languages: ["any"] });
-    expect(q).not.toContain("language:any");
-    expect(q).not.toContain("language:");
+    const queries = buildBroadFeatureSearchQueries({ languages: ["any"] });
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).not.toContain("language:");
   });
 
   it("includes -repo and -user clauses for excluded repos and orgs", () => {
@@ -905,6 +929,48 @@ describe("discoverFeaturesBroad", () => {
     expect(result.quickWins).toHaveLength(1);
     expect(result.biggerBets).toHaveLength(1);
     expect(result.anchorRepos).toEqual([]);
+    expect(result.message).toBeNull();
+  });
+
+  it("fans out per language and dedups across queries (#121)", async () => {
+    const item = (n: number) => ({
+      html_url: `https://github.com/x/y/issues/${n}`,
+      title: `feature ${n}`,
+      labels: [{ name: "enhancement" }],
+      comments: 1,
+      reactions: { total_count: 1 },
+      milestone: null,
+      pull_request: undefined,
+      assignee: null,
+      created_at: "2026-04-01",
+      number: n,
+    });
+    const search = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { items: [item(1), item(2)] } })
+      .mockResolvedValueOnce({ data: { items: [item(2), item(3)] } });
+    const octokit = { search: { issuesAndPullRequests: search } } as never;
+    const vetter = makeVetter();
+
+    const result = await discoverFeaturesBroad({
+      octokit,
+      vetter,
+      count: 10,
+      languages: ["typescript", "python"],
+    });
+
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(search.mock.calls[0][0].q).toContain("language:typescript");
+    expect(search.mock.calls[1][0].q).toContain("language:python");
+    // Issue 2 appeared in both result sets but is vetted once
+    const vetted = (
+      vetter as unknown as { vetIssue: ReturnType<typeof vi.fn> }
+    ).vetIssue.mock.calls.map((c) => c[0]);
+    expect(vetted).toEqual([
+      "https://github.com/x/y/issues/1",
+      "https://github.com/x/y/issues/2",
+      "https://github.com/x/y/issues/3",
+    ]);
     expect(result.message).toBeNull();
   });
 

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -20,6 +20,7 @@ import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { warn } from "./logger.js";
 import { sleep } from "./utils.js";
 import { fetchRoadmapIssueRefs } from "./roadmap.js";
+import { cachedSearchIssues } from "./search-phases.js";
 
 const MODULE = "feature-discovery";
 
@@ -377,13 +378,15 @@ const DEFAULT_BROAD_MAX_TO_VET = 30;
  * is independently testable without mocking the Search API.
  */
 export function buildBroadFeatureSearchQuery(opts: {
-  languages?: string[];
+  /** Single language per query; see buildBroadFeatureSearchQueries. */
+  language?: string;
   excludeRepos?: string[];
   excludeOrgs?: string[];
 }): string {
   const parts: string[] = ["is:issue", "is:open", "no:assignee"];
 
-  // Feature labels — any-of via parenthesized OR.
+  // Feature labels — any-of via parenthesized OR. The six labels spend
+  // exactly five OR operators, GitHub's entire per-query allowance.
   const labelClause = FEATURE_LABELS.map((l) => `label:"${l}"`).join(" OR ");
   parts.push(`(${labelClause})`);
 
@@ -392,14 +395,8 @@ export function buildBroadFeatureSearchQuery(opts: {
     parts.push(`-label:"${excl}"`);
   }
 
-  // Languages — skip the filter when "any" is the only preference, since
-  // GitHub Search has no `language:any` operator.
-  const languages = (opts.languages ?? []).filter(
-    (l) => l && l.toLowerCase() !== "any",
-  );
-  if (languages.length > 0) {
-    const langClause = languages.map((l) => `language:${l}`).join(" OR ");
-    parts.push(`(${langClause})`);
+  if (opts.language) {
+    parts.push(`language:${opts.language}`);
   }
 
   // User exclusions.
@@ -411,6 +408,32 @@ export function buildBroadFeatureSearchQuery(opts: {
   }
 
   return parts.join(" ");
+}
+
+/**
+ * One query per language. A combined `(language:a OR language:b)` clause
+ * pushed the query past GitHub's 5-operator limit (the label ORs already
+ * spend all five), so every 2+ language config drew a 422 that the caller
+ * swallowed into "no results" (#121). "any" disables the filter.
+ */
+export function buildBroadFeatureSearchQueries(opts: {
+  languages?: string[];
+  excludeRepos?: string[];
+  excludeOrgs?: string[];
+}): string[] {
+  const base = {
+    excludeRepos: opts.excludeRepos,
+    excludeOrgs: opts.excludeOrgs,
+  };
+  const languages = (opts.languages ?? []).filter(
+    (l) => l && l.toLowerCase() !== "any",
+  );
+  if (languages.length === 0) {
+    return [buildBroadFeatureSearchQuery(base)];
+  }
+  return languages.map((language) =>
+    buildBroadFeatureSearchQuery({ ...base, language }),
+  );
 }
 
 /**
@@ -429,7 +452,7 @@ export function buildBroadFeatureSearchQuery(opts: {
 export async function discoverFeaturesBroad(
   opts: DiscoverFeaturesBroadOptions,
 ): Promise<FeatureSearchResult> {
-  const query = buildBroadFeatureSearchQuery({
+  const queries = buildBroadFeatureSearchQueries({
     languages: opts.languages,
     excludeRepos: opts.excludeRepos,
     excludeOrgs: opts.excludeOrgs,
@@ -438,15 +461,28 @@ export async function discoverFeaturesBroad(
 
   let items: RawIssueItem[];
   try {
-    const response = await opts.octokit.search.issuesAndPullRequests({
-      q: query,
-      sort: "interactions",
-      order: "desc",
-      per_page: maxToVet,
-    });
-    items = (response.data.items as RawIssueItem[]).filter(
-      (it) => !it.pull_request && !it.assignee && isFeatureIssue(it),
-    );
+    // cachedSearchIssues pays the budget tracker and the 15-minute search
+    // cache; this was previously the only Search API call in the pipeline
+    // outside that infrastructure (#121). Runtime items keep the rich
+    // fields (milestone, reactions, ...) the narrow cache type omits.
+    const merged: RawIssueItem[] = [];
+    const seenUrls = new Set<string>();
+    for (const query of queries) {
+      const data = await cachedSearchIssues(opts.octokit, {
+        q: query,
+        sort: "interactions",
+        order: "desc",
+        per_page: maxToVet,
+      });
+      for (const raw of data.items as unknown as RawIssueItem[]) {
+        if (seenUrls.has(raw.html_url)) continue;
+        seenUrls.add(raw.html_url);
+        merged.push(raw);
+      }
+    }
+    items = merged
+      .filter((it) => !it.pull_request && !it.assignee && isFeatureIssue(it))
+      .slice(0, maxToVet);
   } catch (err: unknown) {
     if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
     warn(MODULE, `broad feature search failed: ${errorMessage(err)}`);


### PR DESCRIPTION
## Summary
- `buildBroadFeatureSearchQueries` fans out one query per configured language ("any"/empty → one unfiltered query); each query spends exactly the five OR operators the six feature labels need, pinned by a new OR-count test
- `discoverFeaturesBroad` loops the queries through `cachedSearchIssues` (budget tracker + 15-min cache, previously bypassed), merges with insertion-order dedup by URL, and slices to `maxToVet`
- Rich item fields (milestone, reactions, created_at) verified to survive the JSON disk-cache round-trip; empty results are never cached
- Behavior note: result ordering is now per-language insertion order rather than GitHub's cross-language interactions interleave; first configured language fills the slice first

## Test plan
- [x] Builder tests updated to the fan-out shape (per-language queries, OR-count cap, "any" handling); new fan-out + cross-query dedup test; cache/budget singletons stubbed in the test file
- [x] lint, format:check, typecheck, 834 core + 22 mcp green

Closes #121