### PR TITLE
fix(mcp): make the package import side-effect-free

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "bundle": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/mcp-server.bundle.cjs",
+    "bundle": "esbuild src/bin.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/mcp-server.bundle.cjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/mcp-server/src/bin.ts
+++ b/packages/mcp-server/src/bin.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * Executable entry for the `oss-scout-mcp` binary. The shebang lives here
+ * (this is the esbuild bundle entry); importing the package (`index.ts`)
+ * stays side-effect-free (#148).
+ */
+import { runServer } from "./index.js";
+
+runServer().catch((err) => {
+  process.stderr.write(
+    `oss-scout-mcp fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Importing the package entry must have no side effects: no server boot,
+// no token read, no process.exit (#148).
+describe("@oss-scout/mcp library import", () => {
+  it("exposes the library surface without running anything", async () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    const mod = await import("./index.js");
+
+    expect(typeof mod.createServer).toBe("function");
+    expect(typeof mod.registerTools).toBe("function");
+    expect(typeof mod.registerResources).toBe("function");
+    expect(typeof mod.runServer).toBe("function");
+    expect(mod.SERVER_INFO.name).toBe("oss-scout-mcp");
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("createServer wires a server without connecting a transport", async () => {
+    const { createServer } = await import("./index.js");
+    const scout = {
+      search: vi.fn(),
+      vetIssue: vi.fn(),
+      features: vi.fn(),
+      getPreferences: vi.fn(() => ({})),
+      getSavedResults: vi.fn(() => []),
+      getState: vi.fn(() => ({ repoScores: {} })),
+    } as unknown as Parameters<typeof createServer>[0];
+    const server = createServer(scout);
+    expect(server).toBeDefined();
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,37 +1,53 @@
-#!/usr/bin/env node
+/**
+ * Library entry point for @oss-scout/mcp.
+ *
+ * Importing this module has NO side effects: it does not start a server,
+ * read a token, or call process.exit (#148). The executable lives in
+ * `bin.ts`, which the published `oss-scout-mcp` binary bundles.
+ */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createScout, getGitHubToken } from "@oss-scout/core";
 import { registerTools } from "./tools.js";
 import { registerResources } from "./resources.js";
 
-async function main(): Promise<void> {
-  const token = getGitHubToken();
-  if (!token) {
-    process.stderr.write(
-      "oss-scout-mcp: GitHub token required.\n" +
-        "Set GITHUB_TOKEN or run `gh auth login`.\n",
-    );
-    process.exit(1);
-  }
+export { registerTools } from "./tools.js";
+export { registerResources } from "./resources.js";
 
-  const scout = await createScout({ githubToken: token });
+/** Server identity, kept in one place for the bin and any embedding host. */
+export const SERVER_INFO = {
+  name: "oss-scout-mcp",
+  version: "0.8.0", // x-release-please-version
+} as const;
 
+/**
+ * Build a fully-wired MCP server (tools + resources) around a scout.
+ * Side-effect-free: the caller owns transport and lifecycle.
+ */
+export function createServer(
+  scout: Parameters<typeof registerTools>[1],
+): McpServer {
   const server = new McpServer(
-    { name: "oss-scout-mcp", version: "0.8.0" }, // x-release-please-version
+    { name: SERVER_INFO.name, version: SERVER_INFO.version },
     { capabilities: { resources: {}, tools: {} } },
   );
-
   registerTools(server, scout);
   registerResources(server, scout);
-
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  return server;
 }
 
-main().catch((err) => {
-  process.stderr.write(
-    `oss-scout-mcp fatal: ${err instanceof Error ? err.message : String(err)}\n`,
-  );
-  process.exit(1);
-});
+/**
+ * Boot the stdio MCP server: resolve a token, build the scout, and connect.
+ * Throws on a missing token (the bin maps that to a stderr message + exit).
+ */
+export async function runServer(): Promise<void> {
+  const token = getGitHubToken();
+  if (!token) {
+    throw new Error(
+      "GitHub token required. Set GITHUB_TOKEN or run `gh auth login`.",
+    );
+  }
+  const scout = await createScout({ githubToken: token });
+  const server = createServer(scout);
+  await server.connect(new StdioServerTransport());
+}


### PR DESCRIPTION
## Summary
- `src/index.ts` is now a pure library entry: exports `registerTools`, `registerResources`, `createServer`, `runServer`, `SERVER_INFO`; no top-level execution, no token read, no shebang
- New `src/bin.ts` carries the shebang + `runServer().catch(stderr + exit)`; the bundle script targets it, so the published `oss-scout-mcp` binary is unchanged (shebang verified at the head of the cjs bundle)
- The `x-release-please-version` constant stayed in index.ts (now on `SERVER_INFO`), so the generic extra-file tracking still matches

Verified: `import` of dist/index.js exposes the surface and boots nothing / calls no exit (live node check + new test). Behavior of the binary is end-to-end equivalent (missing token still → stderr + exit 1, via the bin's catch).

## Test plan
- [x] New tests: import exposes the library surface with process.exit never called; createServer wires a server without a transport
- [x] lint, format:check, typecheck, 843 core + 24 mcp green

Closes #148