### PR TITLE
fix(plugin): valid PreToolUse hook JSON and a jq guard

### DIFF
--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -14,14 +14,18 @@ warn_and_exit() {
   cat <<WARN_EOF
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "allow",
-    "updatedInput": {}
+    "permissionDecisionReason": "Auto-format hook: ${msg}"
   },
   "systemMessage": "Auto-format hook: ${msg}"
 }
 WARN_EOF
   exit 0
 }
+
+# jq is required to parse the hook payload (#144); degrade to a no-op
+command -v jq >/dev/null 2>&1 || exit 0
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
@@ -133,8 +137,9 @@ fi
 cat <<EOF
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "allow",
-    "updatedInput": {}
+    "permissionDecisionReason": "Auto-formatted changed files (${format_result}) and committed before the push."
   },
   "systemMessage": "Auto-formatted changed files (${format_result}) and committed as 'style: auto-format before push'. The push will include this formatting commit."
 }

--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+# jq is required to parse the hook payload; without it every Bash call in a
+# session would surface a hook failure (#144). Degrade to a no-op instead.
+command -v jq >/dev/null 2>&1 || exit 0
+
 input=$(cat)
 
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
@@ -23,10 +27,11 @@ if echo "$command" | grep -qE 'git\s+push\b' && echo "$command" | grep -qE '(\s-
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "updatedInput": {}
+    "permissionDecisionReason": "Never use `git push --force`. Use `git push --force-with-lease` instead — it prevents overwriting commits pushed by others. Before pushing, always fetch the remote branch first: `git fetch <remote> <branch>`."
   },
-  "systemMessage": "BLOCKED: Never use `git push --force`. Use `git push --force-with-lease` instead — it prevents overwriting commits pushed by others. Before pushing, always fetch the remote branch first: `git fetch <remote> <branch>`."
+  "systemMessage": "BLOCKED: bare git push --force. Use --force-with-lease after fetching the remote branch."
 }
 EOF
   exit 0
@@ -37,10 +42,10 @@ if echo "$command" | grep -qE 'git\s+rebase\b'; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "updatedInput": {}
-  },
-  "systemMessage": "Before rebasing, you MUST fetch the remote tracking branch to avoid overwriting commits pushed by others (e.g. maintainer cleanup commits). Run `git fetch <remote> <branch>` first and verify no new remote commits exist. If the remote has commits you don't have locally, incorporate them before rebasing."
+    "permissionDecisionReason": "Before rebasing, you MUST fetch the remote tracking branch to avoid overwriting commits pushed by others (e.g. maintainer cleanup commits). Run `git fetch <remote> <branch>` first and verify no new remote commits exist. If the remote has commits you don't have locally, incorporate them before rebasing."
+  }
 }
 EOF
   exit 0
@@ -51,10 +56,10 @@ if echo "$command" | grep -qE 'git\s+push\b.*--force-with-lease'; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "updatedInput": {}
-  },
-  "systemMessage": "Before force-pushing (even with --force-with-lease), verify you fetched the remote branch and incorporated any new commits. Maintainers may push directly to your PR branch. If you haven't fetched, --force-with-lease may still overwrite their work if your local remote-tracking ref is stale."
+    "permissionDecisionReason": "Before force-pushing (even with --force-with-lease), verify you fetched the remote branch and incorporated any new commits. Maintainers may push directly to your PR branch. If you haven't fetched, --force-with-lease may still overwrite their work if your local remote-tracking ref is stale."
+  }
 }
 EOF
   exit 0


### PR DESCRIPTION
## Summary
- All five hook heredocs emit the documented PreToolUse shape: `hookEventName` + `permissionDecision` + `permissionDecisionReason` (reviewer verified verbatim against current hooks docs); the force-push deny is now actually honored
- `deny` keeps a short top-level `systemMessage` (the user-visible channel; the reason goes to the model); the two `ask` cases rely on the reason, which the confirmation prompt displays
- `updatedInput: {}` removed everywhere (it would replace the Bash command with nothing under a lenient parser)
- `command -v jq || exit 0` guards both scripts: missing jq degrades to a no-op instead of erroring every Bash call under `set -euo pipefail`

## Test plan
- [x] jq assertions on live hook output: deny case has hookEventName and no updatedInput; ask case parses; non-git commands exit silently; `bash -n` clean on both scripts
- [x] Full suite green (840 core + 22 mcp), lint, format:check

Closes #144