### PR TITLE
test(e2e): make search-flow a real pipeline test (#161)

### DIFF
--- a/packages/core/src/e2e/search-flow.test.ts
+++ b/packages/core/src/e2e/search-flow.test.ts
@@ -1,223 +1,222 @@
 /**
- * E2E test — exercises the full OssScout flow without hitting GitHub.
+ * E2E test — exercises the real OssScout search pipeline end-to-end.
  *
- * Uses the real OssScout class with provided state, verifying:
- *   search → saveResults → getSavedResults → clearResults
+ * Only the Octokit boundary is mocked (canned search / timeline / repo / content
+ * responses). Discovery, phase gating, filtering, vetting, scoring, and
+ * persistence all run for real, so this catches cross-phase regressions that a
+ * test mocking the whole IssueDiscovery engine cannot (#161).
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { OssScout } from "../scout.js";
-import { ScoutStateSchema } from "../core/schemas.js";
-import type { ScoutState } from "../core/schemas.js";
-import type { IssueCandidate, SearchResult } from "../core/types.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
 
-// ── Mock the IssueDiscovery layer (avoids hitting GitHub) ────────────
+let tmpDir: string;
 
-function makeFakeCandidate(
-  overrides: Partial<IssueCandidate> = {},
-): IssueCandidate {
-  return {
-    issue: {
-      id: 101,
-      url: "https://github.com/test-org/test-repo/issues/7",
-      repo: "test-org/test-repo",
-      number: 7,
-      title: "Add dark mode support",
-      status: "candidate",
-      labels: ["enhancement", "good first issue"],
-      createdAt: "2025-01-01T00:00:00Z",
-      updatedAt: "2025-01-05T00:00:00Z",
-      vetted: true,
-    },
-    vettingResult: {
-      passedAllChecks: true,
-      checks: {
-        noExistingPR: true,
-        notClaimed: true,
-        projectActive: true,
-        clearRequirements: true,
-        contributionGuidelinesFound: true,
-      },
-      notes: [],
-    },
-    projectHealth: {
-      repo: "test-org/test-repo",
-      lastCommitAt: "2025-01-04T00:00:00Z",
-      daysSinceLastCommit: 1,
-      openIssuesCount: 20,
-      avgIssueResponseDays: 0.5,
-      ciStatus: "passing",
-      isActive: true,
-    },
-    recommendation: "approve",
-    reasonsToSkip: [],
-    reasonsToApprove: ["Active project", "Good first issue"],
-    viabilityScore: 88,
-    searchPriority: "normal",
-    ...overrides,
+// Mock only the Octokit boundary. getOctokit is shared by discovery, the
+// budget pre-flight (checkRateLimit), and vetting, so one fake octokit drives
+// the whole pipeline. checkRateLimit stays real (it calls the mocked
+// getOctokit internally).
+const { fakeOctokit } = vi.hoisted(() => {
+  // Recent so the issue survives buildIssueFilter's maxIssueAgeDays (90) gate
+  // and the repo reads as active. created_at can stay old.
+  const recentIso = new Date(
+    Date.now() - 3 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const issueItem = {
+    id: 101,
+    html_url: "https://github.com/test-org/test-repo/issues/7",
+    number: 7,
+    title: "Add dark mode support to the settings panel",
+    body: "We should add a dark mode toggle. Steps: 1) add a theme context, 2) wire the toggle, 3) persist the choice.",
+    labels: [{ name: "good first issue" }, { name: "enhancement" }],
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: recentIso,
+    state: "open",
+    user: { login: "maintainer" },
+    repository_url: "https://api.github.com/repos/test-org/test-repo",
   };
-}
 
-vi.mock("../core/issue-discovery.js", () => {
-  return {
-    IssueDiscovery: class MockIssueDiscovery {
-      rateLimitWarning: string | null = null;
-      async searchIssues() {
-        return {
-          candidates: [makeFakeCandidate()],
-          strategiesUsed: ["broad" as const],
-        };
-      }
-      async vetIssue() {
-        return makeFakeCandidate();
-      }
+  const fakeOctokit = {
+    rateLimit: {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          resources: {
+            // reset is read via new Date(reset * 1000); use a far-future epoch.
+            search: { remaining: 5000, limit: 5000, reset: 4102444800 },
+            core: { remaining: 5000, limit: 5000, reset: 4102444800 },
+          },
+        },
+      }),
+    },
+    search: {
+      issuesAndPullRequests: vi.fn(async ({ q }: { q: string }) => {
+        // The user's merged-PR affinity check searches for is:pr is:merged.
+        if (typeof q === "string" && q.includes("is:pr")) {
+          return { data: { total_count: 0, items: [] } };
+        }
+        // Issue discovery phases.
+        return { data: { total_count: 1, items: [issueItem] } };
+      }),
+    },
+    issues: {
+      // vetIssue re-fetches the full issue by URL.
+      get: vi.fn().mockResolvedValue({
+        data: {
+          id: 101,
+          number: 7,
+          title: "Add dark mode support to the settings panel",
+          body: "We should add a dark mode toggle. Steps: 1) add a theme context, 2) wire the toggle, 3) persist the choice.",
+          state: "open",
+          labels: [{ name: "good first issue" }, { name: "enhancement" }],
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: recentIso,
+          user: { login: "maintainer" },
+          html_url: "https://github.com/test-org/test-repo/issues/7",
+        },
+      }),
+      listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
+      listComments: vi.fn().mockResolvedValue({ data: [] }),
+      listForRepo: vi.fn().mockResolvedValue({ data: [] }),
+    },
+    repos: {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          pushed_at: recentIso,
+          stargazers_count: 500,
+          forks_count: 40,
+          open_issues_count: 12,
+          owner: { login: "test-org" },
+          name: "test-repo",
+        },
+      }),
+      listCommits: vi.fn().mockResolvedValue({
+        data: [{ commit: { author: { date: recentIso } } }],
+      }),
+      // No CONTRIBUTING / CODE_OF_CONDUCT / README files: 404 = clean absent.
+      getContent: vi
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error("Not Found"), { status: 404 }),
+        ),
     },
   };
+  return { fakeOctokit };
 });
 
-// Stub the shared cache singleton so search()'s evictStale call never
-// touches the real ~/.oss-scout/cache during tests.
-const { evictStaleMock } = vi.hoisted(() => ({
-  evictStaleMock: vi.fn(() => 0),
-}));
-vi.mock("../core/http-cache.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../core/http-cache.js")>();
+vi.mock("../core/github.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../core/github.js")>();
   return {
     ...actual,
-    getHttpCache: () =>
-      ({ evictStale: evictStaleMock }) as unknown as ReturnType<
-        typeof actual.getHttpCache
-      >,
+    getOctokit: () =>
+      fakeOctokit as unknown as ReturnType<typeof actual.getOctokit>,
+    // checkRateLimit calls github.js's INTERNAL getOctokit (intra-module
+    // binding the export override can't reach), so stub it directly.
+    checkRateLimit: async () => ({
+      remaining: 5000,
+      limit: 5000,
+      resetAt: new Date(4102444800000).toISOString(),
+    }),
   };
 });
 
-// ── Helpers ──────────────────────────────────────────────────────────
+// Real on-disk cache, pointed at a temp dir so the pipeline's caching runs for
+// real without touching ~/.oss-scout.
+vi.mock("../core/http-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../core/http-cache.js")>();
+  let cache: InstanceType<typeof actual.HttpCache> | null = null;
+  return {
+    ...actual,
+    getHttpCache: () => {
+      if (!cache) cache = new actual.HttpCache(tmpDir);
+      return cache;
+    },
+  };
+});
 
-function makeState(overrides: Partial<ScoutState> = {}): ScoutState {
-  return ScoutStateSchema.parse({ version: 1, ...overrides });
+vi.mock("../core/logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  setLogLevel: vi.fn(),
+  getLogLevel: vi.fn(() => "info"),
+  enableDebug: vi.fn(),
+}));
+
+const { OssScout } = await import("../scout.js");
+const { ScoutStateSchema } = await import("../core/schemas.js");
+
+function freshScout() {
+  const state = ScoutStateSchema.parse({
+    version: 1,
+    preferences: {
+      githubUsername: "tester",
+      // Permissive filters so the canned issue survives to vetting.
+      languages: ["any"],
+      labels: ["good first issue", "help wanted"],
+      minStars: 0,
+      minRepoScoreThreshold: 1,
+    },
+  });
+  return new OssScout("test-token", state);
 }
 
-// ── Tests ────────────────────────────────────────────────────────────
-
-describe("E2E: search flow", () => {
-  let scout: OssScout;
-
+describe("search pipeline e2e (#161)", () => {
   beforeEach(() => {
-    scout = new OssScout("fake-token", makeState());
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oss-scout-e2e-"));
+    vi.clearAllMocks();
   });
 
-  it("search evicts stale cache entries exactly once per invocation", async () => {
-    evictStaleMock.mockClear();
-    await scout.search({ maxResults: 5 });
-    expect(evictStaleMock).toHaveBeenCalledTimes(1);
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("search returns candidates", async () => {
-    const result: SearchResult = await scout.search({ maxResults: 5 });
+  it("runs discovery, vetting, and scoring against the Octokit boundary", async () => {
+    const scout = freshScout();
 
-    expect(result.candidates).toHaveLength(1);
-    expect(result.candidates[0].issue.repo).toBe("test-org/test-repo");
-    expect(result.candidates[0].viabilityScore).toBe(88);
-    expect(result.strategiesUsed).toEqual(["broad"]);
-  });
+    const result = await scout.search({
+      maxResults: 5,
+      interPhaseDelayMs: 0,
+      broadPhaseDelayMs: 0,
+    });
 
-  it("saveResults persists candidates to state", async () => {
-    const result = await scout.search({ maxResults: 5 });
-
-    scout.saveResults(result.candidates);
-
-    const saved = scout.getSavedResults();
-    expect(saved).toHaveLength(1);
-    expect(saved[0].issueUrl).toBe(
-      "https://github.com/test-org/test-repo/issues/7",
-    );
-    expect(saved[0].repo).toBe("test-org/test-repo");
-    expect(saved[0].number).toBe(7);
-    expect(saved[0].title).toBe("Add dark mode support");
-    expect(saved[0].viabilityScore).toBe(88);
-    expect(saved[0].recommendation).toBe("approve");
-  });
-
-  it("getSavedResults returns persisted results", async () => {
-    const result = await scout.search({ maxResults: 5 });
-    scout.saveResults(result.candidates);
-
-    // Re-read
-    const savedAgain = scout.getSavedResults();
-    expect(savedAgain).toHaveLength(1);
-    expect(savedAgain[0].issueUrl).toBe(
-      "https://github.com/test-org/test-repo/issues/7",
-    );
-  });
-
-  it("clearResults removes all saved results", async () => {
-    const result = await scout.search({ maxResults: 5 });
-    scout.saveResults(result.candidates);
-    expect(scout.getSavedResults()).toHaveLength(1);
-
-    scout.clearResults();
-
-    expect(scout.getSavedResults()).toEqual([]);
-  });
-
-  it("full flow: search → save → verify → clear → verify empty", async () => {
-    // 1. Search
-    const result = await scout.search({ maxResults: 10 });
+    // The real discovery engine selected at least one strategy and the canned
+    // issue crossed phase gating + filtering into a vetted candidate.
+    expect(result.strategiesUsed.length).toBeGreaterThan(0);
     expect(result.candidates.length).toBeGreaterThan(0);
 
-    // 2. Save
+    const candidate = result.candidates[0];
+    expect(candidate.issue.repo).toBe("test-org/test-repo");
+    expect(candidate.issue.number).toBe(7);
+    // Scoring ran for real (a number in range), not a canned value.
+    expect(typeof candidate.viabilityScore).toBe("number");
+    expect(candidate.viabilityScore).toBeGreaterThanOrEqual(0);
+    // Vetting ran for real: no PR (empty timeline) and not claimed (no comments).
+    expect(candidate.vettingResult.checks.noExistingPR).toBe(true);
+    expect(candidate.vettingResult.checks.notClaimed).toBe(true);
+    // The real project-health check consumed the repo + commits responses.
+    expect(fakeOctokit.repos.get).toHaveBeenCalled();
+
+    // Real search-API calls were issued (not a mocked IssueDiscovery).
+    expect(fakeOctokit.search.issuesAndPullRequests).toHaveBeenCalled();
+  });
+
+  it("persists vetted results via saveResults (the command-layer bookkeeping)", async () => {
+    const scout = freshScout();
+    const result = await scout.search({
+      maxResults: 5,
+      interPhaseDelayMs: 0,
+      broadPhaseDelayMs: 0,
+    });
+
+    // search() returns candidates; the command layer persists them. Mirror it.
     scout.saveResults(result.candidates);
 
-    // 3. Verify saved
     const saved = scout.getSavedResults();
-    expect(saved).toHaveLength(result.candidates.length);
-    expect(saved[0].repo).toBe(result.candidates[0].issue.repo);
-
-    // 4. Clear
-    scout.clearResults();
-
-    // 5. Verify empty
-    expect(scout.getSavedResults()).toEqual([]);
-  });
-
-  it("search updates lastSearchAt in state", async () => {
-    const stateBefore = scout.getState();
-    expect(stateBefore.lastSearchAt).toBeUndefined();
-
-    await scout.search({ maxResults: 5 });
-
-    const stateAfter = scout.getState();
-    expect(stateAfter.lastSearchAt).toBeDefined();
-    // Should be a valid ISO date
-    const parsed = new Date(stateAfter.lastSearchAt!);
-    expect(parsed.getTime()).not.toBeNaN();
-  });
-
-  it("marks scout as dirty after search", async () => {
-    expect(scout.isDirty()).toBe(false);
-
-    await scout.search({ maxResults: 5 });
-
-    expect(scout.isDirty()).toBe(true);
-  });
-
-  it("checkpoint resets dirty flag", async () => {
-    await scout.search({ maxResults: 5 });
-    expect(scout.isDirty()).toBe(true);
-
-    const ok = await scout.checkpoint();
-
-    expect(ok).toBe(true);
-    expect(scout.isDirty()).toBe(false);
-  });
-
-  it("saveResults deduplicates by URL", async () => {
-    const result = await scout.search({ maxResults: 5 });
-
-    scout.saveResults(result.candidates);
-    scout.saveResults(result.candidates); // save again
-
-    const saved = scout.getSavedResults();
-    expect(saved).toHaveLength(1); // not 2
+    expect(saved.length).toBe(result.candidates.length);
+    expect(saved.some((r) => r.issueUrl.includes("test-repo/issues/7"))).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
Closes #161.

The old e2e did `vi.mock("../core/issue-discovery.js")`, replacing the whole discovery engine with a class returning one canned candidate. Nothing crossed phases, filtering, vetting, or scoring, so it only exercised OssScout bookkeeping that's already covered in scout.test.ts / skip.test.ts.

## Now a real e2e

Mocks only the Octokit boundary and lets the real pipeline run end-to-end:

- **`getOctokit`** is mocked to return one fake octokit shared by discovery, the budget pre-flight, and vetting. **`checkRateLimit`** is stubbed too, because it calls github.js's *internal* `getOctokit` binding that an export override can't reach (intra-module ESM binding).
- **`getHttpCache`** returns a real `HttpCache` pointed at a temp dir, so the pipeline's caching runs for real without touching `~/.oss-scout`.
- The fake provides canned `search` / `issues.get` / `listEventsForTimeline` / `listComments` / `repos.get` / `listCommits` / `getContent` responses tuned so one issue survives discovery → phase gating → the `maxIssueAgeDays` filter → vetting → scoring.

## What it asserts

The real discovery selected a strategy, the canned issue crossed phase gating and filtering into a vetted candidate with a scoring-computed `viabilityScore` (not a canned value), the real vetting checks ran (`noExistingPR`, `notClaimed` derived from the empty timeline/comments), and the real search/repo API calls were issued. This is the path that would catch the Phase 1 label-semantics class of bug the issue mentions.

## Verification

Both e2e tests pass (stable across runs). Full suite 873 core + 26 mcp green. lint, format, typecheck clean. Test-only; no production code changed.