### PR TITLE
ci: cover the mcp-server package and build before checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Build first so @oss-scout/mcp's typecheck, tests, and bundle resolve
+      # @oss-scout/core through its published dist/ (the artifact consumers
+      # actually get), not a stale or missing build (#149).
+      - name: Build
+        run: pnpm -r run build
+
       - name: Lint
         run: pnpm run lint
 
@@ -32,13 +38,13 @@ jobs:
         run: pnpm run format:check
 
       - name: Typecheck
-        run: pnpm --filter @oss-scout/core run typecheck
+        run: pnpm -r run typecheck
 
       - name: Test with coverage
-        run: pnpm --filter @oss-scout/core run test:coverage
+        run: pnpm -r run test:coverage
 
       - name: Bundle
-        run: pnpm --filter @oss-scout/core run bundle
+        run: pnpm -r run bundle
 
   # Advisory-only: a new transitive advisory should not block unrelated PRs.
   # Failures surface as a red job here without failing required checks.


### PR DESCRIPTION
## Summary
- New `Build` step (`pnpm -r run build`) before lint/typecheck/test/bundle: core's `dist/` exists before mcp-server resolves `@oss-scout/core` through it (the published artifact), in pnpm's topo order
- Typecheck, test:coverage, and bundle switched from `--filter @oss-scout/core` to `pnpm -r run`, so a core API break now fails CI instead of silently publishing a broken `@oss-scout/mcp`
- The first attempt used a vitest src-alias; review caught that it left mcp typecheck/bundle red on a fresh checkout (no build step) and decoupled the tested artifact from the shipped one. Dropped the alias and added the build step so tests run against `dist/` too.

## Test plan
- [x] Reproduced a fresh CI checkout (deleted both packages' `dist/`): build → typecheck → test → bundle all pass; before the build step, mcp typecheck (TS2307) and bundle ("Could not resolve") failed
- [x] lint, format:check green

Closes #149