### PR TITLE
fix(cli): document the -- escape for dash-prefixed config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ oss-scout config set languages "typescript,rust"    # set languages
 oss-scout config set minStars 100                   # minimum repo stars
 oss-scout config set includeDocIssues false          # exclude doc-only issues
 oss-scout config set excludeRepos "+spam/repo"       # append to exclude list
-oss-scout config set excludeRepos "-spam/repo"       # remove from exclude list
+oss-scout config set excludeRepos -- "-spam/repo"   # remove ("--" escapes the dash)
 oss-scout config reset                               # reset to defaults
 ```
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -450,7 +450,9 @@ const configCmd = program
 
 configCmd
   .command("set <key> <value>")
-  .description("Update a single preference (e.g. config set minStars 100)")
+  .description(
+    'Update a single preference (e.g. config set minStars 100). For dash-prefixed values like the array-remove form, escape with --: config set excludeRepos -- "-spam/repo"',
+  )
   .option("--json", "Output as JSON")
   .action(async (key: string, value: string, options: { json?: boolean }) => {
     try {

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -79,6 +79,13 @@ function parseArrayValue(value: string): string[] {
 
 /**
  * Apply an array update: plain set, +append, or -remove.
+ *
+ * The -remove form starts with a dash, which commander rejects as an
+ * unknown option unless escaped: `config set excludeRepos -- "-spam/repo"`.
+ * Documented in the CLI help and README (#132). Full pass-through parsing
+ * was evaluated and rejected: it breaks `config set k v --json` (trailing
+ * flag becomes a third operand) and, via the required program-level
+ * positional mode, `search 5 --debug`.
  */
 function updateArray(current: string[], value: string): string[] {
   if (value.startsWith("+")) {


### PR DESCRIPTION
## Summary
Documentation-only resolution, chosen on empirical evidence against the project's commander 14.0.3:
- `config set excludeRepos -- "-spam/repo"` already works natively (verified end-to-end on the built bundle: remove path executes, exit 0); README, `config set` help text, and the updateArray docstring now teach it
- `passThroughOptions` was evaluated and rejected: with the required program-level `enablePositionalOptions` chain it breaks `config set k v --json` (trailing flag becomes a third operand) and `search 5 --debug` (global flag after subcommand), both currently-working orderings; the rationale is recorded in the docstring so a future refactor doesn't naively re-add it

## Test plan
- [x] Reviewer independently reproduced all four parsing cases against commander 14.0.3
- [x] lint, format:check, typecheck, 840 core + 22 mcp green

Closes #132