### PR TITLE
fix(core): in-flight dedup for per-repo lookups during parallel vetting

### DIFF
--- a/packages/core/src/core/http-cache.test.ts
+++ b/packages/core/src/core/http-cache.test.ts
@@ -3,7 +3,12 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as crypto from "crypto";
-import { HttpCache, cachedRequest, cachedTimeBased } from "./http-cache.js";
+import {
+  HttpCache,
+  cachedRequest,
+  cachedTimeBased,
+  withInflightDedup,
+} from "./http-cache.js";
 
 vi.mock("./logger.js", () => ({
   debug: vi.fn(),
@@ -188,5 +193,60 @@ describe("HttpCache", () => {
 
     // The corrupt file should have been deleted
     expect(fs.existsSync(filePath)).toBe(false);
+  });
+});
+
+describe("withInflightDedup (#124)", () => {
+  it("shares one computation between concurrent same-key callers", async () => {
+    const cache = new HttpCache(tmpDir);
+    let resolveFn: (v: string) => void;
+    const fn = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    const a = withInflightDedup(cache, "stampede-key", fn);
+    const b = withInflightDedup(cache, "stampede-key", fn);
+    resolveFn!("shared");
+
+    expect(await a).toBe("shared");
+    expect(await b).toBe("shared");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a rejection to every waiter and clears the slot", async () => {
+    const cache = new HttpCache(tmpDir);
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+
+    const a = withInflightDedup(cache, "reject-key", fn);
+    const b = withInflightDedup(cache, "reject-key", fn);
+    await expect(a).rejects.toThrow("boom");
+    await expect(b).rejects.toThrow("boom");
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Slot cleared: the next call retries
+    const ok = vi.fn().mockResolvedValue(42);
+    await expect(withInflightDedup(cache, "reject-key", ok)).resolves.toBe(42);
+  });
+
+  it("cachedTimeBased dedups a concurrent same-key stampede", async () => {
+    const cache = new HttpCache(tmpDir);
+    let resolveFn: (v: { ok: boolean }) => void;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<{ ok: boolean }>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    const a = cachedTimeBased(cache, "tb-stampede", 60_000, fetcher);
+    const b = cachedTimeBased(cache, "tb-stampede", 60_000, fetcher);
+    resolveFn!({ ok: true });
+
+    expect(await a).toEqual({ ok: true });
+    expect(await b).toEqual({ ok: true });
+    expect(fetcher).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/core/http-cache.ts
+++ b/packages/core/src/core/http-cache.ts
@@ -280,6 +280,32 @@ export function getHttpCache(): HttpCache {
  *    cached body without consuming a rate-limit point.
  * 3. On a fresh 200, caches the ETag + body for next time.
  */
+/**
+ * Share one in-flight computation per key: concurrent callers for the same
+ * key await the same promise instead of paying duplicate API calls (#124).
+ * The check-then-register pair runs without an intervening await, so two
+ * concurrent callers cannot both miss. Rejections propagate to every waiter
+ * and are never cached.
+ */
+export async function withInflightDedup<T>(
+  cache: HttpCache,
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const existing = cache.getInflight(key);
+  if (existing) {
+    debug(MODULE, `Dedup hit for ${key}`);
+    return (await existing) as T;
+  }
+  const promise = fn();
+  const cleanup = cache.setInflight(key, promise);
+  try {
+    return await promise;
+  } finally {
+    cleanup();
+  }
+}
+
 export async function cachedRequest<T>(
   cache: HttpCache,
   url: string,
@@ -287,13 +313,6 @@ export async function cachedRequest<T>(
     headers: Record<string, string>,
   ) => Promise<{ data: T; headers?: Record<string, string> }>,
 ): Promise<T> {
-  // --- Deduplication ---
-  const existing = cache.getInflight(url);
-  if (existing) {
-    debug(MODULE, `Dedup hit for ${url}`);
-    return (await existing) as T;
-  }
-
   const doFetch = async (): Promise<T> => {
     const extraHeaders: Record<string, string> = {};
     const cached = cache.get(url);
@@ -332,15 +351,7 @@ export async function cachedRequest<T>(
     }
   };
 
-  const promise = doFetch();
-  const cleanup = cache.setInflight(url, promise);
-
-  try {
-    const result = await promise;
-    return result;
-  } finally {
-    cleanup();
-  }
+  return withInflightDedup(cache, url, doFetch);
 }
 
 /**
@@ -364,9 +375,19 @@ export async function cachedTimeBased<T>(
     return cached.body as T;
   }
 
-  const result = await fetcher();
-  cache.set(key, "", result);
-  return result;
+  // Concurrent same-key callers (parallel vetting hitting one repo) share
+  // a single fetch instead of stampeding the API (#124)
+  return withInflightDedup(cache, key, async () => {
+    // Re-check inside the dedup window: a caller that finished while we
+    // queued may have populated the cache
+    const fresh = cache.getEntryIfFresh(key, maxAgeMs);
+    if (fresh) {
+      return fresh.body as T;
+    }
+    const result = await fetcher();
+    cache.set(key, "", result);
+    return result;
+  });
 }
 
 /**

--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -20,6 +20,10 @@ vi.mock("./http-cache.js", () => ({
     getIfFresh: vi.fn(() => null),
     set: vi.fn(),
   })),
+  // Passthrough: dedup behavior itself is covered in http-cache.test.ts
+  withInflightDedup: vi.fn(
+    async (_cache: unknown, _key: string, fn: () => Promise<unknown>) => fn(),
+  ),
 }));
 
 vi.mock("./pagination.js", () => ({

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -10,7 +10,7 @@ import { Octokit } from "@octokit/rest";
 import { paginateAll } from "./pagination.js";
 import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { warn } from "./logger.js";
-import { getHttpCache } from "./http-cache.js";
+import { getHttpCache, withInflightDedup } from "./http-cache.js";
 import { getSearchBudgetTracker } from "./search-budget.js";
 import type { CheckResult, LinkedPR } from "./types.js";
 
@@ -228,43 +228,49 @@ export async function checkUserMergedPRsInRepo(
   const cache = getHttpCache();
   const cacheKey = `merged-prs:${owner}/${repo}`;
 
-  // Manual cache check — do not use cachedTimeBased because we must NOT cache
-  // error-path fallback values (a transient failure returning 0 would poison the
-  // cache for 15 minutes, hiding that the user has merged PRs in the repo).
-  const cached = cache.getIfFresh(cacheKey, MERGED_PR_CACHE_TTL_MS);
-  if (cached != null && typeof cached === "number") {
-    return cached;
-  }
+  // In-flight dedup: parallel vetting frequently hits several issues from
+  // one repo at once, and each used to pay a separate Search API call
+  // before the first populated the cache (#124).
+  return withInflightDedup(cache, cacheKey, async () => {
+    // Manual cache check — do not use cachedTimeBased because we must NOT
+    // cache error-path fallback values (a transient failure returning 0
+    // would poison the cache for 15 minutes, hiding that the user has
+    // merged PRs in the repo).
+    const cached = cache.getIfFresh(cacheKey, MERGED_PR_CACHE_TTL_MS);
+    if (cached != null && typeof cached === "number") {
+      return cached;
+    }
 
-  try {
-    const tracker = getSearchBudgetTracker();
-    await tracker.waitForBudget();
     try {
-      // Use @me to search as the authenticated user
-      const { data } = await octokit.search.issuesAndPullRequests({
-        q: `repo:${owner}/${repo} is:pr is:merged author:@me`,
-        per_page: 1, // We only need total_count
-      });
-      // Only cache successful results
-      cache.set(cacheKey, "", data.total_count);
-      return data.total_count;
-    } finally {
-      // Always record the call — failed requests still consume GitHub rate limit points
-      tracker.recordCall();
+      const tracker = getSearchBudgetTracker();
+      await tracker.waitForBudget();
+      try {
+        // Use @me to search as the authenticated user
+        const { data } = await octokit.search.issuesAndPullRequests({
+          q: `repo:${owner}/${repo} is:pr is:merged author:@me`,
+          per_page: 1, // We only need total_count
+        });
+        // Only cache successful results
+        cache.set(cacheKey, "", data.total_count);
+        return data.total_count;
+      } finally {
+        // Always record the call — failed requests still consume GitHub rate limit points
+        tracker.recordCall();
+      }
+    } catch (error) {
+      if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
+        throw error;
+      }
+      const errMsg = errorMessage(error);
+      warn(
+        MODULE,
+        `Could not check merged PRs in ${owner}/${repo}: ${errMsg}. Treating as unknown.`,
+      );
+      // null (not 0) so callers can tell a transient failure from a real zero
+      // and avoid caching verdicts built on it. Not cached — next call retries.
+      return null;
     }
-  } catch (error) {
-    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
-      throw error;
-    }
-    const errMsg = errorMessage(error);
-    warn(
-      MODULE,
-      `Could not check merged PRs in ${owner}/${repo}: ${errMsg}. Treating as unknown.`,
-    );
-    // null (not 0) so callers can tell a transient failure from a real zero
-    // and avoid caching verdicts built on it. Not cached — next call retries.
-    return null;
-  }
+  });
 }
 
 /**

--- a/packages/core/src/core/repo-health.test.ts
+++ b/packages/core/src/core/repo-health.test.ts
@@ -302,3 +302,35 @@ describe("fetchContributionGuidelines", () => {
     ).rejects.toThrow("Unauthorized");
   });
 });
+
+describe("fetchContributionGuidelines in-flight dedup (#124)", () => {
+  it("concurrent same-repo callers share one probe round", async () => {
+    const resolvers: Array<(v: unknown) => void> = [];
+    const getContent = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const octokit = { repos: { getContent } } as unknown as Octokit;
+
+    const a = fetchContributionGuidelines(octokit, "dedup-org", "dedup-repo");
+    const b = fetchContributionGuidelines(octokit, "dedup-org", "dedup-repo");
+    // Let the probes register, then resolve every pending path
+    await new Promise((r) => setImmediate(r));
+    for (const resolve of resolvers) {
+      resolve({
+        data: {
+          content: Buffer.from("# Contributing\nUse eslint.").toString(
+            "base64",
+          ),
+        },
+      });
+    }
+
+    const [ga, gb] = await Promise.all([a, b]);
+    expect(getContent).toHaveBeenCalledTimes(4);
+    expect(ga!.linter).toBe("ESLint");
+    expect(gb!.linter).toBe("ESLint");
+  });
+});

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -163,6 +163,30 @@ export async function fetchContributionGuidelines(
     return cached.guidelines;
   }
 
+  // Concurrent vets of issues from one repo share a single probe (#124)
+  const inflight = guidelinesInflight.get(cacheKey);
+  if (inflight) return inflight;
+  const promise = fetchContributionGuidelinesUncached(octokit, owner, repo);
+  guidelinesInflight.set(cacheKey, promise);
+  try {
+    return await promise;
+  } finally {
+    guidelinesInflight.delete(cacheKey);
+  }
+}
+
+const guidelinesInflight = new Map<
+  string,
+  Promise<ContributionGuidelines | undefined>
+>();
+
+async function fetchContributionGuidelinesUncached(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<ContributionGuidelines | undefined> {
+  const cacheKey = `${owner}/${repo}`;
+
   const filesToCheck = [
     "CONTRIBUTING.md",
     ".github/CONTRIBUTING.md",

--- a/packages/core/src/core/roadmap.ts
+++ b/packages/core/src/core/roadmap.ts
@@ -123,6 +123,26 @@ export async function fetchRoadmapIssueRefs(
     return cached.refs;
   }
 
+  // Concurrent feature vets of issues from one repo share a probe (#124)
+  const inflight = roadmapInflight.get(cacheKey);
+  if (inflight) return inflight;
+  const promise = fetchRoadmapIssueRefsUncached(octokit, owner, repo, cacheKey);
+  roadmapInflight.set(cacheKey, promise);
+  try {
+    return await promise;
+  } finally {
+    roadmapInflight.delete(cacheKey);
+  }
+}
+
+const roadmapInflight = new Map<string, Promise<Set<number>>>();
+
+async function fetchRoadmapIssueRefsUncached(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  cacheKey: string,
+): Promise<Set<number>> {
   for (const path of ROADMAP_PATHS) {
     try {
       const { data } = await octokit.repos.getContent({ owner, repo, path });


### PR DESCRIPTION
## Summary
- New `withInflightDedup(cache, key, fn)`: concurrent same-key callers share one promise; the check-then-register pair has no intervening await so two callers cannot both miss; rejections propagate to every waiter and clear the slot
- `cachedRequest` refactored onto it (behavior-preserving, single registration spans the post-304 refetch); `cachedTimeBased` dedups its miss path with a re-check inside the window
- `checkUserMergedPRsInRepo` (the scarce Search-quota stampede), `fetchContributionGuidelines`, and `fetchRoadmapIssueRefs` all share probes across concurrent same-repo vets now; module inflight maps clean up in finally on throw paths too

## Test plan
- [x] 5 new tests: shared computation, rejection fan-out + slot clearing, cachedTimeBased stampede, guidelines concurrent probe sharing (4 probes total, not 8)
- [x] lint, format:check, typecheck, 838 core + 22 mcp green

Closes #124