### PR TITLE
refactor: dedup command and CLI boilerplate (#154)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -30,6 +30,30 @@ function handleCommandError(err: unknown, options: { json?: boolean }): never {
   process.exit(1);
 }
 
+/**
+ * Run a command body, routing any thrown error through handleCommandError so
+ * every command shares one try/catch epilogue instead of repeating it (#154).
+ */
+async function runAction(
+  options: { json?: boolean },
+  body: () => Promise<void>,
+): Promise<void> {
+  try {
+    await body();
+  } catch (err) {
+    handleCommandError(err, options);
+  }
+}
+
+/** Emoji for a vetting recommendation, shared by the search and vet renderers. */
+function recommendationIcon(
+  recommendation: "approve" | "skip" | "needs_review",
+): string {
+  if (recommendation === "approve") return "✅";
+  if (recommendation === "skip") return "❌";
+  return "⚠️";
+}
+
 const program = new Command();
 
 program
@@ -50,8 +74,8 @@ program
   .command("setup")
   .description("Interactive first-run configuration")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runSetup } = await import("./commands/setup.js");
       const prefs = await runSetup();
       const state = loadLocalState();
@@ -61,17 +85,15 @@ program
       if (options.json) {
         console.log(formatJsonSuccess(prefs));
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 program
   .command("bootstrap")
   .description("Import starred repos and PR history from GitHub")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { bootstrapScout } = await import("./core/bootstrap.js");
       const { createScout } = await import("./scout.js");
       const { requireGitHubToken } = await import("./core/utils.js");
@@ -99,10 +121,8 @@ program
           console.log(`Scored ${result.reposScoredCount} repositories`);
         }
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 program
   .command("search [count]")
@@ -134,8 +154,8 @@ program
         preferRepos?: string;
         diversityRatio?: string;
       },
-    ) => {
-      try {
+    ) =>
+      runAction(options, async () => {
         if (!hasLocalState() && !options.json) {
           // Human hint only: stdout must stay pure JSON under --json (#131)
           console.log(
@@ -213,12 +233,7 @@ program
             `\nFound ${results.candidates.length} issue candidates:\n`,
           );
           for (const c of results.candidates) {
-            const icon =
-              c.recommendation === "approve"
-                ? "✅"
-                : c.recommendation === "skip"
-                  ? "❌"
-                  : "⚠️";
+            const icon = recommendationIcon(c.recommendation);
             const stalledTag = c.linkedPR?.isStalled
               ? " (stalled PR, revive opportunity)"
               : "";
@@ -247,10 +262,7 @@ program
             console.error(`\n⚠️  ${results.rateLimitWarning}`);
           }
         }
-      } catch (err) {
-        handleCommandError(err, options);
-      }
-    },
+      }),
   );
 
 program
@@ -274,8 +286,8 @@ program
         splitRatio?: string;
         broad?: boolean;
       },
-    ) => {
-      try {
+    ) =>
+      runAction(options, async () => {
         const { runFeatures } = await import("./commands/features.js");
         const maxResults = count ? parseInt(count, 10) : 10;
         if (isNaN(maxResults) || maxResults < 1 || maxResults > 50) {
@@ -359,10 +371,7 @@ program
             console.log("");
           }
         }
-      } catch (err) {
-        handleCommandError(err, options);
-      }
-    },
+      }),
   );
 
 // ── results command ────────────────────────────────────────────────
@@ -375,8 +384,8 @@ resultsCmd
   .command("show", { isDefault: true })
   .description("Display saved search results")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runResults } = await import("./commands/results.js");
       const results = await runResults(options);
       if (options.json) {
@@ -406,17 +415,15 @@ resultsCmd
         }
         console.log();
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 resultsCmd
   .command("clear")
   .description("Clear all saved results")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runResultsClear } = await import("./commands/results.js");
       await runResultsClear();
       if (options.json) {
@@ -424,10 +431,8 @@ resultsCmd
       } else {
         console.log("Saved results cleared.");
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 // ── config command ──────────────────────────────────────────────────
 
@@ -435,8 +440,8 @@ const configCmd = program
   .command("config")
   .description("View and update preferences")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runConfigShow, getConfigData } =
         await import("./commands/config.js");
       if (options.json) {
@@ -444,10 +449,8 @@ const configCmd = program
       } else {
         runConfigShow();
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 configCmd
   .command("set <key> <value>")
@@ -455,8 +458,8 @@ configCmd
     'Update a single preference (e.g. config set minStars 100). For dash-prefixed values like the array-remove form, escape with --: config set excludeRepos -- "-spam/repo"',
   )
   .option("--json", "Output as JSON")
