### PR TITLE
fix(core): default createScout to local persistence instead of throwaway state

### DIFF
--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -199,17 +199,21 @@ export interface VetListResult {
 /** Configuration for creating an OssScout instance. */
 export type ScoutConfig =
   | {
-      /** GitHub token with `repo` read scope. Add `gist` scope for persistence. */
+      /** GitHub token with `repo` read scope. Add `gist` scope for gist persistence. */
       githubToken: string;
-      /** Use gist-backed persistence (default for standalone CLI). */
-      persistence?: "gist";
-      /** Gist ID override. Skips gist discovery/creation if provided. */
+      /**
+       * State storage. Omitted defaults to `"local"`: load and persist
+       * `~/.oss-scout/state.json`, no network on construct. `"gist"` syncs
+       * via a private GitHub gist (needs the `gist` token scope).
+       */
+      persistence?: "local" | "gist";
+      /** Gist ID override (gist mode). Skips gist discovery/creation if provided. */
       gistId?: string;
     }
   | {
       /** GitHub token with `repo` read scope. */
       githubToken: string;
-      /** Caller provides state directly. */
+      /** Caller provides and owns state directly (embedding hosts). */
       persistence: "provided";
       /** Pre-loaded state. Required when persistence is 'provided'. */
       initialState: ScoutState;

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createScout, OssScout } from "./scout.js";
 import { ScoutStateSchema } from "./core/schemas.js";
 import type { ScoutState } from "./core/schemas.js";
@@ -13,6 +13,21 @@ vi.mock("./core/feature-discovery.js", async (importOriginal) => {
 });
 
 import { discoverFeatures } from "./core/feature-discovery.js";
+
+// In-memory local-state stub so the default ("local") createScout path is
+// hermetic and never touches the developer's real ~/.oss-scout/state.json.
+// Tests seed `localStateStore.current` (see beforeEach) with a parsed state.
+const localStateStore = vi.hoisted(() => ({ current: null as unknown }));
+vi.mock("./core/local-state.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./core/local-state.js")>();
+  return {
+    ...actual,
+    loadLocalState: vi.fn(() => localStateStore.current),
+    saveLocalState: vi.fn((s: unknown) => {
+      localStateStore.current = s;
+    }),
+  };
+});
 
 // Stub the shared cache singleton so cache-burning entry points
 // (search/features/vetList) never touch the real ~/.oss-scout/cache in tests.
