### PR TITLE
refactor(core): extract deriveRecommendation and vetAndClassify (#157)

### DIFF
--- a/packages/core/src/core/derive-recommendation.test.ts
+++ b/packages/core/src/core/derive-recommendation.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveRecommendation,
+  type RecommendationInput,
+} from "./issue-vetting.js";
+
+// All checks passing, no affinity signals — the "clean approve" baseline.
+function baseInput(
+  overrides: Partial<RecommendationInput> = {},
+): RecommendationInput {
+  return {
+    noExistingPR: true,
+    notClaimed: true,
+    clearRequirements: true,
+    contributionGuidelinesFound: true,
+    projectIsActive: true,
+    projectCheckFailed: false,
+    existingPRInconclusive: false,
+    claimInconclusive: false,
+    mergedCountInconclusive: false,
+    effectiveMergedCount: 0,
+    orgName: "owner",
+    orgHasMergedPRs: false,
+    matchesCategory: false,
+    issueClosed: false,
+    passedAllChecks: true,
+    ...overrides,
+  };
+}
+
+describe("deriveRecommendation (#157)", () => {
+  it("approves when all checks pass and nothing is inconclusive", () => {
+    const out = deriveRecommendation(baseInput());
+    expect(out.recommendation).toBe("approve");
+    expect(out.notes).toEqual([]);
+    expect(out.reasonsToApprove).toContain("No existing PR");
+    expect(out.reasonsToApprove).toContain("Active project");
+    expect(out.reasonsToSkip).toEqual([]);
+  });
+
+  it("downgrades approve to needs_review on an inconclusive check", () => {
+    const out = deriveRecommendation(baseInput({ claimInconclusive: true }));
+    expect(out.recommendation).toBe("needs_review");
+    expect(out.notes).toContain(
+      "Recommendation downgraded: one or more checks were inconclusive",
+    );
+    expect(out.notes).toContain("Could not verify claim status: API error");
+  });
+
+  it("skips a closed issue regardless of other checks", () => {
+    const out = deriveRecommendation(baseInput({ issueClosed: true }));
+    expect(out.recommendation).toBe("skip");
+    expect(out.reasonsToSkip).toContain("Issue is closed");
+  });
+
+  it("skips when more than two skip reasons accumulate", () => {
+    const out = deriveRecommendation(
+      baseInput({
+        noExistingPR: false,
+        notClaimed: false,
+        clearRequirements: false,
+        projectIsActive: false,
+        passedAllChecks: false,
+      }),
+    );
+    expect(out.recommendation).toBe("skip");
+    expect(out.reasonsToSkip.length).toBeGreaterThan(2);
+  });
+
+  it("needs_review when checks fail but fewer than three skip reasons", () => {
+    const out = deriveRecommendation(
+      baseInput({ clearRequirements: false, passedAllChecks: false }),
+    );
+    expect(out.recommendation).toBe("needs_review");
+    expect(out.reasonsToSkip).toEqual(["Unclear requirements"]);
+  });
+
+  it("emits trusted-project and org-affinity reasons from merged-PR signals", () => {
+    const out = deriveRecommendation(
+      baseInput({ effectiveMergedCount: 3, orgHasMergedPRs: true }),
+    );
+    expect(out.reasonsToApprove).toContain("Trusted project (3 PRs merged)");
+    expect(out.reasonsToApprove).toContain(
+      "Org affinity (merged PRs in other owner repos)",
+    );
+  });
+});

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -241,6 +241,60 @@ function isFeatureIssue(item: RawIssueItem): boolean {
 }
 
 /**
+ * Extract feature signals from a raw issue, vet it, and classify its horizon.
+ * Shared by the anchor (discoverFeatures) and broad (discoverFeaturesBroad)
+ * paths (#157). Returns null when vetting fails for this item so the caller
+ * can skip it; fatal errors (auth/rate-limit) propagate.
+ *
+ * `roadmapRefs` is only supplied by the anchor path: when present, the roadmap
+ * signal is threaded into both the vet call and the horizon classifier exactly
+ * as before; the broad path omits it (roadmap scraping is per-repo and kept out
+ * of the cheap broad search).
+ */
+async function vetAndClassify(
+  item: RawIssueItem,
+  vetter: IssueVetter,
+  roadmapRefs?: ReadonlySet<number>,
+): Promise<FeatureCandidate | null> {
+  const labels = extractLabels(item);
+  const hasMilestone = !!item.milestone;
+  const reactions = item.reactions?.total_count ?? 0;
+  const comments = item.comments ?? 0;
+  const wontfixNoContributor = item.created_at
+    ? detectWontfixNoContributor({ labels, createdAt: item.created_at })
+    : false;
+  const useRoadmap = roadmapRefs !== undefined;
+  const onRoadmap =
+    useRoadmap &&
+    typeof item.number === "number" &&
+    roadmapRefs.has(item.number);
+
+  let candidate;
+  try {
+    candidate = await vetter.vetIssue(item.html_url, {
+      featureSignals: {
+        reactions,
+        comments,
+        hasMilestone,
+        wontfixNoContributor,
+        ...(useRoadmap ? { onRoadmap } : {}),
+      },
+    });
+  } catch (err: unknown) {
+    rethrowIfFatal(err);
+    warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
+    return null;
+  }
+
+  const horizon = classifyHorizon({
+    hasMilestone,
+    labels,
+    ...(useRoadmap ? { isOnRoadmap: onRoadmap } : {}),
+  });
+  return { ...candidate, horizon };
+}
+
+/**
  * Orchestrate `scout features`: anchor resolution → per-repo issue listing
  * → feature-signal extraction → vetting → horizon classification → bucket split.
  *
@@ -302,37 +356,8 @@ export async function discoverFeatures(
     );
 
     for (const item of items) {
-      const labels = extractLabels(item);
-      const hasMilestone = !!item.milestone;
-      const reactions = item.reactions?.total_count ?? 0;
-      const comments = item.comments ?? 0;
-      const wontfixNoContributor = item.created_at
-        ? detectWontfixNoContributor({ labels, createdAt: item.created_at })
-        : false;
-      const onRoadmap =
-        typeof item.number === "number" && roadmapRefs.has(item.number);
-      let candidate;
-      try {
-        candidate = await opts.vetter.vetIssue(item.html_url, {
-          featureSignals: {
-            reactions,
-            comments,
-            hasMilestone,
-            wontfixNoContributor,
-            onRoadmap,
-          },
-        });
-      } catch (err: unknown) {
-        rethrowIfFatal(err);
-        warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
-        continue;
-      }
-      const horizon = classifyHorizon({
-        hasMilestone,
-        labels,
-        isOnRoadmap: onRoadmap,
-      });
-      candidates.push({ ...candidate, horizon });
+      const candidate = await vetAndClassify(item, opts.vetter, roadmapRefs);
+      if (candidate) candidates.push(candidate);
     }
   }
 
@@ -496,33 +521,10 @@ export async function discoverFeaturesBroad(
 
   const candidates: FeatureCandidate[] = [];
   for (const item of items) {
-    const labels = extractLabels(item);
-    const hasMilestone = !!item.milestone;
-    const reactions = item.reactions?.total_count ?? 0;
-    const comments = item.comments ?? 0;
-    const wontfixNoContributor = item.created_at
-      ? detectWontfixNoContributor({ labels, createdAt: item.created_at })
-      : false;
-    let candidate;
-    try {
-      candidate = await opts.vetter.vetIssue(item.html_url, {
-        featureSignals: {
-          reactions,
-          comments,
-          hasMilestone,
-          wontfixNoContributor,
-          // Roadmap scraping is per-repo and would require an extra fetch
-          // per unique repo in the broad result set — deliberately skipped
-          // here to keep the broad path cheap. Anchor mode keeps the bonus.
-        },
-      });
-    } catch (err: unknown) {
-      rethrowIfFatal(err);
-      warn(MODULE, `vet failed for ${item.html_url}: ${errorMessage(err)}`);
-      continue;
-    }
-    const horizon = classifyHorizon({ hasMilestone, labels });
-    candidates.push({ ...candidate, horizon });
+    // No roadmapRefs: roadmap scraping is per-repo and deliberately skipped
+    // on the broad path to keep it cheap. Anchor mode keeps the bonus.
+    const candidate = await vetAndClassify(item, opts.vetter);
+    if (candidate) candidates.push(candidate);
   }
 
   const passing = candidates.filter(

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -131,6 +131,137 @@ export interface ScoutStateWriter {
   getState(): Readonly<ScoutState>;
 }
 
+/**
+ * Inputs to deriveRecommendation: the already-computed check results and
+ * affinity signals. Kept as a flat record of primitives so the derivation is a
+ * pure function, independently unit-testable (#157).
+ */
+export interface RecommendationInput {
+  noExistingPR: boolean;
+  notClaimed: boolean;
+  clearRequirements: boolean;
+  contributionGuidelinesFound: boolean;
+  projectIsActive: boolean;
+  projectCheckFailed: boolean;
+  projectFailureReason?: string;
+  existingPRInconclusive: boolean;
+  existingPRReason?: string;
+  claimInconclusive: boolean;
+  claimReason?: string;
+  mergedCountInconclusive: boolean;
+  effectiveMergedCount: number;
+  orgName: string;
+  orgHasMergedPRs: boolean;
+  matchesCategory: boolean;
+  issueClosed: boolean;
+  /** noExistingPR && notClaimed && projectActive && clearRequirements. */
+  passedAllChecks: boolean;
+}
+
+export interface RecommendationOutput {
+  notes: string[];
+  reasonsToApprove: string[];
+  reasonsToSkip: string[];
+  recommendation: "approve" | "skip" | "needs_review";
+}
+
+/**
+ * Derive the human-readable notes, approve/skip reasons, and the final
+ * recommendation from a vet's check results. Pure: no I/O, no state reads — the
+ * caller computes the inputs and threads them in. Extracted from vetIssue so
+ * the recommendation logic is testable in isolation (#157).
+ */
+export function deriveRecommendation(
+  input: RecommendationInput,
+): RecommendationOutput {
+  const notes: string[] = [];
+  const reasonsToApprove: string[] = [];
+  const reasonsToSkip: string[] = [];
+
+  // Notes (order preserved from the original vetIssue body).
+  if (!input.noExistingPR) notes.push("Existing PR found for this issue");
+  if (!input.notClaimed) notes.push("Issue appears to be claimed by someone");
+  if (input.existingPRInconclusive) {
+    notes.push(
+      `Could not verify absence of existing PRs: ${input.existingPRReason || "API error"}`,
+    );
+  }
+  if (input.claimInconclusive) {
+    notes.push(
+      `Could not verify claim status: ${input.claimReason || "API error"}`,
+    );
+  }
+  if (input.projectCheckFailed) {
+    notes.push(
+      `Could not verify project activity: ${input.projectFailureReason || "API error"}`,
+    );
+  } else if (!input.projectIsActive) {
+    notes.push("Project may be inactive");
+  }
+  if (!input.clearRequirements) notes.push("Issue requirements are unclear");
+  if (!input.contributionGuidelinesFound)
+    notes.push("No CONTRIBUTING.md found");
+
+  // Reasons to skip / approve.
+  if (!input.noExistingPR) reasonsToSkip.push("Has existing PR");
+  if (!input.notClaimed) reasonsToSkip.push("Already claimed");
+  if (!input.projectIsActive && !input.projectCheckFailed)
+    reasonsToSkip.push("Inactive project");
+  if (!input.clearRequirements) reasonsToSkip.push("Unclear requirements");
+
+  if (input.noExistingPR) reasonsToApprove.push("No existing PR");
+  if (input.notClaimed) reasonsToApprove.push("Not claimed");
+  if (input.projectIsActive && !input.projectCheckFailed)
+    reasonsToApprove.push("Active project");
+  if (input.clearRequirements) reasonsToApprove.push("Clear requirements");
+  if (input.contributionGuidelinesFound)
+    reasonsToApprove.push("Has contribution guidelines");
+  if (input.effectiveMergedCount > 0) {
+    reasonsToApprove.push(
+      `Trusted project (${input.effectiveMergedCount} PR${input.effectiveMergedCount > 1 ? "s" : ""} merged)`,
+    );
+  }
+  if (input.orgHasMergedPRs) {
+    reasonsToApprove.push(
+      `Org affinity (merged PRs in other ${input.orgName} repos)`,
+    );
+  }
+  if (input.matchesCategory) {
+    reasonsToApprove.push("Matches preferred project category");
+  }
+  if (input.issueClosed) {
+    reasonsToSkip.push("Issue is closed");
+  }
+
+  // Recommendation.
+  let recommendation: "approve" | "skip" | "needs_review";
+  if (input.issueClosed) {
+    recommendation = "skip";
+  } else if (input.passedAllChecks) {
+    recommendation = "approve";
+  } else if (reasonsToSkip.length > 2) {
+    recommendation = "skip";
+  } else {
+    recommendation = "needs_review";
+  }
+
+  // Downgrade an "approve" when any check was inconclusive — "approve" should
+  // only be given when checks actually passed, not when they were skipped.
+  const hasInconclusiveChecks =
+    input.projectCheckFailed ||
+    input.existingPRInconclusive ||
+    input.claimInconclusive ||
+    input.mergedCountInconclusive;
+  if (recommendation === "approve" && hasInconclusiveChecks) {
+    recommendation = "needs_review";
+    notes.push(
+      "Recommendation downgraded: one or more checks were inconclusive",
+    );
+  }
+
+  return { notes, reasonsToApprove, reasonsToSkip, recommendation };
+}
+
 export class IssueVetter {
   private octokit: Octokit;
   private stateReader: ScoutStateReader;
@@ -247,34 +378,8 @@ export class IssueVetter {
       notes: [],
     };
 
-    // Build notes
-    if (!noExistingPR)
-      vettingResult.notes.push("Existing PR found for this issue");
-    if (!notClaimed)
-      vettingResult.notes.push("Issue appears to be claimed by someone");
-    if (existingPRCheck.inconclusive) {
-      vettingResult.notes.push(
-        `Could not verify absence of existing PRs: ${existingPRCheck.reason || "API error"}`,
-      );
-    }
-    if (claimCheck.inconclusive) {
-      vettingResult.notes.push(
-        `Could not verify claim status: ${claimCheck.reason || "API error"}`,
-      );
-    }
-    if (projectHealth.checkFailed) {
-      vettingResult.notes.push(
-        `Could not verify project activity: ${projectHealth.failureReason || "API error"}`,
-      );
-    } else if (!projectHealth.isActive) {
-      vettingResult.notes.push("Project may be inactive");
-    }
-    if (!clearRequirements)
-      vettingResult.notes.push("Issue requirements are unclear");
-    if (!contributionGuidelines)
-      vettingResult.notes.push("No CONTRIBUTING.md found");
-
-    // Create tracked issue
+    // Create tracked issue. It holds a reference to vettingResult, whose
+    // notes are filled in by deriveRecommendation below.
     const trackedIssue: TrackedIssue = {
       id: ghIssue.id,
       url: issueUrl,
@@ -291,25 +396,7 @@ export class IssueVetter {
       vettingResult,
     };
 
-    // Determine recommendation
-    const reasonsToSkip: string[] = [];
-    const reasonsToApprove: string[] = [];
-
-    if (!noExistingPR) reasonsToSkip.push("Has existing PR");
-    if (!notClaimed) reasonsToSkip.push("Already claimed");
-    if (!projectHealth.isActive && !projectHealth.checkFailed)
-      reasonsToSkip.push("Inactive project");
-    if (!clearRequirements) reasonsToSkip.push("Unclear requirements");
-
-    if (noExistingPR) reasonsToApprove.push("No existing PR");
-    if (notClaimed) reasonsToApprove.push("Not claimed");
-    if (projectHealth.isActive && !projectHealth.checkFailed)
-      reasonsToApprove.push("Active project");
-    if (clearRequirements) reasonsToApprove.push("Clear requirements");
-    if (contributionGuidelines)
-      reasonsToApprove.push("Has contribution guidelines");
-
-    // Determine effective merged PR count: prefer local state (authoritative if present),
+    // Effective merged PR count: prefer local state (authoritative if present),
     // fall back to live GitHub API count to detect contributions made before
     // using oss-scout. null means the live check transiently failed: score as
     // 0 but treat the result as inconclusive so it is not cached.
@@ -318,13 +405,8 @@ export class IssueVetter {
     const effectiveMergedCount = hasMergedPRsInRepo
       ? 1
       : (userMergedPRCount ?? 0);
-    if (effectiveMergedCount > 0) {
-      reasonsToApprove.push(
-        `Trusted project (${effectiveMergedCount} PR${effectiveMergedCount > 1 ? "s" : ""} merged)`,
-      );
-    }
 
-    // Check for org-level affinity (user has merged PRs in another repo under same org)
+    // Org-level affinity (user has merged PRs in another repo under same org).
     const orgName = repoFullName.split("/")[0];
     let orgHasMergedPRs = false;
     if (orgName && repoFullName.includes("/")) {
@@ -332,53 +414,46 @@ export class IssueVetter {
         (r) => r.startsWith(orgName + "/") && r !== repoFullName,
       );
     }
-    if (orgHasMergedPRs) {
-      reasonsToApprove.push(
-        `Org affinity (merged PRs in other ${orgName} repos)`,
-      );
-    }
 
-    // Check for category preference match
-    const projectCategories = this.stateReader.getProjectCategories();
     const matchesCategory = repoBelongsToCategory(
       repoFullName,
-      projectCategories,
+      this.stateReader.getProjectCategories(),
     );
-    if (matchesCategory) {
-      reasonsToApprove.push("Matches preferred project category");
-    }
 
     // GitHub answers 200 for closed issues, so without an explicit state
     // check a closed issue would vet as still available (#120).
     const issueClosed = ghIssue.state === "closed";
-    if (issueClosed) {
-      reasonsToSkip.push("Issue is closed");
-    }
 
-    let recommendation: "approve" | "skip" | "needs_review";
-    if (issueClosed) {
-      recommendation = "skip";
-    } else if (vettingResult.passedAllChecks) {
-      recommendation = "approve";
-    } else if (reasonsToSkip.length > 2) {
-      recommendation = "skip";
-    } else {
-      recommendation = "needs_review";
-    }
-
-    // Downgrade to needs_review if any check was inconclusive —
-    // "approve" should only be given when all checks actually passed, not when they were skipped.
+    // Never cache a verdict built on inconclusive/failed checks (e.g. a
+    // transient 5xx): that would pin a degraded result for the whole TTL.
     const hasInconclusiveChecks =
       projectHealth.checkFailed ||
-      existingPRCheck.inconclusive ||
-      claimCheck.inconclusive ||
+      !!existingPRCheck.inconclusive ||
+      !!claimCheck.inconclusive ||
       mergedCountInconclusive;
-    if (recommendation === "approve" && hasInconclusiveChecks) {
-      recommendation = "needs_review";
-      vettingResult.notes.push(
-        "Recommendation downgraded: one or more checks were inconclusive",
-      );
-    }
+
+    const { notes, reasonsToApprove, reasonsToSkip, recommendation } =
+      deriveRecommendation({
+        noExistingPR,
+        notClaimed,
+        clearRequirements,
+        contributionGuidelinesFound: !!contributionGuidelines,
+        projectIsActive: projectHealth.isActive,
+        projectCheckFailed: !!projectHealth.checkFailed,
+        projectFailureReason: projectHealth.failureReason,
+        existingPRInconclusive: !!existingPRCheck.inconclusive,
+        existingPRReason: existingPRCheck.reason,
+        claimInconclusive: !!claimCheck.inconclusive,
+        claimReason: claimCheck.reason,
+        mergedCountInconclusive,
+        effectiveMergedCount,
+        orgName,
+        orgHasMergedPRs,
+        matchesCategory,
+        issueClosed,
+        passedAllChecks: vettingResult.passedAllChecks,
+      });
+    vettingResult.notes = notes;
 
     // Calculate repo quality bonus from star/fork counts
     const repoQualityBonus = calculateRepoQualityBonus(


### PR DESCRIPTION
Part of #157. Delivers the two genuine function extractions; the cli.ts renderer move and the searchIssues phase-runner table are deferred (see "Deferred"), so this does not auto-close the issue.

## 1. `deriveRecommendation` (issue-vetting.ts)

The notes / approve-skip-reasons / recommendation logic is lifted out of `IssueVetter.vetIssue` into an exported pure function `deriveRecommendation(input): RecommendationOutput`, independently unit-testable.

- `vetIssue` keeps the value computations it still needs downstream (`effectiveMergedCount`, `mergedCountInconclusive`, org affinity, category match, `issueClosed`) and recomputes `hasInconclusiveChecks` for the cache-skip guard.
- Behavior is preserved exactly: identical note ordering (base notes, then the downgrade note, then the repo-quality note pushed after), identical reason content/order, and identical recommendation + inconclusive-downgrade logic. Verified by the existing 32 `vetIssue` tests plus 6 new focused `deriveRecommendation` tests.

## 2. `vetAndClassify` (feature-discovery.ts)

Collapses the duplicated per-item vet-and-classify body shared by `discoverFeatures` (anchor) and `discoverFeaturesBroad` (broad).

- The roadmap signal is threaded only on the anchor path (keyed on whether `roadmapRefs` is supplied), exactly as before. The broad path omits both the `onRoadmap` featureSignal and the `isOnRoadmap` horizon input (keys genuinely absent, matching the original).
- A vet failure returns `null` so the caller skips the item, equivalent to the original `continue`.

## Deferred (still open on #157)

- Moving the search/features/vet/vet-list human renderers from cli.ts into `formatters/human.ts` (a pure code move, but cli.ts has no renderer-level test coverage to guard the populated-output paths, so it warrants its own pass with dedicated rendering tests).
- The `IssueDiscovery.searchIssues` phase-runner table: the four phase gates carry bespoke per-phase delay logic, so tabling them risks subtle timing/ordering changes; this is the largest and riskiest split and deserves a focused PR.

## Verification

lint, format, typecheck clean. Full suite 866 core (+6 deriveRecommendation tests; existing 32 vetIssue + 46 feature-discovery still green) + 26 mcp.