-  .action(async (key: string, value: string, options: { json?: boolean }) => {
-    try {
+  .action(async (key: string, value: string, options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runConfigSet } = await import("./commands/config.js");
       const updated = runConfigSet(key, value);
       if (options.json) {
@@ -464,17 +467,15 @@ configCmd
       } else {
         console.log(`✅ Updated "${key}" successfully.`);
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 configCmd
   .command("reset")
   .description("Reset all preferences to defaults")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runConfigReset } = await import("./commands/config.js");
       const defaults = runConfigReset();
       if (options.json) {
@@ -482,10 +483,8 @@ configCmd
       } else {
         console.log("✅ Preferences reset to defaults.");
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 program
   .command("vet-list")
@@ -504,8 +503,8 @@ program
       prune?: boolean;
       concurrency?: number;
       json?: boolean;
-    }) => {
-      try {
+    }) =>
+      runAction(options, async () => {
         if (
           options.concurrency !== undefined &&
           (isNaN(options.concurrency) || options.concurrency < 1)
@@ -557,10 +556,7 @@ program
           }
           console.log();
         }
-      } catch (err) {
-        handleCommandError(err, options);
-      }
-    },
+      }),
   );
 
 // ── skip command ───────────────────────────────────────────────────
@@ -573,8 +569,8 @@ skipCmd
   .command("add <issue-url>")
   .description("Skip an issue by URL")
   .option("--json", "Output as JSON")
