### PR TITLE
feat(core): logger level control + ScoutStateWriter injectable + export bootstrapScout

### DIFF
--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -7,7 +7,7 @@ import { getOctokit, checkRateLimit } from "./github.js";
 import { debug, warn } from "./logger.js";
 import { ConfigurationError, errorMessage, rethrowIfFatal } from "./errors.js";
 import { extractRepoFromUrl } from "./utils.js";
-import type { OssScout } from "../scout.js";
+import type { ScoutStateWriter } from "./issue-vetting.js";
 
 const MODULE = "bootstrap";
 
@@ -26,7 +26,7 @@ const SEARCH_MAX_PAGES = 3;
 const PER_PAGE = 100;
 
 export async function bootstrapScout(
-  scout: OssScout,
+  scout: ScoutStateWriter,
   token: string,
 ): Promise<BootstrapResult> {
   const username = scout.getPreferences().githubUsername;

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -15,6 +15,11 @@ import {
   type SearchPriority,
   type IssueCandidate,
   type ProjectCategory,
+  type ScoutPreferences,
+  type ScoutState,
+  type MergedPRRecord,
+  type ClosedPRRecord,
+  type OpenPRRecord,
 } from "./types.js";
 import {
   ValidationError,
@@ -103,6 +108,27 @@ export interface ScoutStateReader {
    * Optional so existing implementations keep compiling; absent reads as 0.
    */
   getClosedWithoutMergeCount?(repo: string): number;
+}
+
+/**
+ * Write side of the scout state, consumed by the bootstrap flow. Defined here
+ * next to ScoutStateReader so core/bootstrap.ts can depend on this contract
+ * instead of importing the OssScout facade from the package root (an upward
+ * dependency). OssScout implements it (#156).
+ */
+export interface ScoutStateWriter {
+  /** Read current preferences (bootstrap reads githubUsername). */
+  getPreferences(): Readonly<ScoutPreferences>;
+  /** Replace the cached starred-repo list. */
+  setStarredRepos(repos: string[]): void;
+  /** Record a merged PR (deduplicated by URL). */
+  recordMergedPR(pr: MergedPRRecord): void;
+  /** Record a PR closed without merge (deduplicated by URL). */
+  recordClosedPR(pr: ClosedPRRecord): void;
+  /** Record an open PR (deduplicated by URL). */
+  recordOpenPR(pr: OpenPRRecord): void;
+  /** Snapshot the current state (bootstrap reports counts from it). */
+  getState(): Readonly<ScoutState>;
 }
 
 export class IssueVetter {

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { enableDebug, debug, info, warn } from "./logger.js";
+import {
+  enableDebug,
+  debug,
+  info,
+  warn,
+  setLogLevel,
+  getLogLevel,
+} from "./logger.js";
 
 describe("logger", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -95,6 +102,43 @@ describe("logger", () => {
       enableDebug();
       debug("mod", "should appear");
       expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("setLogLevel (#156)", () => {
+    // currentLevel is a module global; restore the default so the leveled
+    // tests don't leak state into the rest of the file.
+    afterEach(() => setLogLevel("info"));
+
+    it("silent suppresses warn, info, and debug", () => {
+      setLogLevel("silent");
+      warn("mod", "w");
+      info("mod", "i");
+      debug("mod", "d");
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("warn level emits warn but suppresses info and debug", () => {
+      setLogLevel("warn");
+      info("mod", "i");
+      debug("mod", "d");
+      expect(errorSpy).not.toHaveBeenCalled();
+      warn("mod", "w");
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("info level emits warn and info but suppresses debug", () => {
+      setLogLevel("info");
+      debug("mod", "d");
+      expect(errorSpy).not.toHaveBeenCalled();
+      info("mod", "i");
+      warn("mod", "w");
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("getLogLevel reflects the set level", () => {
+      setLogLevel("warn");
+      expect(getLogLevel()).toBe("warn");
     });
   });
 });

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -1,15 +1,43 @@
 /**
- * Lightweight debug logger for oss-scout.
- * Activated by the global --debug CLI flag.
+ * Lightweight leveled logger for oss-scout.
  *
- * All debug/warn output goes to stderr so it never contaminates
- * the --json stdout contract.
+ * All output goes to stderr so it never contaminates the --json stdout
+ * contract. The CLI raises the level to "debug" via the global --debug flag;
+ * library hosts that don't want oss-scout's "[INFO] Phase 0..." chatter can
+ * lower it with setLogLevel (or ScoutConfig.logLevel) — including to "silent"
+ * (#156).
  */
 
-let debugEnabled = false;
+export type LogLevel = "silent" | "warn" | "info" | "debug";
 
+const LEVEL_RANK: Record<LogLevel, number> = {
+  silent: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+// Default "info" preserves the historical behavior: info + warn emit, debug is
+// suppressed until --debug (enableDebug) or setLogLevel raises the level.
+let currentLevel: LogLevel = "info";
+
+/** Set the minimum level that will be emitted. */
+export function setLogLevel(level: LogLevel): void {
+  currentLevel = level;
+}
+
+/** Current minimum emitted level. */
+export function getLogLevel(): LogLevel {
+  return currentLevel;
+}
+
+/** Raise the level to "debug" (used by the CLI --debug flag). */
 export function enableDebug(): void {
-  debugEnabled = true;
+  currentLevel = "debug";
+}
+
+function shouldLog(level: Exclude<LogLevel, "silent">): boolean {
+  return LEVEL_RANK[currentLevel] >= LEVEL_RANK[level];
 }
 
 export function debug(
@@ -17,7 +45,7 @@ export function debug(
   message: string,
   ...args: unknown[]
 ): void {
-  if (!debugEnabled) return;
+  if (!shouldLog("debug")) return;
   const timestamp = new Date().toISOString();
   console.error(`[${timestamp}] [DEBUG] [${module}] ${message}`, ...args);
 }
@@ -27,6 +55,7 @@ export function info(
   message: string,
   ...args: unknown[]
 ): void {
+  if (!shouldLog("info")) return;
   const timestamp = new Date().toISOString();
   console.error(`[${timestamp}] [INFO] [${module}] ${message}`, ...args);
 }
@@ -36,6 +65,7 @@ export function warn(
   message: string,
   ...args: unknown[]
 ): void {
+  if (!shouldLog("warn")) return;
   const timestamp = new Date().toISOString();
   console.error(`[${timestamp}] [WARN] [${module}] ${message}`, ...args);
 }

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -10,6 +10,7 @@ import type {
   ScoutState,
   SearchStrategy,
 } from "./schemas.js";
+import type { LogLevel } from "./logger.js";
 
 // Re-export persisted types for convenience
 export type {
@@ -209,6 +210,12 @@ export type ScoutConfig =
       persistence?: "local" | "gist";
       /** Gist ID override (gist mode). Skips gist discovery/creation if provided. */
       gistId?: string;
+      /**
+       * Minimum log level emitted to stderr. Omitted leaves the global level
+       * (default "info"). Hosts that don't want the "[INFO] Phase 0..."
+       * chatter can pass "warn" or "silent" (#156).
+       */
+      logLevel?: LogLevel;
     }
   | {
       /** GitHub token with `repo` read scope. */
@@ -217,6 +224,12 @@ export type ScoutConfig =
       persistence: "provided";
       /** Pre-loaded state. Required when persistence is 'provided'. */
       initialState: ScoutState;
+      /**
+       * Minimum log level emitted to stderr. Omitted leaves the global level
+       * (default "info"). Hosts that don't want the "[INFO] Phase 0..."
+       * chatter can pass "warn" or "silent" (#156).
+       */
+      logLevel?: LogLevel;
     };
 
 /** Options for the search method. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,12 +89,24 @@ export { IssueDiscovery } from "./core/issue-discovery.js";
 export {
   IssueVetter,
   type ScoutStateReader,
+  type ScoutStateWriter,
   type FeatureSignals,
 } from "./core/issue-vetting.js";
 export {
   scanForAntiLLMPolicy,
   ANTI_LLM_KEYWORDS,
 } from "./core/anti-llm-policy.js";
+
+// Bootstrap (seed state from GitHub) — usable by library/MCP hosts (#156)
+export { bootstrapScout, type BootstrapResult } from "./core/bootstrap.js";
+
+// Log-level control for library hosts (#156)
+export {
+  setLogLevel,
+  getLogLevel,
+  enableDebug,
+  type LogLevel,
+} from "./core/logger.js";
 
 // Feature discovery API
 export {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -7,7 +7,10 @@
 
 import { IssueDiscovery } from "./core/issue-discovery.js";
 import { IssueVetter } from "./core/issue-vetting.js";
-import type { ScoutStateReader } from "./core/issue-vetting.js";
+import type {
+  ScoutStateReader,
+  ScoutStateWriter,
+} from "./core/issue-vetting.js";
 import {
   discoverFeatures,
   discoverFeaturesBroad,
@@ -43,7 +46,7 @@ import type {
 import { getOctokit } from "./core/github.js";
 import type { Octokit } from "@octokit/rest";
 import { loadLocalState, saveLocalState } from "./core/local-state.js";
-import { warn } from "./core/logger.js";
+import { warn, setLogLevel } from "./core/logger.js";
 import { extractRepoFromUrl } from "./core/utils.js";
 import {
   errorMessage,
@@ -133,6 +136,11 @@ function toGistOctokit(octokit: Octokit): GistOctokitLike {
  * ```
  */
 export async function createScout(config: ScoutConfig): Promise<OssScout> {
+  // Apply the host's log-level preference before any bootstrap chatter (#156).
+  if (config.logLevel !== undefined) {
+    setLogLevel(config.logLevel);
+  }
+
   let state: ScoutState;
   let gistStore: GistStateStore | null = null;
 
@@ -174,7 +182,7 @@ export async function createScout(config: ScoutConfig): Promise<OssScout> {
  * Implements ScoutStateReader so the search engine can read state
  * without knowing about the persistence layer.
  */
-export class OssScout implements ScoutStateReader {
+export class OssScout implements ScoutStateReader, ScoutStateWriter {
   private state: ScoutState;
   private dirty = false;
 


### PR DESCRIPTION
Part of #156 (the additive-injectables portion). The broader singleton threading and the probeRepoFiles consolidation are deferred (see "Deferred" below), so this does not auto-close the issue.

## 1. Logger level control

Replaces the boolean `debugEnabled` gate with a `LogLevel = "silent" | "warn" | "info" | "debug"`:

- `setLogLevel` / `getLogLevel` added; `enableDebug()` now raises the level to `"debug"` (CLI `--debug` unchanged).
- Default level `"info"` preserves the historical behavior exactly: `info` + `warn` always emit, `debug` is gated.
- `ScoutConfig.logLevel` (both variants) lets a library host silence the `[INFO] Phase 0...` chatter (including `"silent"`), applied at the top of `createScout` before any bootstrap output. Omitting it leaves the global level untouched.
- The logger controls (`setLogLevel`, `getLogLevel`, `enableDebug`, `LogLevel`) are exported from the package root.

## 2. ScoutStateWriter + export bootstrapScout

- New `ScoutStateWriter` interface next to `ScoutStateReader`, capturing the methods bootstrap calls (`getPreferences`, `setStarredRepos`, `recordMergedPR`/`recordClosedPR`/`recordOpenPR`, `getState`).
- `core/bootstrap.ts` now depends on `ScoutStateWriter` instead of importing the `OssScout` facade from the package root, removing an upward (core depends on facade) dependency. `OssScout` now `implements ScoutStateReader, ScoutStateWriter`.
- Exported `bootstrapScout` + `BootstrapResult` (and `ScoutStateWriter`) so library / MCP consumers can bootstrap, which they previously could not.

## Deferred (still open on #156)

- Threading the `octokit` / `getHttpCache()` / `getSearchBudgetTracker()` singletons through constructors (spans ~12 files; the budget tracker is read deep in the search-phases hot path, so it is not a contained change).
- The `probeRepoFiles` consolidation of the three repo-doc probing implementations (must preserve the contributing-guidelines undefined-vs-null subtlety).

These are larger, more invasive refactors that warrant their own pass.

## Verification

lint, format, typecheck clean. Full suite 860 core (+4 logger level tests) + 26 mcp green. Build passes, which validates the new `implements ScoutStateWriter` clause and that the CLI's `bootstrapScout(scout)` call satisfies the interface.