### PR TITLE
test: cover high-value untested branches (#162)

### DIFF
--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -211,6 +211,40 @@ describe("GistStateStore", () => {
       expect(cached.preferences.githubUsername).toBe("cached-user");
     });
 
+    it("falls back to the local cache when a found gist has unparseable content (data-loss guard #162)", async () => {
+      // Seed a local cache so the fallback has something to return.
+      const cachedState = makeState({
+        preferences: { githubUsername: "cached-user" },
+      });
+      fs.writeFileSync(
+        path.join(tempDir, "state-cache.json"),
+        JSON.stringify(cachedState),
+      );
+
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({
+          data: [{ id: "found-gist", description: "oss-scout-state" }],
+        }),
+        // The gist exists but its state.json is corrupt, so fetchGistState
+        // returns null — we must NOT create a new gist (that would orphan the
+        // user's real state); fall back to cache in degraded mode instead.
+        get: vi.fn().mockResolvedValue({
+          data: {
+            id: "found-gist",
+            files: { "state.json": { content: "{ not valid json" } },
+          },
+        }),
+        create: vi.fn(),
+      });
+
+      const store = new GistStateStore(octokit);
+      const result = await store.bootstrap();
+
+      expect(result.degraded).toBe(true);
+      expect(result.state.preferences.githubUsername).toBe("cached-user");
+      expect(octokit.gists.create).not.toHaveBeenCalled();
+    });
+
     describe("degraded mode", () => {
       it("falls back to local cache on API failure", async () => {
         const cachedState = makeState({
@@ -429,6 +463,44 @@ describe("GistStateStore", () => {
       const ok = await store.push(makeState());
 
       expect(ok).toBe(false);
+    });
+
+    it("refuses to write a state that exceeds the 900KB gist limit (#162)", async () => {
+      const update = vi.fn().mockResolvedValue({ data: { id: "gist-1" } });
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({
+          data: [{ id: "gist-1", description: "oss-scout-state" }],
+        }),
+        get: vi.fn().mockResolvedValue(gistResponse(makeState(), "gist-1")),
+        update,
+      });
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      // One saved result with a >900KB title pushes the serialized state past
+      // the guard threshold.
+      const huge = makeState({
+        savedResults: [
+          {
+            issueUrl: "https://github.com/a/b/issues/1",
+            repo: "a/b",
+            number: 1,
+            title: "x".repeat(1_000_000),
+            labels: [],
+            recommendation: "approve" as const,
+            viabilityScore: 80,
+            searchPriority: "normal",
+            firstSeenAt: "2026-06-01T00:00:00Z",
+            lastSeenAt: "2026-06-01T00:00:00Z",
+            lastScore: 80,
+          },
+        ],
+      });
+
+      const ok = await store.push(huge);
+
+      expect(ok).toBe(false);
+      expect(update).not.toHaveBeenCalled();
     });
 
     it("merges the concurrent remote state before writing, not last-writer-wins (#117)", async () => {
@@ -690,6 +762,50 @@ describe("mergeStates", () => {
     const merged = mergeStates(local, remote);
     expect(merged.savedResults.find((r) => r.issueUrl === url)).toBeUndefined();
     expect(merged.skippedIssues.find((s) => s.url === url)).toBeDefined();
+  });
+
+  it("merges skipped issues by URL, keeping the newer skippedAt and unioning distinct URLs (#162)", () => {
+    const shared = "https://github.com/a/b/issues/1";
+    const local = makeState({
+      skippedIssues: [
+        {
+          url: shared,
+          repo: "a/b",
+          number: 1,
+          title: "old",
+          skippedAt: "2026-06-01T00:00:00Z",
+        },
+      ],
+    });
+    const remote = makeState({
+      skippedIssues: [
+        {
+          url: shared,
+          repo: "a/b",
+          number: 1,
+          title: "newer",
+          skippedAt: "2026-06-05T00:00:00Z",
+        },
+        {
+          url: "https://github.com/a/b/issues/2",
+          repo: "a/b",
+          number: 2,
+          title: "remote-only",
+          skippedAt: "2026-06-02T00:00:00Z",
+        },
+      ],
+    });
+
+    const merged = mergeStates(local, remote);
+    const sharedEntry = merged.skippedIssues.find((s) => s.url === shared);
+    expect(sharedEntry?.title).toBe("newer");
+    expect(sharedEntry?.skippedAt).toBe("2026-06-05T00:00:00Z");
+    expect(
+      merged.skippedIssues.find(
+        (s) => s.url === "https://github.com/a/b/issues/2",
+      ),
+    ).toBeDefined();
+    expect(merged.skippedIssues).toHaveLength(2);
   });
 
   it("unions mergedPRs by URL", () => {

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -565,3 +565,81 @@ describe("OssScout.features", () => {
     );
   });
 });
+
+describe("OssScout checkpoint + scoring branches (#162)", () => {
+  type GistStoreArg = ConstructorParameters<typeof OssScout>[2];
+
+  it("returns false and keeps the dirty flag when the gist push fails", async () => {
+    const push = vi.fn().mockResolvedValue(false);
+    const gistStore = { push } as unknown as GistStoreArg;
+    const scout = new OssScout(
+      "test-token",
+      ScoutStateSchema.parse({ version: 1 }),
+      gistStore,
+    );
+
+    // Dirty the scout so checkpoint actually attempts a push.
+    scout.updatePreferences({ minStars: 123 });
+
+    expect(await scout.checkpoint()).toBe(false);
+    expect(push).toHaveBeenCalledTimes(1);
+
+    // Still dirty: the next checkpoint must retry the push, not no-op.
+    expect(await scout.checkpoint()).toBe(false);
+    expect(push).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns true without pushing when nothing is dirty", async () => {
+    const push = vi.fn().mockResolvedValue(true);
+    const gistStore = { push } as unknown as GistStoreArg;
+    const scout = new OssScout(
+      "test-token",
+      ScoutStateSchema.parse({ version: 1 }),
+      gistStore,
+    );
+
+    expect(await scout.checkpoint()).toBe(true);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  describe("updateRepoScore signal branches", () => {
+    function scoreAfter(update: Parameters<OssScout["updateRepoScore"]>[1]) {
+      const scout = new OssScout(
+        "test-token",
+        ScoutStateSchema.parse({ version: 1 }),
+      );
+      scout.updateRepoScore("owner/repo", update);
+      return scout.getRepoScore("owner/repo");
+    }
+
+    it("subtracts 2 for hostile comments", () => {
+      expect(scoreAfter({ signals: { hasHostileComments: true } })).toBe(3);
+    });
+
+    it("adds 1 each for responsive and active maintainers", () => {
+      expect(
+        scoreAfter({
+          signals: { isResponsive: true, hasActiveMaintainers: true },
+        }),
+      ).toBe(7);
+    });
+
+    it("clamps the upper bound at 10", () => {
+      expect(
+        scoreAfter({
+          mergedPRCount: 3,
+          signals: { isResponsive: true, hasActiveMaintainers: true },
+        }),
+      ).toBe(10);
+    });
+
+    it("clamps the lower bound at 1", () => {
+      expect(
+        scoreAfter({
+          closedWithoutMergeCount: 3,
+          signals: { hasHostileComments: true },
+        }),
+      ).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Part of #162. Adds coverage for 5 of the 9 flagged branch gaps (the higher-value, well-bounded ones); the rest are noted as a follow-up below, so this does not auto-close the issue.

## Covered

- **`checkpoint()` failure**: when the gist push returns false, `checkpoint()` returns false and keeps the dirty flag so the next checkpoint retries the push (and a clean scout checkpoints `true` without pushing at all).
- **`updateRepoScore` signal branches**: hostile comments (−2), responsive + active maintainers (+1 each), and both the upper (10) and lower (1) clamps.
- **`mergeSkippedIssues`** via `mergeStates`: the newer `skippedAt` wins for a shared URL, and distinct URLs are unioned.
- **`push()` 900KB size guard**: a state that serializes past the limit returns false without calling `gists.update`.
- **Bootstrap data-loss guard**: a found gist whose content is unparseable falls back to the local cache (degraded mode) instead of creating a new gist that would orphan the user's real state.

## Remaining (still open on #162)

- `createScout` with `persistence: "gist"` (degraded warn, `mergeStates`, gistId precedence) and the `toGistOctokit` adapter — needs module-level mocking of the gist store.
- `vetList` mixed success-then-401 partial-results-discard path.
- repo-health's low-coverage parsers (CI-status determination, `avgIssueResponseDays`, the guideline parsers).
- `issue-eligibility`'s caching contract, which needs the shared mock instances hoisted before cache-hit / error-not-cached tests can assert anything.

## Verification

Full suite 881 core (+9) + 26 mcp green. lint, format, typecheck clean. Test-only; no production code changed.