### PR TITLE
fix(mcp): stop the 60s tool timeout firing on every default search

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -961,6 +961,36 @@ describe("IssueDiscovery", () => {
       expect(sleep).toHaveBeenCalledWith(60000);
     });
 
+    it("per-call delay overrides take precedence over preferences (#143)", async () => {
+      const phase0Candidates = [
+        makeCandidate("org/merged-1", "merged_pr"),
+        makeCandidate("org/merged-2", "merged_pr"),
+      ];
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: phase0Candidates,
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      // Preferences say 30s/90s, but the per-call override is 0/0
+      const discovery = makeDiscovery(
+        { getReposWithMergedPRs: vi.fn(() => ["org/merged-1"]) },
+        { interPhaseDelayMs: 30000, broadPhaseDelayMs: 90000 },
+      );
+
+      await discovery.searchIssues({
+        maxResults: 10,
+        interPhaseDelayMs: 0,
+        broadPhaseDelayMs: 0,
+      });
+
+      // No delay sleep fired with either the preference value or the broad value
+      const sleepArgs = vi.mocked(sleep).mock.calls.map((c) => c[0]);
+      expect(sleepArgs).not.toContain(30000);
+      expect(sleepArgs).not.toContain(90000);
+    });
+
     it("skips delay when previous phases found 0 results", async () => {
       // No Phase 0/1 candidates, so Phase 2 should run without the broad delay
       mockFetchIssuesFromKnownRepos.mockResolvedValue({

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -504,6 +504,8 @@ export class IssueDiscovery {
       preferLanguages?: string[];
       preferRepos?: string[];
       diversityRatio?: number;
+      interPhaseDelayMs?: number;
+      broadPhaseDelayMs?: number;
     } = {},
   ): Promise<{
     candidates: IssueCandidate[];
@@ -517,7 +519,8 @@ export class IssueDiscovery {
       (scopes ? buildEffectiveLabels(scopes, config.labels) : config.labels);
     const maxResults = options.maxResults || 10;
     const minStars = config.minStars ?? 50;
-    const interPhaseDelay = config.interPhaseDelayMs ?? 30000;
+    const interPhaseDelay =
+      options.interPhaseDelayMs ?? config.interPhaseDelayMs ?? 30000;
 
     // Strategy selection. Empty arrays count as "unset" so a stored
     // defaultStrategy of [] can't silently produce zero-strategy searches.
@@ -691,7 +694,8 @@ export class IssueDiscovery {
     }
 
     // Phase 2: General search (with rate limit mitigation)
-    const broadDelay = config.broadPhaseDelayMs ?? 90000;
+    const broadDelay =
+      options.broadPhaseDelayMs ?? config.broadPhaseDelayMs ?? 90000;
     // Clamp to maxResults - 1: the phase gate below already skips the whole
     // phase at >= maxResults, so any larger threshold would be unsatisfiable
     // (the default 15 vs default maxResults 10 made this dead config). 0

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -244,6 +244,19 @@ export interface SearchOptions {
    * clamped to [0, 1].
    */
   diversityRatio?: number;
+  /**
+   * Per-call override for the delay between search phases (ms). Defaults to
+   * the `interPhaseDelayMs` preference (30s). Latency-sensitive callers like
+   * the MCP server pass 0; the sliding-window budget tracker still paces the
+   * actual API calls, so the fixed sleep is the only thing removed (#143).
+   */
+  interPhaseDelayMs?: number;
+  /**
+   * Per-call override for the extra cooldown before the broad phase (ms).
+   * Defaults to the `broadPhaseDelayMs` preference (90s). See
+   * `interPhaseDelayMs` for the rationale (#143).
+   */
+  broadPhaseDelayMs?: number;
 }
 
 /** Result of a search operation. */

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -215,6 +215,8 @@ export class OssScout implements ScoutStateReader {
       preferLanguages: options?.preferLanguages,
       preferRepos: options?.preferRepos,
       diversityRatio: options?.diversityRatio,
+      interPhaseDelayMs: options?.interPhaseDelayMs,
+      broadPhaseDelayMs: options?.broadPhaseDelayMs,
     });
 
     this.state.lastSearchAt = new Date().toISOString();

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -151,14 +151,20 @@ describe("registerTools", () => {
       expect(parsed.candidates[0].issue.repo).toBe("test/repo");
     });
 
-    it("calls scout.search with parsed options", async () => {
+    it("calls scout.search with parsed options and zero inter-phase delays (#143)", async () => {
       const handler = getToolHandler(server, "search");
       await handler({ maxResults: 3, strategies: "broad,merged" }, {});
 
-      expect(scout.search).toHaveBeenCalledWith({
-        maxResults: 3,
-        strategies: ["broad", "merged"],
-      });
+      expect(scout.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxResults: 3,
+          strategies: ["broad", "merged"],
+          // MCP runs in a request/response context, so the fixed phase
+          // sleeps that would blow the tool timeout are disabled
+          interPhaseDelayMs: 0,
+          broadPhaseDelayMs: 0,
+        }),
+      );
     });
 
     it("saves results and checkpoints after search", async () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -9,7 +9,9 @@ import {
   validateUrl,
 } from "@oss-scout/core";
 
-const TOOL_TIMEOUT_MS = 60000;
+// Generous ceiling: even with inter-phase delays zeroed, vetting many issues
+// under the budget tracker's sliding-window pacing can take minutes (#143).
+const TOOL_TIMEOUT_MS = 300000;
 
 function withTimeout<T>(
   promise: Promise<T>,
@@ -82,6 +84,10 @@ export function registerTools(server: McpServer, scout: OssScout): void {
             preferLanguages,
             preferRepos,
             diversityRatio,
+            // No fixed inter-phase sleeps in the request/response MCP context;
+            // the budget tracker still paces the GitHub calls (#143)
+            interPhaseDelayMs: 0,
+            broadPhaseDelayMs: 0,
           }),
         );
 


### PR DESCRIPTION
## Summary
- New optional `interPhaseDelayMs` / `broadPhaseDelayMs` on `SearchOptions` (and the `searchIssues` options object); default to the existing preference, override wins when set. Additive and non-breaking for provided-mode consumers (verified: omitted → `undefined` → preference/default)
- The MCP `search` tool passes `0/0`: the 30s+90s fixed inter-phase sleeps (the thing that blew the 60s timeout) are gone, while the budget tracker's sliding window and the 2s per-call `INTER_QUERY_DELAY_MS` still pace the actual GitHub calls, plus ThrottledOctokit's secondary-rate-limit retry backstop
- `TOOL_TIMEOUT_MS` 60000 → 300000 as a generous ceiling so normal searches (now seconds to low tens of seconds) never trip it

Out of scope, flagged: fully cancelling the search on timeout needs an AbortSignal through IssueDiscovery; with the timeout effectively no longer firing for normal searches, the bare Promise.race leak is off the hot path.

## Test plan
- [x] Discovery test: `0/0` overrides suppress the preference-valued (30s/90s) phase sleeps
- [x] MCP test: search receives `interPhaseDelayMs:0`/`broadPhaseDelayMs:0`
- [x] lint, format:check, typecheck, 843 core + 22 mcp green

Closes #143