### PR TITLE
refactor(config): unify preference-field map across CLI and MCP (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ oss-scout config reset                               # reset to defaults
 | `aiPolicyBlocklist` | string[] | matplotlib/matplotlib | Repos with anti-AI policies |
 | `projectCategories` | enum[] | [] | Topic filter: devtools, web-frameworks, etc. |
 | `persistence` | enum | local | State storage: local or gist |
+| `slmTriageModel` | string | (disabled) | Ollama model id for local SLM pre-triage during vetting (e.g. `gemma4:e4b`); empty disables it |
+| `slmTriageHost` | string | (127.0.0.1:11434) | Override the Ollama HTTP host when it runs on another machine |
 
 ## Install Options
 

--- a/packages/core/src/commands/config.test.ts
+++ b/packages/core/src/commands/config.test.ts
@@ -368,6 +368,25 @@ describe("config command", () => {
       });
     });
 
+    describe("SLM triage fields", () => {
+      it("should set slmTriageModel (#153)", () => {
+        writeState(makeState());
+
+        const result = runConfigSet("slmTriageModel", "gemma4:e4b");
+
+        expect(result.slmTriageModel).toBe("gemma4:e4b");
+        expect(readState().preferences.slmTriageModel).toBe("gemma4:e4b");
+      });
+
+      it("should set slmTriageHost (#153)", () => {
+        writeState(makeState());
+
+        const result = runConfigSet("slmTriageHost", "http://10.0.0.5:11434");
+
+        expect(result.slmTriageHost).toBe("http://10.0.0.5:11434");
+      });
+    });
+
     describe("validation", () => {
       it("should reject unknown keys", () => {
         writeState(makeState());

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -3,105 +3,9 @@
  */
 
 import { loadLocalState, saveLocalState } from "../core/local-state.js";
-import {
-  ScoutPreferencesSchema,
-  IssueScopeSchema,
-  ProjectCategorySchema,
-  PersistenceModeSchema,
-  SearchStrategySchema,
-} from "../core/schemas.js";
+import { ScoutPreferencesSchema } from "../core/schemas.js";
 import type { ScoutPreferences } from "../core/schemas.js";
-import { ValidationError } from "../core/errors.js";
-
-type FieldConfig =
-  | { type: "array" | "number" | "float" | "boolean" | "string" }
-  | { type: "enum" | "enum-array"; validValues: readonly string[] };
-
-const FIELD_CONFIGS: Record<string, FieldConfig> = {
-  languages: { type: "array" },
-  labels: { type: "array" },
-  excludeRepos: { type: "array" },
-  excludeOrgs: { type: "array" },
-  aiPolicyBlocklist: { type: "array" },
-  minStars: { type: "number" },
-  maxIssueAgeDays: { type: "number" },
-  minRepoScoreThreshold: { type: "number" },
-  interPhaseDelayMs: { type: "number" },
-  includeDocIssues: { type: "boolean" },
-  scope: { type: "enum-array", validValues: IssueScopeSchema.options },
-  projectCategories: {
-    type: "enum-array",
-    validValues: ProjectCategorySchema.options,
-  },
-  persistence: { type: "enum", validValues: PersistenceModeSchema.options },
-  defaultStrategy: {
-    type: "enum-array",
-    validValues: SearchStrategySchema.options,
-  },
-  githubUsername: { type: "string" },
-  broadPhaseDelayMs: { type: "number" },
-  skipBroadWhenSufficientResults: { type: "number" },
-  featuresAnchorThreshold: { type: "number" },
-  featuresSplitRatio: { type: "float" },
-};
-
-function parseBoolean(value: string): boolean {
-  const lower = value.toLowerCase();
-  if (lower === "true" || lower === "yes") return true;
-  if (lower === "false" || lower === "no") return false;
-  throw new ValidationError(
-    `Invalid boolean value: "${value}". Use true/false or yes/no.`,
-  );
-}
-
-function parseNumber(value: string, key: string): number {
-  const num = parseInt(value, 10);
-  if (isNaN(num)) {
-    throw new ValidationError(`Invalid number for "${key}": "${value}"`);
-  }
-  return num;
-}
-
-function parseFloat(value: string, key: string): number {
-  const num = Number.parseFloat(value);
-  if (isNaN(num)) {
-    throw new ValidationError(`Invalid number for "${key}": "${value}"`);
-  }
-  return num;
-}
-
-function parseArrayValue(value: string): string[] {
-  return value
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}
-
-/**
- * Apply an array update: plain set, +append, or -remove.
- *
- * The -remove form starts with a dash, which commander rejects as an
- * unknown option unless escaped: `config set excludeRepos -- "-spam/repo"`.
- * Documented in the CLI help and README (#132). Full pass-through parsing
- * was evaluated and rejected: it breaks `config set k v --json` (trailing
- * flag becomes a third operand) and, via the required program-level
- * positional mode, `search 5 --debug`.
- */
-function updateArray(current: string[], value: string): string[] {
-  if (value.startsWith("+")) {
-    const toAdd = parseArrayValue(value.slice(1));
-    const merged = [...current];
-    for (const item of toAdd) {
-      if (!merged.includes(item)) merged.push(item);
-    }
-    return merged;
-  }
-  if (value.startsWith("-")) {
-    const toRemove = new Set(parseArrayValue(value.slice(1)));
-    return current.filter((item) => !toRemove.has(item));
-  }
-  return parseArrayValue(value);
-}
+import { applyPreferenceField } from "../core/preference-fields.js";
 
 function formatArray(arr: string[]): string {
   return arr.length > 0 ? arr.join(", ") : "(none)";
@@ -148,6 +52,12 @@ export function runConfigShow(): void {
   console.log(
     `  skipBroadWhenSufficientResults: ${prefs.skipBroadWhenSufficientResults}`,
   );
+  console.log(
+    `  slmTriageModel:       ${prefs.slmTriageModel || "(disabled)"}`,
+  );
+  console.log(
+    `  slmTriageHost:        ${prefs.slmTriageHost || "(default 127.0.0.1:11434)"}`,
+  );
   console.log(`  featuresAnchorThreshold: ${prefs.featuresAnchorThreshold}`);
   console.log(`  featuresSplitRatio:    ${prefs.featuresSplitRatio}`);
   console.log();
@@ -165,75 +75,8 @@ export function getConfigData(): ScoutPreferences {
  * Update a single preference by key.
  */
 export function runConfigSet(key: string, value: string): ScoutPreferences {
-  const field = FIELD_CONFIGS[key];
-  if (!field) {
-    throw new ValidationError(
-      `Unknown config key: "${key}". Valid keys: ${Object.keys(FIELD_CONFIGS).sort().join(", ")}`,
-    );
-  }
-
   const state = loadLocalState();
-  const prefs = { ...state.preferences };
-
-  switch (field.type) {
-    case "string":
-      (prefs as Record<string, unknown>)[key] = value;
-      break;
-
-    case "boolean":
-      (prefs as Record<string, unknown>)[key] = parseBoolean(value);
-      break;
-
-    case "number":
-      (prefs as Record<string, unknown>)[key] = parseNumber(value, key);
-      break;
-
-    case "float":
-      (prefs as Record<string, unknown>)[key] = parseFloat(value, key);
-      break;
-
-    case "array": {
-      const current =
-        ((prefs as Record<string, unknown>)[key] as string[] | undefined) ?? [];
-      (prefs as Record<string, unknown>)[key] = updateArray(current, value);
-      break;
-    }
-
-    case "enum": {
-      const validValues = field.validValues;
-      if (!validValues.includes(value)) {
-        throw new ValidationError(
-          `Invalid value for "${key}": "${value}". Valid: ${validValues.join(", ")}`,
-        );
-      }
-      (prefs as Record<string, unknown>)[key] = value;
-      break;
-    }
-
-    case "enum-array": {
-      const current =
-        ((prefs as Record<string, unknown>)[key] as string[] | undefined) ?? [];
-      const updated = updateArray(current, value);
-      const validValues = field.validValues;
-      const invalid = updated.filter((s) => !validValues.includes(s));
-      if (invalid.length > 0) {
-        throw new ValidationError(
-          `Invalid value(s) for "${key}": ${invalid.join(", ")}. Valid: ${validValues.join(", ")}`,
-        );
-      }
-      // For 'scope', empty array means undefined (all scopes)
-      if (key === "scope") {
-        (prefs as Record<string, unknown>)[key] =
-          updated.length > 0 ? updated : undefined;
-      } else {
-        (prefs as Record<string, unknown>)[key] = updated;
-      }
-      break;
-    }
-  }
-
-  // Validate the full preferences object
-  const validated = ScoutPreferencesSchema.parse(prefs);
+  const validated = applyPreferenceField(state.preferences, key, value);
   state.preferences = validated;
   state.preferencesUpdatedAt = new Date().toISOString(); // #117 merge recency
   saveLocalState(state);

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -178,6 +178,12 @@ export async function runSetup(
     );
     const excludeRepos = parseCSV(excludeInput);
 
+    // Optional local SLM pre-triage (Ollama). Empty leaves it disabled.
+    const slmTriageModel = await ask(
+      rl,
+      "Local SLM triage model for faster pre-filtering (Ollama model id, e.g. gemma4:e4b, optional): ",
+    );
+
     const prefs = ScoutPreferencesSchema.parse({
       githubUsername,
       languages,
@@ -186,6 +192,7 @@ export async function runSetup(
       excludeRepos,
       projectCategories,
       minStars: isNaN(minStars) ? 50 : minStars,
+      slmTriageModel,
     });
 
     console.error("\n✅ Setup complete! Preferences saved.\n");

--- a/packages/core/src/core/preference-fields.test.ts
+++ b/packages/core/src/core/preference-fields.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyPreferenceField,
+  assertFieldConfigsCover,
+  FIELD_CONFIGS,
+  PREFERENCE_KEYS,
+} from "./preference-fields.js";
+import { ScoutPreferencesSchema } from "./schemas.js";
+
+const defaults = ScoutPreferencesSchema.parse({});
+
+describe("preference-fields", () => {
+  describe("assertFieldConfigsCover", () => {
+    it("FIELD_CONFIGS covers every schema preference key", () => {
+      expect(() => assertFieldConfigsCover()).not.toThrow();
+    });
+
+    it("every preference key (incl. SLM triage) has a field config", () => {
+      for (const key of PREFERENCE_KEYS) {
+        expect(FIELD_CONFIGS[key]).toBeDefined();
+      }
+      // The keys that previously drifted out of the CLI map (#153).
+      expect(FIELD_CONFIGS.slmTriageModel).toEqual({ type: "string" });
+      expect(FIELD_CONFIGS.slmTriageHost).toEqual({ type: "string" });
+    });
+  });
+
+  describe("applyPreferenceField", () => {
+    it("parses the SLM triage keys the CLI map used to reject", () => {
+      const updated = applyPreferenceField(
+        defaults,
+        "slmTriageModel",
+        "gemma4:e4b",
+      );
+      expect(updated.slmTriageModel).toBe("gemma4:e4b");
+    });
+
+    it("applies +append / -remove array syntax (parity for MCP)", () => {
+      const appended = applyPreferenceField(
+        { ...defaults, excludeRepos: ["a/b"] },
+        "excludeRepos",
+        "+c/d",
+      );
+      expect(appended.excludeRepos).toEqual(["a/b", "c/d"]);
+
+      const removed = applyPreferenceField(
+        { ...defaults, excludeRepos: ["a/b", "c/d"] },
+        "excludeRepos",
+        "-a/b",
+      );
+      expect(removed.excludeRepos).toEqual(["c/d"]);
+    });
+
+    it("keeps the scope empty-array-means-all special case", () => {
+      const cleared = applyPreferenceField(
+        { ...defaults, scope: ["beginner"] },
+        "scope",
+        "-beginner",
+      );
+      expect(cleared.scope).toBeUndefined();
+    });
+
+    it("validates enum-array members", () => {
+      expect(() => applyPreferenceField(defaults, "scope", "expert")).toThrow(
+        "Invalid value",
+      );
+    });
+
+    it("rejects an unknown key with the sorted key list", () => {
+      expect(() => applyPreferenceField(defaults, "nope", "x")).toThrow(
+        "Unknown config key",
+      );
+    });
+
+    it("does not mutate the input preferences object", () => {
+      const input = ScoutPreferencesSchema.parse({ minStars: 50 });
+      applyPreferenceField(input, "minStars", "999");
+      expect(input.minStars).toBe(50);
+    });
+  });
+});

--- a/packages/core/src/core/preference-fields.ts
+++ b/packages/core/src/core/preference-fields.ts
@@ -1,0 +1,222 @@
+/**
+ * Shared preference-field metadata and value parsing.
+ *
+ * The CLI (`commands/config.ts`) and the MCP `config-set` tool both update a
+ * single preference from a raw string. They used to carry separate, drifting
+ * copies of the key tables and parse logic — the CLI was missing the SLM
+ * triage keys, the MCP side lacked the `scope` special case and the +/- array
+ * syntax. This module is the single source of truth both drive (#153).
+ */
+
+import {
+  ScoutPreferencesSchema,
+  IssueScopeSchema,
+  ProjectCategorySchema,
+  PersistenceModeSchema,
+  SearchStrategySchema,
+} from "./schemas.js";
+import type { ScoutPreferences } from "./schemas.js";
+import { ValidationError } from "./errors.js";
+
+export type FieldConfig =
+  | { type: "array" | "number" | "float" | "boolean" | "string" }
+  | { type: "enum" | "enum-array"; validValues: readonly string[] };
+
+export const FIELD_CONFIGS: Record<string, FieldConfig> = {
+  githubUsername: { type: "string" },
+  languages: { type: "array" },
+  labels: { type: "array" },
+  scope: { type: "enum-array", validValues: IssueScopeSchema.options },
+  excludeRepos: { type: "array" },
+  excludeOrgs: { type: "array" },
+  aiPolicyBlocklist: { type: "array" },
+  projectCategories: {
+    type: "enum-array",
+    validValues: ProjectCategorySchema.options,
+  },
+  minStars: { type: "number" },
+  maxIssueAgeDays: { type: "number" },
+  includeDocIssues: { type: "boolean" },
+  minRepoScoreThreshold: { type: "number" },
+  interPhaseDelayMs: { type: "number" },
+  persistence: { type: "enum", validValues: PersistenceModeSchema.options },
+  defaultStrategy: {
+    type: "enum-array",
+    validValues: SearchStrategySchema.options,
+  },
+  broadPhaseDelayMs: { type: "number" },
+  skipBroadWhenSufficientResults: { type: "number" },
+  slmTriageModel: { type: "string" },
+  slmTriageHost: { type: "string" },
+  featuresAnchorThreshold: { type: "number" },
+  featuresSplitRatio: { type: "float" },
+};
+
+/**
+ * Every configurable preference key, derived from the schema so a new
+ * preference can't be silently left unconfigurable. `assertFieldConfigsCover`
+ * (exercised by a unit test) fails loudly if FIELD_CONFIGS drifts from this.
+ */
+export const PREFERENCE_KEYS: readonly string[] = Object.keys(
+  ScoutPreferencesSchema.shape,
+);
+
+/** Sorted key list for "unknown key" error messages and help text. */
+export const SORTED_PREFERENCE_KEYS: readonly string[] = [
+  ...PREFERENCE_KEYS,
+].sort();
+
+/**
+ * Throw if any schema preference lacks a FIELD_CONFIG entry. Called from a
+ * test so adding a preference to the schema without teaching config-set how to
+ * parse it is caught in CI rather than at a user's first `config set newKey`.
+ */
+export function assertFieldConfigsCover(): void {
+  const missing = PREFERENCE_KEYS.filter((k) => !(k in FIELD_CONFIGS));
+  if (missing.length > 0) {
+    throw new Error(
+      `FIELD_CONFIGS is missing entries for preference keys: ${missing.join(", ")}`,
+    );
+  }
+  const extra = Object.keys(FIELD_CONFIGS).filter(
+    (k) => !PREFERENCE_KEYS.includes(k),
+  );
+  if (extra.length > 0) {
+    throw new Error(
+      `FIELD_CONFIGS has entries for unknown preference keys: ${extra.join(", ")}`,
+    );
+  }
+}
+
+function parseBoolean(value: string): boolean {
+  const lower = value.toLowerCase();
+  if (lower === "true" || lower === "yes") return true;
+  if (lower === "false" || lower === "no") return false;
+  throw new ValidationError(
+    `Invalid boolean value: "${value}". Use true/false or yes/no.`,
+  );
+}
+
+function parseIntValue(value: string, key: string): number {
+  const num = parseInt(value, 10);
+  if (isNaN(num)) {
+    throw new ValidationError(`Invalid number for "${key}": "${value}"`);
+  }
+  return num;
+}
+
+function parseFloatValue(value: string, key: string): number {
+  const num = Number.parseFloat(value);
+  if (isNaN(num)) {
+    throw new ValidationError(`Invalid number for "${key}": "${value}"`);
+  }
+  return num;
+}
+
+function parseArrayValue(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Apply an array update: plain set, +append, or -remove.
+ *
+ * The -remove form starts with a dash, which commander rejects as an unknown
+ * option unless escaped: `config set excludeRepos -- "-spam/repo"`. The MCP
+ * tool has no commander layer so it can pass `-spam/repo` directly. Documented
+ * in the CLI help and README (#132).
+ */
+export function updateArray(current: string[], value: string): string[] {
+  if (value.startsWith("+")) {
+    const toAdd = parseArrayValue(value.slice(1));
+    const merged = [...current];
+    for (const item of toAdd) {
+      if (!merged.includes(item)) merged.push(item);
+    }
+    return merged;
+  }
+  if (value.startsWith("-")) {
+    const toRemove = new Set(parseArrayValue(value.slice(1)));
+    return current.filter((item) => !toRemove.has(item));
+  }
+  return parseArrayValue(value);
+}
+
+/**
+ * Apply a single key/value update to a preferences object and return the
+ * fully validated result. The raw string `value` is the form both the CLI and
+ * the MCP tool receive; arrays accept comma-separated values and the +add /
+ * -remove syntax. Throws ValidationError on an unknown key or a bad value.
+ */
+export function applyPreferenceField(
+  preferences: ScoutPreferences,
+  key: string,
+  value: string,
+): ScoutPreferences {
+  const field = FIELD_CONFIGS[key];
+  if (!field) {
+    throw new ValidationError(
+      `Unknown config key: "${key}". Valid keys: ${SORTED_PREFERENCE_KEYS.join(", ")}`,
+    );
+  }
+
+  const prefs = { ...preferences } as Record<string, unknown>;
+
+  switch (field.type) {
+    case "string":
+      prefs[key] = value;
+      break;
+
+    case "boolean":
+      prefs[key] = parseBoolean(value);
+      break;
+
+    case "number":
+      prefs[key] = parseIntValue(value, key);
+      break;
+
+    case "float":
+      prefs[key] = parseFloatValue(value, key);
+      break;
+
+    case "array": {
+      const current = (prefs[key] as string[] | undefined) ?? [];
+      prefs[key] = updateArray(current, value);
+      break;
+    }
+
+    case "enum": {
+      const validValues = field.validValues;
+      if (!validValues.includes(value)) {
+        throw new ValidationError(
+          `Invalid value for "${key}": "${value}". Valid: ${validValues.join(", ")}`,
+        );
+      }
+      prefs[key] = value;
+      break;
+    }
+
+    case "enum-array": {
+      const current = (prefs[key] as string[] | undefined) ?? [];
+      const updated = updateArray(current, value);
+      const validValues = field.validValues;
+      const invalid = updated.filter((s) => !validValues.includes(s));
+      if (invalid.length > 0) {
+        throw new ValidationError(
+          `Invalid value(s) for "${key}": ${invalid.join(", ")}. Valid: ${validValues.join(", ")}`,
+        );
+      }
+      // For 'scope', an empty array means undefined (all scopes).
+      if (key === "scope") {
+        prefs[key] = updated.length > 0 ? updated : undefined;
+      } else {
+        prefs[key] = updated;
+      }
+      break;
+    }
+  }
+
+  return ScoutPreferencesSchema.parse(prefs);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,17 @@ export {
   HorizonSchema,
 } from "./core/schemas.js";
 
+// Preference-field metadata + parsing (shared by the CLI and the MCP server)
+export {
+  applyPreferenceField,
+  FIELD_CONFIGS,
+  PREFERENCE_KEYS,
+  SORTED_PREFERENCE_KEYS,
+  assertFieldConfigsCover,
+  updateArray,
+  type FieldConfig,
+} from "./core/preference-fields.js";
+
 // Utilities
 export { requireGitHubToken, getGitHubToken } from "./core/utils.js";
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -3,10 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OssScout } from "@oss-scout/core";
 import {
   SearchStrategySchema,
-  ScoutPreferencesSchema,
   ISSUE_URL_PATTERN,
   validateGitHubUrl,
   validateUrl,
+  applyPreferenceField,
+  SORTED_PREFERENCE_KEYS,
 } from "@oss-scout/core";
 
 // Generous ceiling: even with inter-phase delays zeroed, vetting many issues
@@ -307,29 +308,6 @@ export function registerTools(server: McpServer, scout: OssScout): void {
     },
   );
 
-  const VALID_KEYS = Object.keys(ScoutPreferencesSchema.shape);
-  const ARRAY_KEYS = new Set([
-    "languages",
-    "labels",
-    "projectCategories",
-    "excludeRepos",
-    "excludeOrgs",
-    "aiPolicyBlocklist",
-    "scope",
-    "defaultStrategy",
-  ]);
-  const NUMBER_KEYS = new Set([
-    "minStars",
-    "maxIssueAgeDays",
-    "minRepoScoreThreshold",
-    "interPhaseDelayMs",
-    "broadPhaseDelayMs",
-    "skipBroadWhenSufficientResults",
-    "featuresAnchorThreshold",
-    "featuresSplitRatio",
-  ]);
-  const BOOLEAN_KEYS = new Set(["includeDocIssues"]);
-
   server.tool(
     "config-set",
     "Update an oss-scout configuration preference",
@@ -337,91 +315,34 @@ export function registerTools(server: McpServer, scout: OssScout): void {
       key: z
         .string()
         .describe(
-          "Preference key to update (e.g. languages, minStars, excludeRepos)",
+          `Preference key to update. One of: ${SORTED_PREFERENCE_KEYS.join(", ")}`,
         ),
       value: z
         .string()
         .describe(
-          "New value — comma-separated for arrays, plain string for scalars",
+          'New value. Comma-separated for arrays; prefix with + to append or - to remove items (e.g. "+spam/repo"). Plain string/number/boolean for scalars.',
         ),
     },
     async ({ key, value }) => {
-      if (!VALID_KEYS.includes(key)) {
+      // Parse + validate via the shared field map so the CLI and MCP stay in
+      // lockstep, including the +/- array syntax and the scope special case
+      // (#153). applyPreferenceField throws ValidationError on a bad key/value.
+      let validated;
+      try {
+        validated = applyPreferenceField(scout.getPreferences(), key, value);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
         return {
-          content: [
-            {
-              type: "text",
-              text: `Unknown config key: "${key}". Valid keys: ${VALID_KEYS.join(", ")}`,
-            },
-          ],
+          content: [{ type: "text", text: msg }],
           isError: true,
         };
       }
 
-      let parsed: unknown;
-      if (ARRAY_KEYS.has(key)) {
-        // Accept comma-separated strings → arrays
-        try {
-          parsed = JSON.parse(value);
-          if (!Array.isArray(parsed)) {
-            parsed = value
-              .split(",")
-              .map((s: string) => s.trim())
-              .filter(Boolean);
-          }
-        } catch {
-          parsed = value
-            .split(",")
-            .map((s: string) => s.trim())
-            .filter(Boolean);
-        }
-      } else if (NUMBER_KEYS.has(key)) {
-        const num = Number(value);
-        if (isNaN(num)) {
-          return {
-            content: [
-              { type: "text", text: `Invalid number for "${key}": "${value}"` },
-            ],
-            isError: true,
-          };
-        }
-        parsed = num;
-      } else if (BOOLEAN_KEYS.has(key)) {
-        const lower = value.toLowerCase();
-        if (lower === "true" || lower === "yes") parsed = true;
-        else if (lower === "false" || lower === "no") parsed = false;
-        else {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Invalid boolean for "${key}": "${value}". Use true/false or yes/no.`,
-              },
-            ],
-            isError: true,
-          };
-        }
-      } else {
-        // String or enum fields — pass through as-is
-        parsed = value;
-      }
-
-      const currentPrefs = scout.getPreferences();
-      const candidate = { ...currentPrefs, [key]: parsed };
-
-      // Validate the full preferences object with Zod
-      const result = ScoutPreferencesSchema.safeParse(candidate);
-      if (!result.success) {
-        const issues = result.error.issues
-          .map((i) => `${i.path.join(".")}: ${i.message}`)
-          .join("; ");
-        return {
-          content: [{ type: "text", text: `Validation error: ${issues}` }],
-          isError: true,
-        };
-      }
-
-      scout.updatePreferences({ [key]: parsed });
+      // Apply only the changed key; validation above ran against the full
+      // merged object so cross-field rules still hold.
+      scout.updatePreferences({
+        [key]: validated[key as keyof typeof validated],
+      });
       await scout.checkpoint();
       const updated = scout.getPreferences();
       return {


### PR DESCRIPTION
Closes #153.

## Problem

The `config set` logic existed twice and had already drifted:

- `commands/config.ts` was missing `slmTriageModel`/`slmTriageHost`, so `oss-scout config set slmTriageModel ...` threw "Unknown config key". The whole SLM triage feature was enableable only by hand-editing `~/.oss-scout/state.json` (setup didn't prompt for it either).
- `mcp-server/src/tools.ts` built its own parallel key tables. They accepted the SLM keys but lacked config.ts's `scope` special case and the documented `+`/`-` array append/remove syntax, so a `+spam/repo` value was stored literally.

## Fix

- Extract `FIELD_CONFIGS` plus the parse/update logic into a new shared core module `core/preference-fields.ts`. Both the CLI `config set` and the MCP `config-set` tool now drive `applyPreferenceField`, so they can't drift again.
- Derive the key list from `ScoutPreferencesSchema.shape` and add `assertFieldConfigsCover()` (exercised by a unit test) so a preference added to the schema without a field config fails in CI rather than at a user's first `config set newKey`.
- Add `slmTriageModel`/`slmTriageHost` to the CLI field map and `config show`, an optional setup prompt for the SLM model, and README rows.
- Bring the `+`/`-` array syntax and the `scope` empty-array-means-all special case to the MCP tool. MCP `config-set` validates against the full merged preferences object and applies only the changed key.

## Behavior note

The MCP `config-set` tool previously accepted JSON-array values (`["a","b"]`) for array keys. It now uses the same comma-separated and `+add`/`-remove` parser as the CLI, which is the unification this issue asked for. No existing test relied on JSON-array input.

## Tests

New `preference-fields.test.ts` covers the coverage guard, the SLM keys, +/- array parity, the scope special case, unknown-key rejection, and input immutability. Existing CLI and MCP config-set tests still pass unchanged. Full suite green: 867 core + 26 mcp.