### PR TITLE
fix(cli): honor the gist persistence preference in commands

### DIFF
--- a/packages/core/src/commands/command-scout.test.ts
+++ b/packages/core/src/commands/command-scout.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ScoutStateSchema } from "../core/schemas.js";
+
+const createScoutMock = vi.hoisted(() => vi.fn());
+vi.mock("../scout.js", () => ({
+  createScout: createScoutMock,
+}));
+
+import { buildCommandScout } from "./command-scout.js";
+
+describe("buildCommandScout (#115)", () => {
+  beforeEach(() => {
+    createScoutMock.mockReset();
+    createScoutMock.mockResolvedValue({});
+  });
+
+  it("uses gist mode when the persistence preference is gist", async () => {
+    const state = ScoutStateSchema.parse({
+      version: 1,
+      preferences: { persistence: "gist" },
+    });
+    await buildCommandScout(state, "tok");
+    expect(createScoutMock).toHaveBeenCalledWith({
+      githubToken: "tok",
+      persistence: "gist",
+    });
+  });
+
+  it("uses provided mode (local file) when the preference is local", async () => {
+    const state = ScoutStateSchema.parse({
+      version: 1,
+      preferences: { persistence: "local" },
+    });
+    await buildCommandScout(state, "tok");
+    expect(createScoutMock).toHaveBeenCalledWith({
+      githubToken: "tok",
+      persistence: "provided",
+      initialState: state,
+    });
+  });
+
+  it("defaults to provided mode when the preference is unset", async () => {
+    // ScoutPreferencesSchema defaults persistence to "local"
+    const state = ScoutStateSchema.parse({ version: 1 });
+    await buildCommandScout(state, "tok");
+    expect(createScoutMock).toHaveBeenCalledWith(
+      expect.objectContaining({ persistence: "provided" }),
+    );
+  });
+});

