### PR TITLE
fix(mcp): persist server state and report persistence honestly

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -47,7 +47,9 @@ export async function runServer(): Promise<void> {
       "GitHub token required. Set GITHUB_TOKEN or run `gh auth login`.",
     );
   }
-  const scout = await createScout({ githubToken: token });
+  // Local persistence: read and write ~/.oss-scout/state.json so the server
+  // sees the user's preferences and history and survives restarts (#113).
+  const scout = await createScout({ githubToken: token, persistence: "local" });
   const server = createServer(scout);
   await server.connect(new StdioServerTransport());
 }

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -83,6 +83,37 @@ describe("registerTools", () => {
     expect(names).toContain("scout-features");
   });
 
+  describe("persistence reporting (#113)", () => {
+    it("persists a skip add via checkpoint and reports no warning on success", async () => {
+      const checkpoint = vi.fn().mockResolvedValue(true);
+      const local = createMockScout({ checkpoint } as Partial<OssScout>);
+      const localServer = new McpServer({ name: "t", version: "0.0.1" });
+      vi.spyOn(localServer, "tool");
+      registerTools(localServer, local);
+      const handler = getToolHandler(localServer, "skip");
+      const result = (await handler(
+        { action: "add", issueUrl: "https://github.com/o/r/issues/1" },
+        {},
+      )) as { content: Array<{ text: string }> };
+      expect(checkpoint).toHaveBeenCalled();
+      expect(result.content[0].text).not.toContain("failed to persist");
+    });
+
+    it("warns that nothing was persisted when checkpoint fails", async () => {
+      const local = createMockScout({
+        checkpoint: vi.fn().mockResolvedValue(false),
+      } as Partial<OssScout>);
+      const localServer = new McpServer({ name: "t", version: "0.0.1" });
+      vi.spyOn(localServer, "tool");
+      registerTools(localServer, local);
+      const handler = getToolHandler(localServer, "skip");
+      const result = (await handler({ action: "clear" }, {})) as {
+        content: Array<{ text: string }>;
+      };
+      expect(result.content[0].text).toContain("failed to persist");
+    });
+  });
+
   describe("skip tool execution", () => {
     it("rejects invalid issue URLs on add and surfaces isError", async () => {
       const handler = getToolHandler(server, "skip");

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -228,7 +228,9 @@ export function registerTools(server: McpServer, scout: OssScout): void {
           const count = scout.getSkippedIssues().length;
           scout.clearSkippedIssues();
           const synced = await scout.checkpoint();
-          const syncNote = synced ? "" : " (saved locally, gist sync failed)";
+          const syncNote = synced
+            ? ""
+            : " (warning: failed to persist to disk)";
           return {
             content: [
               {
@@ -248,7 +250,9 @@ export function registerTools(server: McpServer, scout: OssScout): void {
             .some((s) => s.url === issueUrl);
           scout.unskipIssue(issueUrl!);
           const synced = await scout.checkpoint();
-          const syncNote = synced ? "" : " (saved locally, gist sync failed)";
+          const syncNote = synced
+            ? ""
+            : " (warning: failed to persist to disk)";
           return {
             content: [
               {
@@ -289,7 +293,7 @@ export function registerTools(server: McpServer, scout: OssScout): void {
           : undefined;
         scout.skipIssue(issueUrl!, metadata);
         const synced = await scout.checkpoint();
-        const syncNote = synced ? "" : " (saved locally, gist sync failed)";
+        const syncNote = synced ? "" : " (warning: failed to persist to disk)";
         return {
           content: [{ type: "text", text: `Skipped: ${issueUrl}${syncNote}` }],
         };


### PR DESCRIPTION
## Summary
- The MCP server's `createScout` is now explicit about `persistence: "local"` at the call site that previously hit the silent amnesiac fallback (the prior local-default PR already made it persist; this documents the contract where it was violated)
- The three skip-tool status notes drop the backwards "(saved locally, gist sync failed)" — in local mode there is no gist and a false checkpoint means the local save threw, so nothing was saved — replaced with "(warning: failed to persist to disk)"

Reviewer flagged a pre-existing, out-of-scope gap: `search`/`scout-features`/`config-set` await checkpoint but discard the boolean, silently swallowing a persist failure. Filing a follow-up rather than expanding this PR's blast radius.

## Test plan
- [x] Two new MCP tests: skip add persists via checkpoint with no warning on success; skip clear with checkpoint→false surfaces the persist-failure warning (exercises two of the three reworded sites)
- [x] lint, format:check, typecheck, 844 core + 26 mcp green

Closes #113