### PR TITLE
fix(plugin): harden the session-start hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
-            "timeout": 15
+            "timeout": 120
           }
         ]
       }

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -10,21 +10,42 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 messages=""
 NL=$'\n'
 
+# Install + bundle. Prefers pnpm with the committed lockfile; falls back to
+# npm. Scripts are ignored either way (pnpm 10 blocks dependency lifecycle
+# scripts by default and the bundle builds fine in CI under that policy, so
+# a tampered transitive dependency cannot execute code at session start;
+# esbuild's binary ships via optional dependencies, no postinstall needed)
+# (#146).
+build_bundle() {
+  if command -v pnpm >/dev/null 2>&1 && [ -f "${PLUGIN_ROOT}/pnpm-lock.yaml" ]; then
+    (cd "${PLUGIN_ROOT}" \
+      && pnpm install --frozen-lockfile --silent 2>/dev/null \
+      && pnpm --filter @oss-scout/core run bundle --silent 2>/dev/null)
+  else
+    (cd "${PLUGIN_ROOT}/packages/core" \
+      && npm install --silent --ignore-scripts 2>/dev/null \
+      && npm run bundle --silent 2>/dev/null)
+  fi
+}
+
+BUNDLE="${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs"
+BUILD_HINT="Run: cd ${PLUGIN_ROOT} && pnpm install && pnpm --filter @oss-scout/core run bundle"
+
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---
-if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
-  if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null); then
+if [ -f "$BUNDLE" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "$BUNDLE" ]; then
+  if build_bundle; then
     messages="CLI bundle rebuilt after plugin update."
   else
-    messages="Warning: CLI bundle rebuild failed. Run: cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+    messages="Warning: CLI bundle rebuild failed. ${BUILD_HINT}"
   fi
 fi
 
 # --- Step 2: Build CLI bundle if missing ---
-if [ ! -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
-  if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null); then
+if [ ! -f "$BUNDLE" ]; then
+  if build_bundle; then
     messages="${messages:+${messages}${NL}}CLI bundle built successfully."
   else
-    messages="${messages:+${messages}${NL}}Warning: CLI bundle build failed. Run: cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+    messages="${messages:+${messages}${NL}}Warning: CLI bundle build failed. ${BUILD_HINT}"
   fi
 fi
 
@@ -42,10 +63,16 @@ if [ -n "$CURRENT" ]; then
 
   if [ "$should_check" = true ]; then
     mkdir -p "${HOME}/.oss-scout"
-    LATEST=$(gh api repos/costajohnt/oss-scout/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^[^0-9]*//' || echo "")
+    # release-please cuts per-component tags (core-vX, mcp-server-vY) and
+    # the releases API is publish-date ordered, not version ordered, so
+    # take the semver max of the core releases specifically (#146)
+    LATEST=$(gh api repos/costajohnt/oss-scout/releases --jq '.[].tag_name' 2>/dev/null | sed -n 's/^core-v//p' | sort -V | tail -1 || echo "")
     if [ -n "$LATEST" ] && echo "$LATEST" | grep -qE '^[0-9]+\.'; then
       touch "$LAST_CHECK"
-      if [ "$LATEST" != "$CURRENT" ]; then
+      # Nag only when the release is strictly newer than the local version;
+      # inequality alone nagged users running ahead of the latest release
+      newest=$(printf '%s\n%s\n' "$CURRENT" "$LATEST" | sort -V | tail -1)
+      if [ "$LATEST" != "$CURRENT" ] && [ "$newest" = "$LATEST" ]; then
         messages="${messages:+${messages}${NL}}oss-scout v${LATEST} available (you have v${CURRENT}). Run: /plugin update oss-scout"
       fi
     fi


### PR DESCRIPTION
## Summary
- `hooks.json` SessionStart timeout 15 → 120: cold install+bundle exceeded 15s and was killed silently
- New `build_bundle()` (dedupes the two copy-pasted blocks): `pnpm install --frozen-lockfile` at the plugin root when available (pnpm 10 blocks dependency lifecycle scripts by default, matching CI; `onlyBuiltDependencies: [esbuild]` already allowlists the one needed build), else `npm install --ignore-scripts` in packages/core (no package-lock there, so npm ci is impossible; esbuild verified working script-free via optional-dep binaries)
- Update check: semver max of `core-v*` releases (the API is publish-date ordered: core-v0.9.1 lists before core-v0.11.0 live) and nags only when strictly newer; verified live that local 0.11.0 vs max 0.11.0 produces no nag. Failure mode is fail-safe: any pipe failure empties LATEST and skips the check

## Test plan
- [x] bash -n clean; live verification of the tag query and nag direction logic; reviewer empirically verified the script-free esbuild install and macOS sort -V support
- [x] Full suite green (840 core + 22 mcp), lint, format:check

Closes #146