-  .action(async (issueUrl: string, options: { json?: boolean }) => {
-    try {
+  .action(async (issueUrl: string, options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runSkip } = await import("./commands/skip.js");
       const state = loadLocalState();
       const result = await runSkip({ issueUrl, state });
@@ -587,17 +583,15 @@ skipCmd
           console.log(`Skipped: ${issueUrl}`);
         }
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 skipCmd
   .command("list")
   .description("Show all skipped issues")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runSkipList } = await import("./commands/skip.js");
       const results = runSkipList();
       if (options.json) {
@@ -626,17 +620,15 @@ skipCmd
         }
         console.log();
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 skipCmd
   .command("remove <issue-url>")
   .description("Remove an issue from the skip list (unskip)")
   .option("--json", "Output as JSON")
-  .action(async (issueUrl: string, options: { json?: boolean }) => {
-    try {
+  .action(async (issueUrl: string, options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runSkipRemove } = await import("./commands/skip.js");
       const result = await runSkipRemove({ issueUrl });
       if (options.json) {
@@ -648,17 +640,15 @@ skipCmd
           console.log("Issue was not in the skip list.");
         }
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 skipCmd
   .command("clear")
   .description("Clear all skipped issues")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) => {
-    try {
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runSkipClear } = await import("./commands/skip.js");
       await runSkipClear();
       if (options.json) {
@@ -666,10 +656,8 @@ skipCmd
       } else {
         console.log("Skip list cleared.");
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 program
   .command("vet <issue-url>")
@@ -677,20 +665,15 @@ program
     "Vet a specific GitHub issue for claimability and project health",
   )
   .option("--json", "Output as JSON")
-  .action(async (issueUrl: string, options: { json?: boolean }) => {
-    try {
+  .action(async (issueUrl: string, options: { json?: boolean }) =>
+    runAction(options, async () => {
       const { runVet } = await import("./commands/vet.js");
       const state = loadLocalState();
       const result = await runVet({ issueUrl, state });
       if (options.json) {
         console.log(formatJsonSuccess(result));
       } else {
-        const icon =
-          result.recommendation === "approve"
-            ? "✅"
-            : result.recommendation === "skip"
-              ? "❌"
-              : "⚠️";
+        const icon = recommendationIcon(result.recommendation);
         console.log(
           `\n${icon} ${result.issue.repo}#${result.issue.number}: ${result.recommendation.toUpperCase()}`,
         );
@@ -712,9 +695,7 @@ program
         );
         console.log(`  CI status: ${result.projectHealth.ciStatus}`);
       }
-    } catch (err) {
-      handleCommandError(err, options);
-    }
-  });
+    }),
+  );
 
 program.parse();

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -2,9 +2,7 @@
  * Features command — surfaces feature opportunities in anchor repos.
  */
 
-import { buildCommandScout } from "./command-scout.js";
-import { requireGitHubToken } from "../core/utils.js";
-import { loadLocalState, saveLocalState } from "../core/local-state.js";
+import { withScout } from "./with-scout.js";
 import { isLinkedPRStalled } from "../core/linked-pr.js";
 import type { ScoutState } from "../core/schemas.js";
 import type { FeatureCandidate } from "../core/feature-discovery.js";
@@ -112,27 +110,23 @@ function mapBiggerBet(
 export async function runFeatures(
   options: FeaturesCommandOptions,
 ): Promise<FeaturesOutput> {
-  const token = requireGitHubToken();
-  const state = options.state ?? loadLocalState();
-  const scout = await buildCommandScout(state, token);
+  return withScout(
+    options.state,
+    async (scout) => {
+      const result = await scout.features({
+        count: options.maxResults,
+        anchorThreshold: options.anchorThreshold,
+        splitRatio: options.splitRatio,
+        broad: options.broad,
+      });
 
-  const result = await scout.features({
-    count: options.maxResults,
-    anchorThreshold: options.anchorThreshold,
-    splitRatio: options.splitRatio,
-    broad: options.broad,
-  });
-
-  saveLocalState(scout.getState() as ScoutState);
-  const persisted = await scout.checkpoint();
-  if (!persisted) {
-    console.error("Warning: changes saved locally but gist sync failed.");
-  }
-
-  return {
-    quickWins: result.quickWins.map(mapQuickWin),
-    biggerBets: result.biggerBets.map(mapBiggerBet),
-    anchorRepos: result.anchorRepos,
-    message: result.message,
-  };
+      return {
+        quickWins: result.quickWins.map(mapQuickWin),
+        biggerBets: result.biggerBets.map(mapBiggerBet),
+        anchorRepos: result.anchorRepos,
+        message: result.message,
+      };
+    },
+    { persist: true },
+  );
 }

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -2,9 +2,7 @@
  * Search command — finds contributable issues using multi-strategy search.
  */
 
-import { buildCommandScout } from "./command-scout.js";
-import { requireGitHubToken } from "../core/utils.js";
-import { loadLocalState, saveLocalState } from "../core/local-state.js";
+import { withScout } from "./with-scout.js";
 import { isLinkedPRStalled } from "../core/linked-pr.js";
 import type { ScoutState, SearchStrategy } from "../core/schemas.js";
 
@@ -78,68 +76,66 @@ interface SearchCommandOptions {
 export async function runSearch(
   options: SearchCommandOptions,
 ): Promise<SearchOutput> {
-  const token = requireGitHubToken();
-  const state = options.state ?? loadLocalState();
-  const scout = await buildCommandScout(state, token);
-  const result = await scout.search({
-    maxResults: options.maxResults,
-    strategies: options.strategies,
-    preferLanguages: options.preferLanguages,
-    preferRepos: options.preferRepos,
-    diversityRatio: options.diversityRatio,
-  });
+  return withScout(
+    options.state,
+    async (scout) => {
+      const result = await scout.search({
+        maxResults: options.maxResults,
+        strategies: options.strategies,
+        preferLanguages: options.preferLanguages,
+        preferRepos: options.preferRepos,
+        diversityRatio: options.diversityRatio,
+      });
 
-  // Persist results to local state and gist
-  scout.saveResults(result.candidates);
-  saveLocalState(scout.getState() as ScoutState);
-  const persisted = await scout.checkpoint();
-  if (!persisted) {
-    console.error("Warning: changes saved locally but gist sync failed.");
-  }
+      scout.saveResults(result.candidates);
 
-  return {
-    candidates: result.candidates.map((c) => {
-      const repoScoreRecord = scout.getRepoScoreRecord(c.issue.repo);
       return {
-        issue: {
-          repo: c.issue.repo,
-          repoUrl: `https://github.com/${c.issue.repo}`,
-          number: c.issue.number,
-          title: c.issue.title,
-          url: c.issue.url,
-          labels: c.issue.labels,
-        },
-        recommendation: c.recommendation,
-        reasonsToApprove: c.reasonsToApprove,
-        reasonsToSkip: c.reasonsToSkip,
-        searchPriority: c.searchPriority,
-        viabilityScore: c.viabilityScore,
-        repoScore: repoScoreRecord
-          ? {
-              score: repoScoreRecord.score,
-              mergedPRCount: repoScoreRecord.mergedPRCount,
-              closedWithoutMergeCount: repoScoreRecord.closedWithoutMergeCount,
-              isResponsive: repoScoreRecord.signals?.isResponsive ?? false,
-              lastMergedAt: repoScoreRecord.lastMergedAt,
-            }
-          : undefined,
-        linkedPR: c.vettingResult.linkedPR
-          ? {
-              number: c.vettingResult.linkedPR.number,
-              state: c.vettingResult.linkedPR.state,
-              url: c.vettingResult.linkedPR.url,
-              updatedAt: c.vettingResult.linkedPR.updatedAt,
-              isStalled: isLinkedPRStalled(c.vettingResult.linkedPR),
-            }
-          : undefined,
-        boostScore: c.boostScore,
-        boostReasons: c.boostReasons,
-        diversitySlot: c.diversitySlot,
+        candidates: result.candidates.map((c) => {
+          const repoScoreRecord = scout.getRepoScoreRecord(c.issue.repo);
+          return {
+            issue: {
+              repo: c.issue.repo,
+              repoUrl: `https://github.com/${c.issue.repo}`,
+              number: c.issue.number,
+              title: c.issue.title,
+              url: c.issue.url,
+              labels: c.issue.labels,
+            },
+            recommendation: c.recommendation,
+            reasonsToApprove: c.reasonsToApprove,
+            reasonsToSkip: c.reasonsToSkip,
+            searchPriority: c.searchPriority,
+            viabilityScore: c.viabilityScore,
+            repoScore: repoScoreRecord
+              ? {
+                  score: repoScoreRecord.score,
+                  mergedPRCount: repoScoreRecord.mergedPRCount,
+                  closedWithoutMergeCount:
+                    repoScoreRecord.closedWithoutMergeCount,
+                  isResponsive: repoScoreRecord.signals?.isResponsive ?? false,
+                  lastMergedAt: repoScoreRecord.lastMergedAt,
+                }
+              : undefined,
+            linkedPR: c.vettingResult.linkedPR
+              ? {
+                  number: c.vettingResult.linkedPR.number,
+                  state: c.vettingResult.linkedPR.state,
+                  url: c.vettingResult.linkedPR.url,
+                  updatedAt: c.vettingResult.linkedPR.updatedAt,
+                  isStalled: isLinkedPRStalled(c.vettingResult.linkedPR),
+                }
+              : undefined,
+            boostScore: c.boostScore,
+            boostReasons: c.boostReasons,
+            diversitySlot: c.diversitySlot,
+          };
+        }),
+        excludedRepos: result.excludedRepos,
+        aiPolicyBlocklist: result.aiPolicyBlocklist,
+        rateLimitWarning: result.rateLimitWarning,
+        strategiesUsed: result.strategiesUsed,
       };
-    }),
-    excludedRepos: result.excludedRepos,
-    aiPolicyBlocklist: result.aiPolicyBlocklist,
-    rateLimitWarning: result.rateLimitWarning,
-    strategiesUsed: result.strategiesUsed,
-  };
+    },
+    { persist: true },
+  );
 }

--- a/packages/core/src/commands/skip.ts
+++ b/packages/core/src/commands/skip.ts
@@ -2,23 +2,17 @@
  * Skip command — manage the skip list for excluding issues from future searches.
  */
 
-import { loadLocalState, saveLocalState } from "../core/local-state.js";
+import { loadLocalState } from "../core/local-state.js";
 import type { SkippedIssue, ScoutState } from "../core/schemas.js";
-import { getGitHubToken } from "../core/utils.js";
-import { buildCommandScout } from "./command-scout.js";
+import { withScout, persistScout } from "./with-scout.js";
 import {
   ISSUE_URL_PATTERN,
   validateGitHubUrl,
   validateUrl,
 } from "./validation.js";
 
-/**
- * Build a scout for skip operations, honoring the persistence preference.
- * The old helper had two identical branches and hardcoded provided mode.
- */
-function createSkipScout(state: ScoutState) {
-  return buildCommandScout(state, getGitHubToken() ?? "");
-}
+// Skip operations are local-only, so they don't require a GitHub token.
+const SKIP_SCOUT_OPTIONS = { requireToken: false } as const;
 
 /**
  * Skip an issue by URL — adds it to the skip list and removes it from saved results.
@@ -37,28 +31,32 @@ export async function runSkip(options: {
   validateUrl(options.issueUrl);
   validateGitHubUrl(options.issueUrl, ISSUE_URL_PATTERN, "issue");
 
-  const state = options.state ?? loadLocalState();
-  const scout = await createSkipScout(state);
+  return withScout(
+    options.state,
+    async (scout) => {
+      const alreadySkipped = scout
+        .getSkippedIssues()
+        .some((s) => s.url === options.issueUrl);
+      if (alreadySkipped) {
+        return { skipped: false, alreadySkipped: true };
+      }
 
-  const alreadySkipped = scout
-    .getSkippedIssues()
-    .some((s) => s.url === options.issueUrl);
-  if (alreadySkipped) {
-    return { skipped: false, alreadySkipped: true };
-  }
+      // Try to enrich metadata from saved results
+      const saved = scout
+        .getSavedResults()
+        .find((r) => r.issueUrl === options.issueUrl);
+      const metadata = saved
+        ? { repo: saved.repo, number: saved.number, title: saved.title }
+        : parseIssueUrl(options.issueUrl);
 
-  // Try to enrich metadata from saved results
-  const saved = scout
-    .getSavedResults()
-    .find((r) => r.issueUrl === options.issueUrl);
-  const metadata = saved
-    ? { repo: saved.repo, number: saved.number, title: saved.title }
-    : parseIssueUrl(options.issueUrl);
-
-  scout.skipIssue(options.issueUrl, metadata);
-  saveLocalState(scout.getState() as ScoutState);
-  await scout.checkpoint();
-  return { skipped: true, alreadySkipped: false };
+      scout.skipIssue(options.issueUrl, metadata);
+      // Persist only on an actual change so an already-skipped no-op doesn't
+      // trigger a needless gist push.
+      await persistScout(scout);
+      return { skipped: true, alreadySkipped: false };
+    },
+    SKIP_SCOUT_OPTIONS,
+  );
 }
 
 /**
@@ -73,11 +71,13 @@ export function runSkipList(options?: { state?: ScoutState }): SkippedIssue[] {
  * Clear all skipped issues.
  */
 export async function runSkipClear(): Promise<void> {
-  const state = loadLocalState();
-  const scout = await createSkipScout(state);
-  scout.clearSkippedIssues();
-  saveLocalState(scout.getState() as ScoutState);
-  await scout.checkpoint();
+  await withScout(
+    undefined,
+    (scout) => {
+      scout.clearSkippedIssues();
+    },
+    { ...SKIP_SCOUT_OPTIONS, persist: true },
+  );
 }
 
 /**
@@ -90,14 +90,17 @@ export async function runSkipClear(): Promise<void> {
 export async function runSkipRemove(options: { issueUrl: string }): Promise<{
   removed: boolean;
 }> {
-  const state = loadLocalState();
-  const scout = await createSkipScout(state);
-  const before = scout.getSkippedIssues().length;
-  scout.unskipIssue(options.issueUrl);
-  const removed = before !== scout.getSkippedIssues().length;
-  saveLocalState(scout.getState() as ScoutState);
-  await scout.checkpoint();
-  return { removed };
+  return withScout(
+    undefined,
+    async (scout) => {
+      const before = scout.getSkippedIssues().length;
+      scout.unskipIssue(options.issueUrl);
+      const removed = before !== scout.getSkippedIssues().length;
+      await persistScout(scout);
+      return { removed };
+    },
+    SKIP_SCOUT_OPTIONS,
+  );
 }
 
 /**

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -1,6 +1,4 @@
-import { buildCommandScout } from "./command-scout.js";
-import { requireGitHubToken } from "../core/utils.js";
-import { loadLocalState, saveLocalState } from "../core/local-state.js";
+import { withScout } from "./with-scout.js";
 import type { ScoutState } from "../core/schemas.js";
 import type { VetListResult } from "../core/types.js";
 
@@ -13,19 +11,13 @@ interface VetListCommandOptions {
 export async function runVetList(
   options: VetListCommandOptions,
 ): Promise<VetListResult> {
-  const token = requireGitHubToken();
-  const state = options.state ?? loadLocalState();
-  const scout = await buildCommandScout(state, token);
-
-  const result = await scout.vetList({
-    concurrency: options.concurrency,
-    prune: options.prune,
-  });
-
-  saveLocalState(scout.getState() as ScoutState);
-  const persisted = await scout.checkpoint();
-  if (!persisted) {
-    console.error("Warning: changes saved locally but gist sync failed.");
-  }
-  return result;
+  return withScout(
+    options.state,
+    (scout) =>
+      scout.vetList({
+        concurrency: options.concurrency,
+        prune: options.prune,
+      }),
+    { persist: true },
+  );
 }

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -2,9 +2,7 @@
  * Vet command — vets a specific issue for claimability.
  */
 
-import { loadLocalState } from "../core/local-state.js";
-import { buildCommandScout } from "./command-scout.js";
-import { requireGitHubToken } from "../core/utils.js";
+import { withScout } from "./with-scout.js";
 import type { ProjectHealth } from "../core/types.js";
 import type { IssueVettingResult, ScoutState } from "../core/schemas.js";
 import {
@@ -37,23 +35,21 @@ export async function runVet(options: VetCommandOptions): Promise<VetOutput> {
   validateUrl(options.issueUrl);
   validateGitHubUrl(options.issueUrl, ISSUE_URL_PATTERN, "issue");
 
-  const token = requireGitHubToken();
-  const state = options.state ?? loadLocalState();
-  const scout = await buildCommandScout(state, token);
-  const candidate = await scout.vetIssue(options.issueUrl);
-
-  return {
-    issue: {
-      repo: candidate.issue.repo,
-      number: candidate.issue.number,
-      title: candidate.issue.title,
-      url: candidate.issue.url,
-      labels: candidate.issue.labels,
-    },
-    recommendation: candidate.recommendation,
-    reasonsToApprove: candidate.reasonsToApprove,
-    reasonsToSkip: candidate.reasonsToSkip,
-    projectHealth: candidate.projectHealth,
-    vettingResult: candidate.vettingResult,
-  };
+  return withScout(options.state, async (scout) => {
+    const candidate = await scout.vetIssue(options.issueUrl);
+    return {
+      issue: {
+        repo: candidate.issue.repo,
+        number: candidate.issue.number,
+        title: candidate.issue.title,
+        url: candidate.issue.url,
+        labels: candidate.issue.labels,
+      },
+      recommendation: candidate.recommendation,
+      reasonsToApprove: candidate.reasonsToApprove,
+      reasonsToSkip: candidate.reasonsToSkip,
+      projectHealth: candidate.projectHealth,
+      vettingResult: candidate.vettingResult,
+    };
+  });
 }

--- a/packages/core/src/commands/with-scout.ts
+++ b/packages/core/src/commands/with-scout.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared command scaffolding (#154).
+ *
+ * Every command repeated the same prologue (require token, load state, build
+ * the scout) and most repeated the same epilogue (write local state, gist
+ * checkpoint, warn on gist failure). The warning text was byte-identical in
+ * three files and inconsistently omitted in skip.ts. `withScout` owns the
+ * prologue plus an optional persist epilogue; `persistScout` is the epilogue
+ * on its own for commands that persist only on some code paths.
+ */
+
+import { buildCommandScout } from "./command-scout.js";
+import { requireGitHubToken, getGitHubToken } from "../core/utils.js";
+import { loadLocalState, saveLocalState } from "../core/local-state.js";
+import type { OssScout } from "../scout.js";
+import type { ScoutState } from "../core/schemas.js";
+
+const GIST_SYNC_WARNING =
+  "Warning: changes saved locally but gist sync failed.";
+
+/**
+ * Write the scout's state to disk and push the gist checkpoint, warning to
+ * stderr if the gist push failed (local save still succeeded).
+ */
+export async function persistScout(scout: OssScout): Promise<void> {
+  saveLocalState(scout.getState() as ScoutState);
+  const persisted = await scout.checkpoint();
+  if (!persisted) {
+    console.error(GIST_SYNC_WARNING);
+  }
+}
+
+export interface WithScoutOptions {
+  /** Persist via persistScout after fn resolves. Default false. */
+  persist?: boolean;
+  /**
+   * Require a GitHub token (throws if absent). Default true. Skip-list
+   * operations are local-only and pass false so they work without auth.
+   */
+  requireToken?: boolean;
+}
+
+/**
+ * Build a scout for the given (or loaded) state, run fn against it, and
+ * optionally persist afterward. Centralizes the create/persist/warn boilerplate
+ * shared by the search, vet, vet-list, features, and skip commands.
+ */
+export async function withScout<T>(
+  state: ScoutState | undefined,
+  fn: (scout: OssScout) => Promise<T> | T,
+  options: WithScoutOptions = {},
+): Promise<T> {
+  const { persist = false, requireToken = true } = options;
+  const token = requireToken ? requireGitHubToken() : (getGitHubToken() ?? "");
+  const resolvedState = state ?? loadLocalState();
+  const scout = await buildCommandScout(resolvedState, token);
+
+  const result = await fn(scout);
+
+  if (persist) {
+    await persistScout(scout);
+  }
+
+  return result;
+}

--- a/packages/core/src/core/anti-llm-policy.test.ts
+++ b/packages/core/src/core/anti-llm-policy.test.ts
@@ -31,6 +31,18 @@ vi.mock("./errors.js", () => ({
     }
     return false;
   }),
+  rethrowIfFatal: vi.fn((e: unknown) => {
+    const s =
+      e && typeof e === "object" && "status" in e
+        ? (e as { status: unknown }).status
+        : undefined;
+    const msg = e instanceof Error ? e.message.toLowerCase() : "";
+    const rateLimited =
+      s === 429 ||
+      (s === 403 &&
+        (msg.includes("rate limit") || msg.includes("abuse detection")));
+    if (s === 401 || rateLimited) throw e;
+  }),
 }));
 
 vi.mock("./http-cache.js", () => ({

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -9,7 +9,12 @@
  */
 
 import { Octokit } from "@octokit/rest";
-import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import {
+  errorMessage,
+  getHttpStatusCode,
+  isRateLimitError,
+  rethrowIfFatal,
+} from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache } from "./http-cache.js";
 import type { AntiLLMPolicyResult, AntiLLMPolicySourceFile } from "./types.js";
@@ -125,7 +130,7 @@ async function fetchFileText(
   } catch (error) {
     const status = getHttpStatusCode(error);
     if (status === 404) return { text: null, transient: false };
-    if (status === 401 || isRateLimitError(error)) throw error;
+    rethrowIfFatal(error);
     warn(
       MODULE,
       `Unexpected error fetching ${path} from ${owner}/${repo}: ${errorMessage(error)}`,

--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -5,12 +5,7 @@
 
 import { getOctokit, checkRateLimit } from "./github.js";
 import { debug, warn } from "./logger.js";
-import {
-  ConfigurationError,
-  errorMessage,
-  getHttpStatusCode,
-  isRateLimitError,
-} from "./errors.js";
+import { ConfigurationError, errorMessage, rethrowIfFatal } from "./errors.js";
 import { extractRepoFromUrl } from "./utils.js";
 import type { OssScout } from "../scout.js";
 
@@ -84,7 +79,7 @@ export async function bootstrapScout(
     debug(MODULE, `Fetched ${starredRepos.length} starred repos`);
     scout.setStarredRepos(starredRepos);
   } catch (err) {
-    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+    rethrowIfFatal(err);
     warn(MODULE, `Failed to fetch starred repos: ${errorMessage(err)}`);
     errors.push("starred repos fetch failed");
   }
@@ -116,7 +111,7 @@ export async function bootstrapScout(
     }
     debug(MODULE, `Imported ${mergedPRCount} merged PRs`);
   } catch (err) {
-    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+    rethrowIfFatal(err);
     warn(MODULE, `Failed to fetch merged PRs: ${errorMessage(err)}`);
     errors.push("merged PR fetch failed");
   }
@@ -148,7 +143,7 @@ export async function bootstrapScout(
     }
     debug(MODULE, `Imported ${closedPRCount} closed PRs`);
   } catch (err) {
-    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+    rethrowIfFatal(err);
     warn(MODULE, `Failed to fetch closed PRs: ${errorMessage(err)}`);
     errors.push("closed PR fetch failed");
   }
@@ -180,7 +175,7 @@ export async function bootstrapScout(
     }
     debug(MODULE, `Imported ${openPRCount} open PRs`);
   } catch (err) {
-    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+    rethrowIfFatal(err);
     warn(MODULE, `Failed to fetch open PRs: ${errorMessage(err)}`);
     errors.push("open PR fetch failed");
   }

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -60,6 +60,21 @@ export function isRateLimitError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * Re-throw an error if it is one that must always propagate: a 401 (auth) or
+ * any rate-limit condition (429, 403 + rate-limit/abuse). Otherwise return so
+ * the caller can degrade gracefully. Centralizes the guard that was
+ * copy-pasted across ~16 catch blocks (#154).
+ *
+ * Note: catch sites that deliberately treat a rate limit as degradable use a
+ * bare `getHttpStatusCode(err) === 401` check instead and must NOT call this.
+ */
+export function rethrowIfFatal(error: unknown): void {
+  if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
+    throw error;
+  }
+}
+
 /** Error codes for JSON output. */
 export type ErrorCode =
   | "AUTH_REQUIRED"

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -16,7 +16,7 @@ import type { Octokit } from "@octokit/rest";
 import type { RepoScore, Horizon } from "./schemas.js";
 import type { IssueCandidate } from "./types.js";
 import type { IssueVetter } from "./issue-vetting.js";
-import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import { errorMessage, rethrowIfFatal } from "./errors.js";
 import { warn } from "./logger.js";
 import { sleep } from "./utils.js";
 import { fetchRoadmapIssueRefs } from "./roadmap.js";
@@ -289,7 +289,7 @@ export async function discoverFeatures(
       response = listResp;
       roadmapRefs = refs;
     } catch (err: unknown) {
-      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      rethrowIfFatal(err);
       warn(
         MODULE,
         `failed to list issues for ${anchorRepos[i]}: ${errorMessage(err)}`,
@@ -323,7 +323,7 @@ export async function discoverFeatures(
           },
         });
       } catch (err: unknown) {
-        if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+        rethrowIfFatal(err);
         warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
         continue;
       }
@@ -484,7 +484,7 @@ export async function discoverFeaturesBroad(
       .filter((it) => !it.pull_request && !it.assignee && isFeatureIssue(it))
       .slice(0, maxToVet);
   } catch (err: unknown) {
-    if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+    rethrowIfFatal(err);
     warn(MODULE, `broad feature search failed: ${errorMessage(err)}`);
     return {
       quickWins: [],
@@ -517,7 +517,7 @@ export async function discoverFeaturesBroad(
         },
       });
     } catch (err: unknown) {
-      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      rethrowIfFatal(err);
       warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
       continue;
     }

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -16,7 +16,12 @@ import type {
 } from "./schemas.js";
 import { getDataDir } from "./utils.js";
 import { debug, warn } from "./logger.js";
-import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import {
+  errorMessage,
+  getHttpStatusCode,
+  isRateLimitError,
+  rethrowIfFatal,
+} from "./errors.js";
 
 const MODULE = "gist-state";
 
@@ -144,7 +149,7 @@ export class GistStateStore {
         toWrite = mergeStates(state, remote);
       }
     } catch (err) {
-      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      rethrowIfFatal(err);
       warn(
         MODULE,
         `Could not fetch gist before push, writing local snapshot: ${errorMessage(err)}`,
@@ -175,7 +180,7 @@ export class GistStateStore {
       // Both auth and rate-limit propagate per documented strategy.
       // Local cache write already happened above, so the user's work isn't
       // lost — but they need clear feedback that the sync failed.
-      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      rethrowIfFatal(err);
       warn(MODULE, `Failed to push: ${errorMessage(err)}`);
       return false;
     }
@@ -194,7 +199,7 @@ export class GistStateStore {
       }
       return state;
     } catch (err) {
-      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      rethrowIfFatal(err);
       warn(MODULE, `Failed to pull: ${errorMessage(err)}`);
       return null;
     }

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -8,7 +8,7 @@
 
 import { Octokit } from "@octokit/rest";
 import { paginateAll } from "./pagination.js";
-import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import { errorMessage, rethrowIfFatal } from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache, withInflightDedup } from "./http-cache.js";
 import { getSearchBudgetTracker } from "./search-budget.js";
@@ -199,9 +199,7 @@ export async function checkNoExistingPR(
 
     return { passed: linkedPRCount === 0, linkedPR };
   } catch (error) {
-    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
-      throw error;
-    }
+    rethrowIfFatal(error);
     const errMsg = errorMessage(error);
     warn(
       MODULE,
@@ -258,9 +256,7 @@ export async function checkUserMergedPRsInRepo(
         tracker.recordCall();
       }
     } catch (error) {
-      if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
-        throw error;
-      }
+      rethrowIfFatal(error);
       const errMsg = errorMessage(error);
       warn(
         MODULE,
@@ -316,9 +312,7 @@ export async function checkNotClaimed(
 
     return { passed: true };
   } catch (error) {
-    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
-      throw error;
-    }
+    rethrowIfFatal(error);
     const errMsg = errorMessage(error);
     warn(
       MODULE,

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -8,7 +8,12 @@
 import { Octokit } from "@octokit/rest";
 import { daysBetween } from "./utils.js";
 import { type ContributionGuidelines, type ProjectHealth } from "./types.js";
-import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import {
+  errorMessage,
+  getHttpStatusCode,
+  isRateLimitError,
+  rethrowIfFatal,
+} from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache, cachedRequest, cachedTimeBased } from "./http-cache.js";
 
@@ -121,9 +126,7 @@ export async function checkProjectHealth(
       },
     );
   } catch (error) {
-    if (getHttpStatusCode(error) === 401 || isRateLimitError(error)) {
-      throw error;
-    }
+    rethrowIfFatal(error);
     const errMsg = errorMessage(error);
     warn(
       MODULE,

--- a/packages/core/src/core/roadmap.ts
+++ b/packages/core/src/core/roadmap.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Octokit } from "@octokit/rest";
-import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
+import { errorMessage, getHttpStatusCode, rethrowIfFatal } from "./errors.js";
 import { warn } from "./logger.js";
 
 const MODULE = "roadmap";
@@ -153,7 +153,7 @@ async function fetchRoadmapIssueRefsUncached(
       pruneCache();
       return refs;
     } catch (err: unknown) {
-      if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;
+      rethrowIfFatal(err);
       const status = getHttpStatusCode(err);
       if (status === 404) continue; // path missing — try next
       warn(


### PR DESCRIPTION
Closes #154.

Three copy-paste families collapsed into shared helpers, with no behavior change.

## 1. `withScout` / `persistScout` (`commands/with-scout.ts`)

Every command repeated the same prologue (require token, load state, `buildCommandScout`) and most repeated the same persist epilogue (`saveLocalState` + `checkpoint` + warn on gist failure, byte-identical in three files). `withScout` owns the prologue plus an optional persist epilogue; `persistScout` is the epilogue alone for commands that persist only on some code paths.

Applied to `search`, `vet`, `vet-list`, `features`, `skip`. Notes:
- skip's gist-failure warning was previously omitted inconsistently and is now emitted via `persistScout`.
- skip operations keep their no-token behavior (`requireToken: false` → `getGitHubToken() ?? ""`).
- `runSkip` / `runSkipRemove` persist only on an actual change, so an already-skipped no-op doesn't trigger a needless gist push.

## 2. `rethrowIfFatal` (`core/errors.ts`)

Replaces the copy-pasted `if (getHttpStatusCode(err) === 401 || isRateLimitError(err)) throw err;` guard across 17 catch sites (bootstrap, feature-discovery, gist-state-store, issue-eligibility, repo-health, anti-llm-policy, roadmap).

The deliberately-401-only catch sites that let a rate limit degrade gracefully (issue-discovery, issue-vetting, gist `bootstrap`) are intentionally left untouched.

## 3. `runAction` (`cli.ts`)

Wraps each of the 15 command action bodies so the `try/catch` + `handleCommandError` epilogue is shared rather than repeated. The bodies are otherwise verbatim. The runner/render split mentioned in the issue was intentionally left out to avoid touching the `--json` output ordering contract (the related contract bug is tracked separately).

## 4. `recommendationIcon` (`cli.ts`)

Dedups the approve→✅ / skip→❌ / needs_review→⚠️ emoji mapping shared by the search and vet renderers. The vet-list status-icon mapping is different and was left alone.

## Verification

lint, format, typecheck clean. Full suite 867 core + 26 mcp green. CLI smoke-tested: `--help`, bare `config` (shows the new SLM rows), and `--json` ValidationError paths for search/features/skip all behave correctly. One test had to add a `rethrowIfFatal` entry to its wholesale `vi.mock("./errors.js")` so the mocked module exposes the new export.