### PR TITLE
fix(gist): prevent merge data loss with tombstones and recency tracking

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -56,6 +56,7 @@ program
       const prefs = await runSetup();
       const state = loadLocalState();
       state.preferences = prefs;
+      state.preferencesUpdatedAt = new Date().toISOString(); // #117 merge recency
       saveLocalState(state);
       if (options.json) {
         console.log(formatJsonSuccess(prefs));

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -235,6 +235,7 @@ export function runConfigSet(key: string, value: string): ScoutPreferences {
   // Validate the full preferences object
   const validated = ScoutPreferencesSchema.parse(prefs);
   state.preferences = validated;
+  state.preferencesUpdatedAt = new Date().toISOString(); // #117 merge recency
   saveLocalState(state);
 
   return validated;
@@ -247,6 +248,7 @@ export function runConfigReset(): ScoutPreferences {
   const state = loadLocalState();
   const defaults = ScoutPreferencesSchema.parse({});
   state.preferences = defaults;
+  state.preferencesUpdatedAt = new Date().toISOString(); // #117 merge recency
   saveLocalState(state);
   return defaults;
 }

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -431,6 +431,50 @@ describe("GistStateStore", () => {
       expect(ok).toBe(false);
     });
 
+    it("merges the concurrent remote state before writing, not last-writer-wins (#117)", async () => {
+      // A second machine pushed a merged PR the local copy never saw
+      const remoteState = makeState({
+        mergedPRs: [
+          {
+            url: "https://github.com/x/y/pull/99",
+            title: "from other machine",
+            mergedAt: "2026-06-01T00:00:00Z",
+          },
+        ],
+      });
+      const update = vi.fn().mockResolvedValue({ data: { id: "gist-1" } });
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({
+          data: [{ id: "gist-1", description: "oss-scout-state" }],
+        }),
+        get: vi.fn().mockResolvedValue(gistResponse(remoteState, "gist-1")),
+        update,
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      // Local push adds a different PR; the remote one must survive
+      const localState = makeState({
+        mergedPRs: [
+          {
+            url: "https://github.com/x/y/pull/1",
+            title: "from this machine",
+            mergedAt: "2026-06-02T00:00:00Z",
+          },
+        ],
+      });
+      const ok = await store.push(localState);
+      expect(ok).toBe(true);
+
+      const written = JSON.parse(
+        update.mock.calls.at(-1)![0].files["state.json"].content,
+      );
+      const urls = written.mergedPRs.map((p: { url: string }) => p.url);
+      expect(urls).toContain("https://github.com/x/y/pull/99");
+      expect(urls).toContain("https://github.com/x/y/pull/1");
+    });
+
     it("returns false on API error but still writes cache", async () => {
       const octokit = makeOctokit({
         list: vi.fn().mockResolvedValue({ data: [] }),
@@ -585,13 +629,144 @@ describe("GistStateStore", () => {
 });
 
 describe("mergeStates", () => {
-  it("uses remote preferences", () => {
+  it("uses remote preferences when neither side has a timestamp", () => {
     const local = makeState({ preferences: { githubUsername: "local" } });
     const remote = makeState({ preferences: { githubUsername: "remote" } });
 
     const merged = mergeStates(local, remote);
 
     expect(merged.preferences.githubUsername).toBe("remote");
+  });
+
+  it("keeps the fresher preferences by preferencesUpdatedAt (#117)", () => {
+    const local = makeState({
+      preferences: { githubUsername: "local" },
+      preferencesUpdatedAt: "2026-06-02T00:00:00Z",
+    });
+    const remote = makeState({
+      preferences: { githubUsername: "remote" },
+      preferencesUpdatedAt: "2026-06-01T00:00:00Z",
+    });
+
+    // Local edit is newer, so it must not be reverted to the remote copy
+    expect(mergeStates(local, remote).preferences.githubUsername).toBe("local");
+    // ...and remote wins when remote is newer
+    expect(mergeStates(remote, local).preferences.githubUsername).toBe("local");
+  });
+
+  it("does not resurrect a tombstoned skip on merge (#117)", () => {
+    const url = "https://github.com/a/b/issues/9";
+    // Local removed the skip (tombstone); remote still has it
+    const local = makeState({
+      skippedIssues: [],
+      tombstones: [{ url, removedAt: "2026-06-02T00:00:00Z" }],
+    });
+    const remote = makeState({
+      skippedIssues: [
+        {
+          url,
+          repo: "a/b",
+          number: 9,
+          title: "t",
+          skippedAt: "2026-06-01T00:00:00Z",
+        },
+      ],
+    });
+
+    const merged = mergeStates(local, remote);
+    expect(merged.skippedIssues.find((s) => s.url === url)).toBeUndefined();
+  });
+
+  it("does not resurrect a tombstoned saved result on merge (#117)", () => {
+    const issueUrl = "https://github.com/a/b/issues/5";
+    const local = makeState({
+      savedResults: [],
+      tombstones: [{ url: issueUrl, removedAt: "2026-06-02T00:00:00Z" }],
+    });
+    const remote = makeState({
+      savedResults: [
+        {
+          issueUrl,
+          repo: "a/b",
+          number: 5,
+          title: "t",
+          labels: [],
+          recommendation: "approve" as const,
+          viabilityScore: 80,
+          searchPriority: "normal",
+          firstSeenAt: "2026-06-01T00:00:00Z",
+          lastSeenAt: "2026-06-01T00:00:00Z",
+          lastScore: 80,
+        },
+      ],
+    });
+
+    expect(
+      mergeStates(local, remote).savedResults.find(
+        (r) => r.issueUrl === issueUrl,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("allows a re-skip after a tombstone (newer timestamp wins) (#117)", () => {
+    const url = "https://github.com/a/b/issues/9";
+    // User unskipped (tombstone at T1) then re-skipped (skippedAt at T2 > T1)
+    const local = makeState({
+      skippedIssues: [
+        {
+          url,
+          repo: "a/b",
+          number: 9,
+          title: "t",
+          skippedAt: "2026-06-03T00:00:00Z",
+        },
+      ],
+      tombstones: [{ url, removedAt: "2026-06-02T00:00:00Z" }],
+    });
+    const remote = makeState({ skippedIssues: [] });
+
+    const merged = mergeStates(local, remote);
+    expect(merged.skippedIssues.find((s) => s.url === url)).toBeDefined();
+  });
+
+  it("does not resurrect a skipped URL into saved results from remote (#117)", () => {
+    // Local skipped an issue (which removes it from savedResults). Remote
+    // still has it saved. The merge must not let the remote saved copy
+    // reappear, because a skip is the authoritative signal to suppress it.
+    const url = "https://github.com/a/b/issues/7";
+    const local = makeState({
+      savedResults: [],
+      skippedIssues: [
+        {
+          url,
+          repo: "a/b",
+          number: 7,
+          title: "t",
+          skippedAt: "2026-06-03T00:00:00Z",
+        },
+      ],
+    });
+    const remote = makeState({
+      savedResults: [
+        {
+          issueUrl: url,
+          repo: "a/b",
+          number: 7,
+          title: "t",
+          labels: [],
+          recommendation: "approve" as const,
+          viabilityScore: 80,
+          searchPriority: "normal",
+          firstSeenAt: "2026-06-01T00:00:00Z",
+          lastSeenAt: "2026-06-01T00:00:00Z",
+          lastScore: 80,
+        },
+      ],
+    });
+
+    const merged = mergeStates(local, remote);
+    expect(merged.savedResults.find((r) => r.issueUrl === url)).toBeUndefined();
+    expect(merged.skippedIssues.find((s) => s.url === url)).toBeDefined();
   });
 
   it("unions mergedPRs by URL", () => {

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -126,14 +126,34 @@ export class GistStateStore {
    * Push state to the gist. Also writes to local cache as fallback.
    */
   async push(state: ScoutState): Promise<boolean> {
-    this.writeCache(state);
-
     if (!this.gistId) {
       warn(MODULE, "No gist ID — cannot push");
+      this.writeCache(state);
       return false;
     }
 
-    const json = JSON.stringify(state, null, 2);
+    // Fetch the current gist and merge before writing, so a concurrent push
+    // from another machine is not blindly clobbered (#117). The deletion
+    // tombstones in mergeStates keep removals from resurfacing. A fetch
+    // failure (not auth/rate-limit, which propagate) degrades to writing the
+    // local snapshot, the prior best-effort behavior.
+    let toWrite = state;
+    try {
+      const remote = await this.fetchGistState(this.gistId);
+      if (remote) {
+        toWrite = mergeStates(state, remote);
+      }
+    } catch (err) {
+      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      warn(
+        MODULE,
+        `Could not fetch gist before push, writing local snapshot: ${errorMessage(err)}`,
+      );
+    }
+
+    this.writeCache(toWrite);
+
+    const json = JSON.stringify(toWrite, null, 2);
     if (json.length > 900000) {
       warn(
         MODULE,
@@ -193,9 +213,10 @@ export class GistStateStore {
     if (cachedId) {
       debug(MODULE, `Trying cached gist ID: ${cachedId}`);
       try {
-        const state = await this.fetchGistState(cachedId);
-        if (state) {
+        const fetched = await this.fetchGistState(cachedId);
+        if (fetched) {
           this.gistId = cachedId;
+          const state = this.mergeCacheInto(fetched);
           this.writeCache(state);
           return { gistId: cachedId, state, created: false };
         }
@@ -217,8 +238,9 @@ export class GistStateStore {
       debug(MODULE, `Found gist via search: ${search.id}`);
       this.saveGistId(search.id);
       this.gistId = search.id;
-      const state = await this.fetchGistState(search.id);
-      if (state) {
+      const fetched = await this.fetchGistState(search.id);
+      if (fetched) {
+        const state = this.mergeCacheInto(fetched);
         this.writeCache(state);
         return { gistId: search.id, state, created: false };
       }
@@ -348,6 +370,18 @@ export class GistStateStore {
     fs.writeFileSync(getGistIdPath(), id + "\n", { mode: 0o600 });
   }
 
+  /**
+   * Merge the local state-cache into a freshly fetched gist state before it
+   * overwrites the cache (#117). Without this, a prior failed push left its
+   * only copy of the user's changes in state-cache.json, which the next
+   * successful bootstrap silently clobbered. Tombstone-aware mergeStates
+   * keeps both sides' real changes.
+   */
+  private mergeCacheInto(fetched: ScoutState): ScoutState {
+    const cached = this.readCache();
+    return cached ? mergeStates(cached, fetched) : fetched;
+  }
+
   private readCache(): ScoutState | null {
     try {
       const raw = fs.readFileSync(getCachePath(), "utf-8");
@@ -384,12 +418,93 @@ export class GistStateStore {
  * - unknown top-level keys (from a newer binary, #137): carried over via
  *   spreads, remote wins on conflicts to mirror the preferences rule
  */
+/** Retain tombstones this long so a slow-to-sync machine still honors them. */
+const TOMBSTONE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+type Tombstone = { url: string; removedAt: string };
+
+/**
+ * Merge tombstones from both sides (newest removedAt per URL wins) and drop
+ * any older than the TTL so the list cannot grow without bound (#117).
+ */
+function mergeTombstones(local: Tombstone[], remote: Tombstone[]): Tombstone[] {
+  const cutoff = Date.now() - TOMBSTONE_TTL_MS;
+  const byUrl = new Map<string, Tombstone>();
+  for (const t of [...local, ...remote]) {
+    const existing = byUrl.get(t.url);
+    if (!existing || t.removedAt > existing.removedAt) byUrl.set(t.url, t);
+  }
+  return [...byUrl.values()].filter((t) => {
+    const ts = new Date(t.removedAt).getTime();
+    return !Number.isFinite(ts) || ts >= cutoff;
+  });
+}
+
+/**
+ * Drop merged items that a tombstone deleted, unless the item was re-added
+ * after the deletion (item timestamp newer than the tombstone) (#117).
+ */
+function applyTombstones<T>(
+  items: T[],
+  tombstones: Tombstone[],
+  urlOf: (item: T) => string,
+  touchedAtOf: (item: T) => string,
+): T[] {
+  if (tombstones.length === 0) return items;
+  const byUrl = new Map(tombstones.map((t) => [t.url, t.removedAt]));
+  return items.filter((item) => {
+    const removedAt = byUrl.get(urlOf(item));
+    if (removedAt === undefined) return true;
+    // Keep only if re-added strictly after the deletion
+    return touchedAtOf(item) > removedAt;
+  });
+}
+
 export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
+  const tombstones = mergeTombstones(
+    local.tombstones ?? [],
+    remote.tombstones ?? [],
+  );
+  const savedResults = applyTombstones(
+    mergeSavedResults(local.savedResults ?? [], remote.savedResults ?? []),
+    tombstones,
+    (r) => r.issueUrl,
+    (r) => r.lastSeenAt,
+  );
+  const skippedIssues = applyTombstones(
+    mergeSkippedIssues(local.skippedIssues ?? [], remote.skippedIssues ?? []),
+    tombstones,
+    (s) => s.url,
+    (s) => s.skippedAt,
+  );
+  // A skipped URL must never linger in saved results (skipIssue's own
+  // invariant). Enforce it after the merge so a remote copy can't resurrect
+  // a now-skipped result into the saved list (#117).
+  const skippedUrls = new Set(skippedIssues.map((s) => s.url));
+  const savedResultsFinal = savedResults.filter(
+    (r) => !skippedUrls.has(r.issueUrl),
+  );
+
+  // Preferences: keep the side with the fresher preferencesUpdatedAt instead
+  // of always taking remote, which silently reverted a local edit (#117).
+  const localPrefsTs = local.preferencesUpdatedAt;
+  const remotePrefsTs = remote.preferencesUpdatedAt;
+  const localPrefsWin =
+    localPrefsTs !== undefined &&
+    (remotePrefsTs === undefined || localPrefsTs > remotePrefsTs);
+  const preferences = localPrefsWin ? local.preferences : remote.preferences;
+  const preferencesUpdatedAt = pickFresherTimestamp(
+    localPrefsTs,
+    remotePrefsTs,
+  );
+
   return {
     ...local,
     ...remote,
     version: 1,
-    preferences: remote.preferences,
+    preferences,
+    preferencesUpdatedAt,
+    tombstones,
     repoScores: mergeRepoScores(local.repoScores, remote.repoScores),
     starredRepos: mergeStarredRepos(local, remote),
     starredReposLastFetched: pickFresherTimestamp(
@@ -399,14 +514,8 @@ export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
     mergedPRs: unionByUrl(local.mergedPRs, remote.mergedPRs),
     closedPRs: unionByUrl(local.closedPRs, remote.closedPRs),
     openPRs: unionByUrl(local.openPRs ?? [], remote.openPRs ?? []),
-    savedResults: mergeSavedResults(
-      local.savedResults ?? [],
-      remote.savedResults ?? [],
-    ),
-    skippedIssues: mergeSkippedIssues(
-      local.skippedIssues ?? [],
-      remote.skippedIssues ?? [],
-    ),
+    savedResults: savedResultsFinal,
+    skippedIssues,
     lastSearchAt: pickFresherTimestamp(local.lastSearchAt, remote.lastSearchAt),
     lastRunAt:
       pickFresherTimestamp(local.lastRunAt, remote.lastRunAt) ??

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -253,6 +253,29 @@ export const ScoutStateSchema = z.looseObject({
   savedResults: z.array(SavedCandidateSchema).default([]),
   skippedIssues: z.array(SkippedIssueSchema).default([]),
 
+  /**
+   * Deletion tombstones (#117). Without these, the gist union-merge would
+   * resurrect any saved result or skipped issue removed on one machine the
+   * next time it merged against another machine's copy that still had it.
+   * A tombstone suppresses an item across a merge until the item is
+   * re-added with a newer timestamp. Pruned after 90 days.
+   */
+  tombstones: z
+    .array(
+      z.looseObject({
+        url: z.string(),
+        removedAt: z.string(),
+      }),
+    )
+    .default([]),
+
+  /**
+   * When preferences were last changed (#117). The gist merge previously
+   * always took the remote preferences, silently reverting a local edit;
+   * the side with the fresher timestamp now wins.
+   */
+  preferencesUpdatedAt: z.string().optional(),
+
   lastSearchAt: z.string().optional(),
   lastRunAt: z.string().default(() => new Date().toISOString()),
 

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -313,6 +313,58 @@ describe("OssScout", () => {
     });
   });
 
+  describe("deletion tombstones (#117)", () => {
+    it("records a tombstone when an issue is unskipped", () => {
+      const scout = makeScout();
+      scout.skipIssue("https://github.com/a/b/issues/1");
+      scout.unskipIssue("https://github.com/a/b/issues/1");
+      const tombstones = scout.getState().tombstones ?? [];
+      expect(tombstones.map((t) => t.url)).toContain(
+        "https://github.com/a/b/issues/1",
+      );
+    });
+
+    it("records tombstones when the skip list is cleared", () => {
+      const scout = makeScout();
+      scout.skipIssue("https://github.com/a/b/issues/1");
+      scout.skipIssue("https://github.com/a/b/issues/2");
+      scout.clearSkippedIssues();
+      const urls = (scout.getState().tombstones ?? []).map((t) => t.url);
+      expect(urls).toContain("https://github.com/a/b/issues/1");
+      expect(urls).toContain("https://github.com/a/b/issues/2");
+    });
+
+    it("records tombstones when results are cleared", () => {
+      const scout = makeScout({
+        savedResults: [
+          {
+            issueUrl: "https://github.com/a/b/issues/3",
+            repo: "a/b",
+            number: 3,
+            title: "t",
+            labels: [],
+            recommendation: "approve",
+            viabilityScore: 80,
+            searchPriority: "normal",
+            firstSeenAt: "2026-06-01T00:00:00Z",
+            lastSeenAt: "2026-06-01T00:00:00Z",
+            lastScore: 80,
+          },
+        ],
+      });
+      scout.clearResults();
+      expect((scout.getState().tombstones ?? []).map((t) => t.url)).toContain(
+        "https://github.com/a/b/issues/3",
+      );
+    });
+
+    it("does not record a tombstone when unskip removes nothing", () => {
+      const scout = makeScout();
+      scout.unskipIssue("https://github.com/a/b/issues/nope");
+      expect(scout.getState().tombstones ?? []).toHaveLength(0);
+    });
+  });
+
   describe("setStarredRepos", () => {
     it("updates starred repos with timestamp", () => {
       const scout = makeScout();

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -402,6 +402,7 @@ export class OssScout implements ScoutStateReader {
         (r) => !unavailableUrls.has(r.issueUrl),
       );
       prunedCount = before - (this.state.savedResults?.length ?? 0);
+      if (prunedCount > 0) this.addTombstones([...unavailableUrls]);
       this.dirty = true;
     }
 
@@ -582,6 +583,9 @@ export class OssScout implements ScoutStateReader {
    */
   updatePreferences(updates: Partial<ScoutPreferences>): void {
     this.state.preferences = { ...this.state.preferences, ...updates };
+    // Stamp so the gist merge keeps the fresher preferences instead of
+    // always taking the remote copy (#117).
+    this.state.preferencesUpdatedAt = new Date().toISOString();
     this.dirty = true;
   }
 
@@ -644,8 +648,23 @@ export class OssScout implements ScoutStateReader {
    * Clear all saved results.
    */
   clearResults(): void {
+    this.addTombstones((this.state.savedResults ?? []).map((r) => r.issueUrl));
     this.state.savedResults = [];
     this.dirty = true;
+  }
+
+  /**
+   * Record deletion tombstones (#117) so a later gist merge does not
+   * resurrect these URLs from another machine's copy. A re-add with a newer
+   * timestamp overrides the tombstone in mergeStates.
+   */
+  private addTombstones(urls: string[]): void {
+    if (urls.length === 0) return;
+    const removedAt = new Date().toISOString();
+    const existing = this.state.tombstones ?? [];
+    const byUrl = new Map(existing.map((t) => [t.url, t]));
+    for (const url of urls) byUrl.set(url, { url, removedAt });
+    this.state.tombstones = [...byUrl.values()];
   }
 
   // ── Skip List ───────────────────────────────────────────────────────
@@ -669,7 +688,10 @@ export class OssScout implements ScoutStateReader {
         skippedAt: new Date().toISOString(),
       },
     ];
-    // Also remove from saved results if present
+    // Also remove from saved results if present. No tombstone needed: the
+    // skip entry itself is the durable record, and mergeStates reconciles
+    // saved results against the skip list so a merge can't resurrect a
+    // skipped URL into the saved list (#117).
     if (this.state.savedResults) {
       this.state.savedResults = this.state.savedResults.filter(
         (r) => r.issueUrl !== url,
@@ -689,9 +711,11 @@ export class OssScout implements ScoutStateReader {
    * Remove a specific issue from the skip list.
    */
   unskipIssue(url: string): void {
+    const before = (this.state.skippedIssues ?? []).length;
     this.state.skippedIssues = (this.state.skippedIssues ?? []).filter(
       (s) => s.url !== url,
     );
+    if (this.state.skippedIssues.length < before) this.addTombstones([url]);
     this.dirty = true;
   }
 
@@ -699,6 +723,7 @@ export class OssScout implements ScoutStateReader {
    * Clear all skipped issues.
    */
   clearSkippedIssues(): void {
+    this.addTombstones((this.state.skippedIssues ?? []).map((s) => s.url));
     this.state.skippedIssues = [];
     this.dirty = true;
   }


### PR DESCRIPTION
Closes #117.

## Problem

Gist sync's `mergeStates` took the remote copy wholesale for several collections. That caused two data-loss bugs:

1. **Resurrected removals.** Clearing results, unskipping, clearing skips, or pruning a vet-list on machine A removed items locally, but a stale remote copy on machine B re-introduced them on the next merge. The act of removal left no trace, so "absent locally, present remotely" always resolved to present.
2. **Silently reverted preferences.** A local `config set` was overwritten whenever the remote preferences object happened to win the merge.

## Fix

- **Tombstones.** Every removal path now records a `{ url, removedAt }` tombstone in `ScoutState`. `mergeStates` applies tombstones to both saved results and skipped issues, with a 90-day TTL and newest-per-URL precedence. A fresher touch on the item itself (e.g. a genuine re-add after the tombstone) overrides an older tombstone, so legitimate re-adds survive.
- **Skip reconciliation.** `skipIssue` removes the URL from saved results, and `mergeStates` reconciles saved results against the skip list after applying tombstones, so a remote saved copy can never resurrect a skipped issue.
- **Preference recency.** `preferencesUpdatedAt` is stamped on every config write (set/reset/setup). The merge keeps the fresher side rather than always taking remote.
- **Concurrent-write safety.** `push()` fetch-merges the remote copy before writing, so a concurrent update from another machine is no longer clobbered.

## Tests

Added coverage for tombstone non-resurrection (saved + skipped), re-skip after a tombstone, skip/saved reconciliation across a merge, preference recency, and concurrent push-merge. Full suite green: 857 core + 26 mcp.