### PR TITLE
fix(cli): honor the JSON contract for hints, validation, and setup

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -8,7 +8,11 @@ import { Command } from "commander";
 import { enableDebug } from "./core/logger.js";
 import { getCLIVersion } from "./core/utils.js";
 import { formatJsonSuccess, formatJsonError } from "./formatters/json.js";
-import { errorMessage, resolveErrorCode } from "./core/errors.js";
+import {
+  ValidationError,
+  errorMessage,
+  resolveErrorCode,
+} from "./core/errors.js";
 import {
   hasLocalState,
   loadLocalState,
@@ -131,7 +135,8 @@ program
       },
     ) => {
       try {
-        if (!hasLocalState()) {
+        if (!hasLocalState() && !options.json) {
+          // Human hint only: stdout must stay pure JSON under --json (#131)
           console.log(
             "💡 Run `oss-scout setup` to configure your preferences for personalized search results.\n",
           );
@@ -139,14 +144,14 @@ program
         const { runSearch } = await import("./commands/search.js");
         const maxResults = count ? parseInt(count, 10) : 10;
         if (isNaN(maxResults) || maxResults < 1) {
-          console.error("Error: count must be a positive integer");
-          process.exit(1);
+          throw new ValidationError("count must be a positive integer");
         }
         const state = loadLocalState();
         if (
           state.mergedPRs.length === 0 &&
           state.starredRepos.length === 0 &&
-          state.preferences.githubUsername
+          state.preferences.githubUsername &&
+          !options.json
         ) {
           console.log(
             "Run `oss-scout bootstrap` to import your starred repos and PR history for better results.\n",
@@ -165,13 +170,9 @@ program
             const parsed = SearchStrategySchema.safeParse(token);
             if (!parsed.success) {
               const valid = [...CONCRETE_STRATEGIES, "all"].join(", ");
-              console.error(
-                'Error: unknown strategy "' +
-                  token +
-                  '". Valid strategies: ' +
-                  valid,
+              throw new ValidationError(
+                `unknown strategy "${token}". Valid strategies: ${valid}`,
               );
-              process.exit(1);
             }
             strategies.push(parsed.data);
           }
@@ -189,10 +190,9 @@ program
         if (options.diversityRatio !== undefined) {
           const parsed = Number(options.diversityRatio);
           if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
-            console.error(
-              `Error: --diversity-ratio must be a number in [0, 1] (got "${options.diversityRatio}")`,
+            throw new ValidationError(
+              `--diversity-ratio must be a number in [0, 1] (got "${options.diversityRatio}")`,
             );
-            process.exit(1);
           }
           diversityRatio = parsed;
         }
@@ -278,17 +278,17 @@ program
         const { runFeatures } = await import("./commands/features.js");
         const maxResults = count ? parseInt(count, 10) : 10;
         if (isNaN(maxResults) || maxResults < 1 || maxResults > 50) {
-          console.error("Error: count must be an integer between 1 and 50");
-          process.exit(1);
+          throw new ValidationError(
+            "count must be an integer between 1 and 50",
+          );
         }
         let anchorThreshold: number | undefined;
         if (options.anchorThreshold !== undefined) {
           const parsed = parseInt(options.anchorThreshold, 10);
           if (isNaN(parsed) || parsed < 1 || parsed > 50) {
-            console.error(
-              "Error: --anchor-threshold must be an integer between 1 and 50",
+            throw new ValidationError(
+              "--anchor-threshold must be an integer between 1 and 50",
             );
-            process.exit(1);
           }
           anchorThreshold = parsed;
         }
@@ -296,10 +296,9 @@ program
         if (options.splitRatio !== undefined) {
           const parsed = Number.parseFloat(options.splitRatio);
           if (isNaN(parsed) || parsed < 0 || parsed > 1) {
-            console.error(
-              "Error: --split-ratio must be a number between 0 and 1",
+            throw new ValidationError(
+              "--split-ratio must be a number between 0 and 1",
             );
-            process.exit(1);
           }
           splitRatio = parsed;
         }
@@ -508,8 +507,7 @@ program
           options.concurrency !== undefined &&
           (isNaN(options.concurrency) || options.concurrency < 1)
         ) {
-          console.error("Error: --concurrency must be a positive integer");
-          process.exit(1);
+          throw new ValidationError("--concurrency must be a positive integer");
         }
         const { runVetList } = await import("./commands/vet-list.js");
         const state = loadLocalState();

--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -141,3 +141,32 @@ describe("runSetup", () => {
     expect(prefs.projectCategories).toEqual(["devtools"]);
   });
 });
+
+describe("non-interactive safety (#131)", () => {
+  it("fails fast without an injected rl when stdin is not a TTY", async () => {
+    // Under vitest, process.stdin.isTTY is falsy, which is exactly the
+    // CI/piped context the guard protects
+    await expect(runSetup({ detectUsername: async () => "" })).rejects.toThrow(
+      "interactive",
+    );
+  });
+
+  it("rejects instead of silently exiting when input ends mid-flow", async () => {
+    let closeListener: (() => void) | undefined;
+    const rl = {
+      question: (_q: string, _cb: (a: string) => void) => {
+        // Simulate piped stdin ending before any answer arrives
+        closeListener?.();
+      },
+      close: () => {},
+      on: (event: "close", listener: () => void) => {
+        if (event === "close") closeListener = listener;
+      },
+      off: () => {},
+    };
+
+    await expect(
+      runSetup({ rl, detectUsername: async () => "user" }),
+    ).rejects.toThrow("preferences were not saved");
+  });
+});

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -14,6 +14,7 @@ import {
   ProjectCategorySchema,
   IssueScopeSchema,
 } from "../core/schemas.js";
+import { ConfigurationError } from "../core/errors.js";
 
 const ALL_CATEGORIES =
   ProjectCategorySchema.options as readonly ProjectCategory[];
@@ -22,18 +23,40 @@ const ALL_SCOPES = IssueScopeSchema.options as readonly IssueScope[];
 interface ReadlineInterface {
   question(query: string, callback: (answer: string) => void): void;
   close(): void;
+  on?(event: "close", listener: () => void): unknown;
+  off?(event: "close", listener: () => void): unknown;
 }
 
 function createReadlineInterface(): ReadlineInterface {
+  // Prompts echo on stderr so stdout stays pure for --json output (#131)
   return readline.createInterface({
     input: process.stdin,
-    output: process.stdout,
+    output: process.stderr,
   });
 }
 
 function ask(rl: ReadlineInterface, query: string): Promise<string> {
-  return new Promise((resolve) => {
-    rl.question(query, (answer) => resolve(answer.trim()));
+  return new Promise((resolve, reject) => {
+    // Piped stdin that ends early used to leave the pending question
+    // unresolved: the event loop drained and the process exited 0 without
+    // saving anything (#131). Reject on close instead.
+    let settled = false;
+    const onClose = () => {
+      if (settled) return;
+      settled = true;
+      reject(
+        new ConfigurationError(
+          "Input ended before setup finished; preferences were not saved",
+        ),
+      );
+    };
+    rl.on?.("close", onClose);
+    rl.question(query, (answer) => {
+      if (settled) return;
+      settled = true;
+      rl.off?.("close", onClose);
+      resolve(answer.trim());
+    });
   });
 }
 
@@ -83,14 +106,23 @@ export interface SetupOptions {
 export async function runSetup(
   options?: SetupOptions,
 ): Promise<ScoutPreferences> {
+  // Fail fast in non-interactive contexts (CI, piped stdin): prompting
+  // would hang or silently save defaults (#131). Injected rl (tests, hosts)
+  // opts out of the guard.
+  if (!options?.rl && !process.stdin.isTTY) {
+    throw new ConfigurationError(
+      "setup is interactive and requires a terminal. Use `oss-scout config set <key> <value>` for non-interactive configuration.",
+    );
+  }
   const rl = options?.rl ?? createReadlineInterface();
   const detect = options?.detectUsername ?? detectGitHubUsername;
 
   try {
-    console.log("\n🔧 oss-scout setup\n");
+    // Interactive chrome goes to stderr; stdout stays pure for --json (#131)
+    console.error("\n🔧 oss-scout setup\n");
 
     // Detect GitHub username
-    console.log("Detecting GitHub username...");
+    console.error("Detecting GitHub username...");
     const detectedUsername = await detect();
     const usernameDefault = detectedUsername || "";
     const usernamePrompt = detectedUsername
@@ -156,7 +188,7 @@ export async function runSetup(
       minStars: isNaN(minStars) ? 50 : minStars,
     });
 
-    console.log("\n✅ Setup complete! Preferences saved.\n");
+    console.error("\n✅ Setup complete! Preferences saved.\n");
     return prefs;
   } finally {
     if (!options?.rl) {


### PR DESCRIPTION
## Summary
- First-run hint lines gated on `!options.json`: `search --json` stdout is pure JSON even on a fresh machine (the plugin's own scout.md parses this)
- All seven ad-hoc option validations (search count/strategy/diversity-ratio, features count/anchor-threshold/split-ratio, vet-list concurrency) throw `ValidationError` through `handleCommandError`; human output is byte-identical (the handler re-adds the "Error:" prefix)
- `setup`: fails fast with a CONFIGURATION envelope when stdin isn't a TTY and no rl is injected (tests/hosts bypass via injection); a mid-flow stream close rejects instead of silently exiting 0 unsaved; banners and readline prompt echo moved to stderr so stdout stays pure under --json

Smoke-verified on the built bundle: piped `setup --json` → `{success:false, errorCode:CONFIGURATION}` exit 1 (previously exit 0, nothing saved); `search abc --json` → `{success:false, errorCode:VALIDATION}` exit 1.

## Test plan
- [x] 2 new setup tests (non-TTY fail-fast under vitest, close-mid-flow rejection); existing 6 setup interaction tests unchanged
- [x] lint, format:check, typecheck, 840 core + 22 mcp green

Closes #131