@@ -32,10 +47,37 @@ function makeState(overrides: Partial<ScoutState> = {}): ScoutState {
 }
 
 describe("createScout", () => {
-  it("creates instance with default state", async () => {
+  beforeEach(() => {
+    localStateStore.current = ScoutStateSchema.parse({ version: 1 });
+  });
+
+  it("default (local) mode loads local state, not throwaway in-memory (#116)", async () => {
+    // The stored local state carries a real preference; the default scout
+    // must surface it rather than silently starting from blank defaults
+    localStateStore.current = ScoutStateSchema.parse({
+      version: 1,
+      preferences: { githubUsername: "stored-user" },
+    });
     const scout = await createScout({ githubToken: "test-token" });
     expect(scout).toBeInstanceOf(OssScout);
-    expect(scout.getState().version).toBe(1);
+    expect(scout.getPreferences().githubUsername).toBe("stored-user");
+  });
+
+  it("default (local) mode persists on checkpoint (#116)", async () => {
+    const { saveLocalState } = await import("./core/local-state.js");
+    const scout = await createScout({ githubToken: "test-token" });
+    scout.recordMergedPR({
+      url: "https://github.com/o/r/pull/1",
+      title: "t",
+      mergedAt: "2026-01-01T00:00:00Z",
+      repo: "o/r",
+    });
+    const ok = await scout.checkpoint();
+    expect(ok).toBe(true);
+    expect(saveLocalState).toHaveBeenCalled();
+    // The saved state actually contains the recorded PR (not a no-op success)
+    const saved = localStateStore.current as ScoutState;
+    expect(saved.mergedPRs).toHaveLength(1);
   });
 
   it("creates instance with provided state", async () => {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -13,7 +13,6 @@ import {
   discoverFeaturesBroad,
   type FeatureSearchResult,
 } from "./core/feature-discovery.js";
-import { ScoutStateSchema } from "./core/schemas.js";
 import type {
   ScoutState,
   ScoutPreferences,
@@ -43,7 +42,7 @@ import type {
 } from "./core/gist-state-store.js";
 import { getOctokit } from "./core/github.js";
 import type { Octokit } from "@octokit/rest";
-import { loadLocalState } from "./core/local-state.js";
+import { loadLocalState, saveLocalState } from "./core/local-state.js";
 import { warn } from "./core/logger.js";
 import { extractRepoFromUrl } from "./core/utils.js";
 import {
@@ -137,6 +136,8 @@ export async function createScout(config: ScoutConfig): Promise<OssScout> {
   let state: ScoutState;
   let gistStore: GistStateStore | null = null;
 
+  let persistLocal = false;
+
   if (config.persistence === "provided") {
     state = config.initialState;
   } else if (config.persistence === "gist") {
@@ -155,10 +156,16 @@ export async function createScout(config: ScoutConfig): Promise<OssScout> {
       state.gistId = result.gistId;
     }
   } else {
-    state = ScoutStateSchema.parse({ version: 1 });
+    // Default: local-file persistence. The previous else-branch silently
+    // created throwaway in-memory state, so a documented standalone scout
+    // (and the MCP server) read no preferences and persisted nothing while
+    // checkpoint() reported success (#116). Load the real state and save it
+    // on checkpoint.
+    state = loadLocalState();
+    persistLocal = true;
   }
 
-  return new OssScout(config.githubToken, state, gistStore);
+  return new OssScout(config.githubToken, state, gistStore, { persistLocal });
 }
 
 /**
@@ -171,12 +178,17 @@ export class OssScout implements ScoutStateReader {
   private state: ScoutState;
   private dirty = false;
 
+  /** When true, checkpoint() also writes ~/.oss-scout/state.json. */
+  private persistLocal: boolean;
+
   constructor(
     private githubToken: string,
     initialState: ScoutState,
     private gistStore: GistStateStore | null = null,
+    opts: { persistLocal?: boolean } = {},
   ) {
     this.state = initialState;
+    this.persistLocal = opts.persistLocal ?? false;
   }
 
   // ── Search ──────────────────────────────────────────────────────────
@@ -731,6 +743,17 @@ export class OssScout implements ScoutStateReader {
     if (this.gistStore) {
       const ok = await this.gistStore.push(this.state);
       if (!ok) return false;
+    }
+
+    if (this.persistLocal) {
+      // Honest persistence: in local mode the previous no-op return true
+      // claimed success while saving nothing (#116). A failed write keeps
+      // the dirty flag and reports failure.
+      try {
+        saveLocalState(this.state);
+      } catch {
+        return false;
+      }
     }
 
     this.dirty = false;


### PR DESCRIPTION
## Summary
- New `"local"` persistence mode; `ScoutConfig` first variant is now `persistence?: "local" | "gist"` and an omitted value defaults to local (no network on construct, the `persistence` preference enum already implied this default)
- `createScout` in local/omitted mode loads `~/.oss-scout/state.json` and constructs `OssScout` with `persistLocal: true`; `checkpoint()` then writes the file and returns false (keeping the dirty flag) on a write failure, replacing the old no-op `return true`
- Removed the amnesiac `ScoutStateSchema.parse({version:1})` branch
- Incidentally repairs the stateless MCP server (#113): its bare-token `createScout` now reads preferences and persists

Non-breaking (reviewer-verified): the `provided` path is byte-identical (oss-autopilot uses it explicitly), the union widening is additive, the new constructor param is optional, and gist/local never both fire.

## Test plan
- [x] scout.test.ts mocks local-state in-memory (hermetic); new tests: default mode surfaces stored prefs, and persists the recorded PR on checkpoint (asserts the saved state actually contains it, proving the no-op success is gone)
- [x] lint, format:check, typecheck, 844 core + 24 mcp green

Closes #116