--- a/packages/core/src/commands/command-scout.ts
+++ b/packages/core/src/commands/command-scout.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared scout construction for CLI commands.
+ *
+ * Picks the persistence mode from `state.preferences.persistence` so the
+ * `gist` preference is actually honored (#115). Previously every command
+ * hardcoded `provided` mode, leaving gist sync unreachable no matter what
+ * `oss-scout config set persistence gist` wrote.
+ */
+import type { ScoutState } from "../core/schemas.js";
+import { createScout, type OssScout } from "../scout.js";
+
+/**
+ * Build a scout for a CLI command from already-loaded local state and a token.
+ *
+ * - `persistence: "gist"` preference → gist-backed scout. createScout loads
+ *   local state itself and merges it with the gist, and `checkpoint()` pushes
+ *   to the gist. The caller still calls `saveLocalState` to keep the local
+ *   file fresh as an offline cache.
+ * - otherwise → provided-state scout backed by the local file. The command's
+ *   `saveLocalState` + `checkpoint()` persist locally.
+ */
+export async function buildCommandScout(
+  state: ScoutState,
+  token: string,
+): Promise<OssScout> {
+  if (state.preferences.persistence === "gist") {
+    return createScout({ githubToken: token, persistence: "gist" });
+  }
+  return createScout({
+    githubToken: token,
+    persistence: "provided",
+    initialState: state,
+  });
+}

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -14,6 +14,17 @@ vi.mock("../core/utils.js", () => ({
 
 vi.mock("../core/local-state.js", () => ({
   saveLocalState: vi.fn(),
+  loadLocalState: vi.fn(() => ({
+    version: 1,
+    preferences: { persistence: "local" },
+    savedResults: [],
+    skippedIssues: [],
+    mergedPRs: [],
+    closedPRs: [],
+    openPRs: [],
+    repoScores: {},
+    starredRepos: [],
+  })),
 }));
 
 function makeFeatureCandidate(

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -2,9 +2,9 @@
  * Features command — surfaces feature opportunities in anchor repos.
  */
 
-import { createScout } from "../scout.js";
+import { buildCommandScout } from "./command-scout.js";
 import { requireGitHubToken } from "../core/utils.js";
-import { saveLocalState } from "../core/local-state.js";
+import { loadLocalState, saveLocalState } from "../core/local-state.js";
 import { isLinkedPRStalled } from "../core/linked-pr.js";
 import type { ScoutState } from "../core/schemas.js";
 import type { FeatureCandidate } from "../core/feature-discovery.js";
@@ -113,13 +113,8 @@ export async function runFeatures(
   options: FeaturesCommandOptions,
 ): Promise<FeaturesOutput> {
   const token = requireGitHubToken();
-  const scout = options.state
-    ? await createScout({
-        githubToken: token,
-        persistence: "provided",
-        initialState: options.state,
-      })
-    : await createScout({ githubToken: token });
+  const state = options.state ?? loadLocalState();
+  const scout = await buildCommandScout(state, token);
 
   const result = await scout.features({
     count: options.maxResults,

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -29,7 +29,17 @@ vi.mock("../core/utils.js", () => ({
 
 vi.mock("../core/local-state.js", () => ({
   saveLocalState: vi.fn(),
-  loadLocalState: vi.fn(),
+  loadLocalState: vi.fn(() => ({
+    version: 1,
+    preferences: { persistence: "local" },
+    savedResults: [],
+    skippedIssues: [],
+    mergedPRs: [],
+    closedPRs: [],
+    openPRs: [],
+    repoScores: {},
+    starredRepos: [],
+  })),
   hasLocalState: vi.fn().mockReturnValue(true),
 }));
 

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -2,9 +2,9 @@
  * Search command — finds contributable issues using multi-strategy search.
  */
 
-import { createScout } from "../scout.js";
+import { buildCommandScout } from "./command-scout.js";
 import { requireGitHubToken } from "../core/utils.js";
-import { saveLocalState } from "../core/local-state.js";
+import { loadLocalState, saveLocalState } from "../core/local-state.js";
 import { isLinkedPRStalled } from "../core/linked-pr.js";
 import type { ScoutState, SearchStrategy } from "../core/schemas.js";
 
@@ -79,13 +79,8 @@ export async function runSearch(
   options: SearchCommandOptions,
 ): Promise<SearchOutput> {
   const token = requireGitHubToken();
-  const scout = options.state
-    ? await createScout({
-        githubToken: token,
-        persistence: "provided",
-        initialState: options.state,
-      })
-    : await createScout({ githubToken: token });
+  const state = options.state ?? loadLocalState();
+  const scout = await buildCommandScout(state, token);
   const result = await scout.search({
     maxResults: options.maxResults,
     strategies: options.strategies,

--- a/packages/core/src/commands/skip.ts
+++ b/packages/core/src/commands/skip.ts
@@ -4,8 +4,8 @@
 
 import { loadLocalState, saveLocalState } from "../core/local-state.js";
 import type { SkippedIssue, ScoutState } from "../core/schemas.js";
-import { createScout } from "../scout.js";
 import { getGitHubToken } from "../core/utils.js";
+import { buildCommandScout } from "./command-scout.js";
 import {
   ISSUE_URL_PATTERN,
   validateGitHubUrl,
@@ -13,23 +13,11 @@ import {
 } from "./validation.js";
 
 /**
- * Create an OssScout instance for skip operations.
- * Uses gist persistence when a token is available, otherwise provided-state mode.
+ * Build a scout for skip operations, honoring the persistence preference.
+ * The old helper had two identical branches and hardcoded provided mode.
  */
-async function createSkipScout(state: ScoutState) {
-  const token = getGitHubToken() ?? "";
-  if (token) {
-    return createScout({
-      githubToken: token,
-      persistence: "provided",
-      initialState: state,
-    });
-  }
-  return createScout({
-    githubToken: "",
-    persistence: "provided",
-    initialState: state,
-  });
+function createSkipScout(state: ScoutState) {
+  return buildCommandScout(state, getGitHubToken() ?? "");
 }
 
 /**

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -5,7 +5,11 @@ import type { IssueCandidate } from "../core/types.js";
 
 // Mock local-state module
 vi.mock("../core/local-state.js", () => {
-  let mockState: any = { version: 1, savedResults: [] };
+  let mockState: any = {
+    version: 1,
+    savedResults: [],
+    preferences: { persistence: "local" },
+  };
   return {
     loadLocalState: () => mockState,
     saveLocalState: (state: any) => {

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -1,6 +1,6 @@
-import { createScout } from "../scout.js";
+import { buildCommandScout } from "./command-scout.js";
 import { requireGitHubToken } from "../core/utils.js";
-import { saveLocalState } from "../core/local-state.js";
+import { loadLocalState, saveLocalState } from "../core/local-state.js";
 import type { ScoutState } from "../core/schemas.js";
 import type { VetListResult } from "../core/types.js";
 
@@ -14,13 +14,8 @@ export async function runVetList(
   options: VetListCommandOptions,
 ): Promise<VetListResult> {
   const token = requireGitHubToken();
-  const scout = options.state
-    ? await createScout({
-        githubToken: token,
-        persistence: "provided",
-        initialState: options.state,
-      })
-    : await createScout({ githubToken: token });
+  const state = options.state ?? loadLocalState();
+  const scout = await buildCommandScout(state, token);
 
   const result = await scout.vetList({
     concurrency: options.concurrency,

--- a/packages/core/src/commands/vet.test.ts
+++ b/packages/core/src/commands/vet.test.ts
@@ -21,7 +21,17 @@ vi.mock("../core/utils.js", () => ({
 
 vi.mock("../core/local-state.js", () => ({
   saveLocalState: vi.fn(),
-  loadLocalState: vi.fn(),
+  loadLocalState: vi.fn(() => ({
+    version: 1,
+    preferences: { persistence: "local" },
+    savedResults: [],
+    skippedIssues: [],
+    mergedPRs: [],
+    closedPRs: [],
+    openPRs: [],
+    repoScores: {},
+    starredRepos: [],
+  })),
   hasLocalState: vi.fn().mockReturnValue(true),
 }));
 

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -2,7 +2,8 @@
  * Vet command — vets a specific issue for claimability.
  */
 
-import { createScout } from "../scout.js";
+import { loadLocalState } from "../core/local-state.js";
+import { buildCommandScout } from "./command-scout.js";
 import { requireGitHubToken } from "../core/utils.js";
 import type { ProjectHealth } from "../core/types.js";
 import type { IssueVettingResult, ScoutState } from "../core/schemas.js";
@@ -37,13 +38,8 @@ export async function runVet(options: VetCommandOptions): Promise<VetOutput> {
   validateGitHubUrl(options.issueUrl, ISSUE_URL_PATTERN, "issue");
 
   const token = requireGitHubToken();
-  const scout = options.state
-    ? await createScout({
-        githubToken: token,
-        persistence: "provided",
-        initialState: options.state,
-      })
-    : await createScout({ githubToken: token });
+  const state = options.state ?? loadLocalState();
+  const scout = await buildCommandScout(state, token);
   const candidate = await scout.vetIssue(options.issueUrl);
 
   return {


### PR DESCRIPTION
## Summary
- New `commands/command-scout.ts`: `buildCommandScout(state, token)` returns a gist-mode scout when `state.preferences.persistence === "gist"`, else provided-mode backed by the local file
- search / vet / vet-list / features / skip all route through it (load local state, then build); `config set persistence gist` is now actually reachable
- skip.ts's `createSkipScout` collapses from two byte-identical branches to one line

Reviewer-verified: gist mode re-loads + merges the gist (state arg redundant but harmless), the dual-write targets distinct files (gist + state.json cache, no conflict), skip awaits correctly, no test asserted the old no-state path, and the only inefficiency (vet bootstraps a gist for a read-only op in gist mode) is consistent with the design and below threshold.

## Test plan
- [x] New command-scout.test.ts: gist pref → gist mode, local pref / unset → provided mode
- [x] Four command-test loadLocalState mocks updated to a realistic state (production never returns undefined)
- [x] lint, format:check, typecheck, 847 core + 26 mcp green

Closes #115