### PR TITLE
docs: fix accumulated drift (README, CLAUDE.md, plugin.json) (#163)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oss-scout",
   "version": "0.11.0",
-  "description": "Find open source issues personalized to your contribution history. Three-strategy search, deep vetting, and viability scoring.",
+  "description": "Find open source issues personalized to your contribution history. Four-strategy search, deep vetting, and viability scoring.",
   "author": {
     "name": "John Costa",
     "url": "https://github.com/costajohnt"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ oss-scout is a standalone tool for finding open source issues personalized to yo
 
 1. **`packages/core`** (`@oss-scout/core`) — Library + CLI. Multi-strategy search engine, issue vetting, viability scoring, and the `OssScout` public API class.
 
-2. **`packages/mcp-server`** (`@oss-scout/mcp`) — MCP server exposing search, vet, config tools and scout:// resources.
+2. **`packages/mcp-server`** (`@oss-scout/mcp`) — MCP server exposing search, scout-features, vet, skip, config, and config-set tools plus scout:// resources.
 
 ### Key Design Decisions
 
@@ -26,23 +26,34 @@ oss-scout is a standalone tool for finding open source issues personalized to yo
 packages/core/src/
 ├── index.ts              # Public API exports
 ├── scout.ts              # OssScout class + createScout() factory
-├── cli.ts                # Commander CLI (10 commands)
+├── cli.ts                # Commander CLI (9 top-level commands)
 ├── commands/             # CLI subcommands
 │   ├── setup.ts          # Interactive first-run configuration
-│   ├── config.ts         # View/update preferences (strategy map pattern)
+│   ├── config.ts         # View/update preferences
 │   ├── search.ts         # Multi-strategy search with result persistence
+│   ├── features.ts       # Feature opportunities in anchor repos
 │   ├── vet.ts            # Single issue vetting
 │   ├── vet-list.ts       # Batch re-vetting of saved results
+│   ├── skip.ts           # Manage the skip list
 │   ├── results.ts        # View/clear saved search results
+│   ├── command-scout.ts  # Build a scout honoring the persistence preference
+│   ├── with-scout.ts     # Shared create/persist scaffolding for commands
 │   └── validation.ts     # URL validation helpers
 ├── core/                 # Domain logic
 │   ├── schemas.ts        # Zod schemas for ScoutState, ScoutPreferences
 │   ├── types.ts          # Ephemeral types, config interfaces
 │   ├── issue-discovery.ts # 4 extracted phase functions + orchestrator
-│   ├── issue-vetting.ts  # Parallel vetting pipeline + ScoutStateReader
+│   ├── issue-vetting.ts  # Parallel vetting pipeline + ScoutStateReader/Writer
 │   ├── issue-eligibility.ts # PR existence, claim detection, requirements
 │   ├── issue-scoring.ts  # Viability scoring (pure functions, 0-100)
 │   ├── issue-filtering.ts # Spam detection, doc-only filtering
+│   ├── anti-llm-policy.ts # Detect repos with anti-AI contribution policies
+│   ├── feature-discovery.ts # `scout features` anchor + broad discovery
+│   ├── personalization.ts # preferLanguages/preferRepos sort boosts + diversity
+│   ├── linked-pr.ts      # Stalled linked-PR detection (revive opportunities)
+│   ├── roadmap.ts        # ROADMAP.md issue-reference scraping
+│   ├── slm-triage.ts     # Optional Ollama SLM pre-triage during vetting
+│   ├── preference-fields.ts # Shared config-set field map (CLI + MCP)
 │   ├── search-phases.ts  # Search helpers, caching, batched search
 │   ├── search-budget.ts  # Rate limit management (30 req/min sliding window)
 │   ├── repo-health.ts    # Project health checks, CONTRIBUTING.md parsing
@@ -61,7 +72,7 @@ packages/core/src/
 
 packages/mcp-server/src/
 ├── index.ts              # MCP server entry point (stdio transport)
-├── tools.ts              # 4 tools: search, vet, config, config-set
+├── tools.ts              # 6 tools: search, scout-features, vet, skip, config, config-set
 ├── resources.ts          # 3 resources: scout://config, results, scores
 └── tools.test.ts         # Tool registration tests
 
@@ -76,7 +87,7 @@ Plugin (repo root):
 
 ```bash
 pnpm install              # Install all workspace dependencies
-pnpm test                 # Run all tests (331 tests, 22 files)
+pnpm test                 # Run all tests (~900 tests across 44 files)
 pnpm run bundle           # Rebuild CLI bundle
 pnpm run lint             # ESLint
 pnpm run format:check     # Prettier check

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ oss-scout config reset                               # reset to defaults
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `githubUsername` | string | (detected) | Your GitHub login; seeds personalization |
 | `languages` | string[] | any (all languages) | Programming language filter (use "any" for no filter) |
 | `labels` | string[] | good first issue, help wanted | Issue label filter |
 | `scope` | enum[] | all | Difficulty: beginner, intermediate, advanced |
@@ -236,11 +237,18 @@ oss-scout config reset                               # reset to defaults
 | `includeDocIssues` | boolean | true | Include documentation-only issues |
 | `minRepoScoreThreshold` | number | 4 | Skip repos scoring below this (1-10) |
 | `excludeRepos` | string[] | [] | Repos to never search |
+| `excludeOrgs` | string[] | [] | Orgs to never search |
 | `aiPolicyBlocklist` | string[] | matplotlib/matplotlib | Repos with anti-AI policies |
 | `projectCategories` | enum[] | [] | Topic filter: devtools, web-frameworks, etc. |
+| `defaultStrategy` | enum[] | all | Default search strategies: merged, starred, broad, maintained |
+| `interPhaseDelayMs` | number | 30000 | Delay between search phases (rate-limit pacing) |
+| `broadPhaseDelayMs` | number | 90000 | Extra delay before the broad phase |
+| `skipBroadWhenSufficientResults` | number | 8 | Skip the broad phase once this many candidates are found (0 disables) |
 | `persistence` | enum | local | State storage: local or gist |
 | `slmTriageModel` | string | (disabled) | Ollama model id for local SLM pre-triage during vetting (e.g. `gemma4:e4b`); empty disables it |
 | `slmTriageHost` | string | (127.0.0.1:11434) | Override the Ollama HTTP host when it runs on another machine |
+| `featuresAnchorThreshold` | number | 3 | Min merged-PR count for a repo to be a `features` anchor (1-50) |
+| `featuresSplitRatio` | number | 0.6 | `features` quick-wins / bigger-bets split (0-1) |
 
 ## Install Options
 
@@ -281,7 +289,7 @@ Agents (dispatched automatically by Claude):
 }
 ```
 
-**Tools:** search, vet, skip, config, config-set
+**Tools:** search, scout-features, vet, skip, config, config-set
 **Resources:** scout://config, scout://results, scout://scores
 
 ### As a Library
@@ -301,12 +309,13 @@ for (const c of results.candidates) {
 }
 ```
 
-Two persistence modes:
-- **`'provided'`** — caller manages state (for embedding in other tools)
-- **`'gist'`** — oss-scout manages state via private GitHub gist
+Three persistence modes:
+- **`'local'`** (default) — loads and saves `~/.oss-scout/state.json`
+- **`'gist'`** — oss-scout manages state via a private GitHub gist
+- **`'provided'`** — caller owns the state object (for embedding in other tools)
 
 ```typescript
-// Host application provides state
+// Host application provides and owns the state
 const scout = await createScout({
   githubToken: token,
   persistence: 'provided',
@@ -316,7 +325,11 @@ const scout = await createScout({
 // Record PR outcomes to improve future search quality
 scout.recordMergedPR({ url, title, mergedAt, repo });
 scout.recordClosedPR({ url, title, closedAt, repo });
-await scout.checkpoint(); // push to gist
+
+// checkpoint() persists according to the mode: it writes local state in
+// 'local' mode and pushes the gist in 'gist' mode. In 'provided' mode the
+// caller owns persistence, so checkpoint() does not write — read scout.getState().
+await scout.checkpoint();
 ```
 
 ## Viability Scoring (0-100)
@@ -341,7 +354,10 @@ Score is clamped to 0-100. Results sorted by: search priority > recommendation >
 ## CLI Reference
 
 ```
-oss-scout [--debug] [--json] <command>
+oss-scout [--debug] <command> [--json]
+
+Note: --debug is program-level; --json is a per-subcommand flag (it goes after
+the command, e.g. `oss-scout search --json`, not `oss-scout --json search`).
 
 Setup:
   setup                         Interactive first-run configuration
@@ -350,6 +366,13 @@ Setup:
 Search:
   search [count]                Search for issues (default: 10)
     --strategy <s>              Strategies: merged,starred,broad,maintained,all
+    --prefer-languages <list>   Soft-boost ranking for matching repo languages
+    --prefer-repos <list>       Soft-boost ranking for these owner/repo slugs
+    --diversity-ratio <n>       Reserve a fraction (0-1) of slots for unboosted
+  features [count]              Feature opportunities in repos with 3+ merged PRs
+    --anchor-threshold <n>      Override featuresAnchorThreshold (1-50)
+    --split-ratio <r>           Override featuresSplitRatio (0-1)
+    --broad                     Search across the ecosystem, not just anchors
   vet <issue-url>               Vet a specific issue
   vet-list                      Re-vet all saved results
     --prune                     Remove unavailable issues
@@ -393,6 +416,11 @@ Automatically filtered out:
 ├── issue-eligibility       PR checks, claim detection, requirements analysis
 ├── issue-scoring           Viability scoring (pure functions)
 ├── issue-filtering         Spam detection, doc-only filtering, per-repo caps
+├── anti-llm-policy         Detect repos with anti-AI contribution policies
+├── feature-discovery       `scout features` anchor + broad discovery
+├── personalization         preferLanguages/preferRepos boosts + diversity
+├── linked-pr / roadmap     Stalled-PR detection, ROADMAP.md scraping
+├── slm-triage              Optional local Ollama SLM pre-triage
 ├── search-phases           GitHub Search API helpers, caching, batching
 ├── search-budget           Rate limit tracking (30 req/min sliding window)
 ├── repo-health             Project health checks, CONTRIBUTING.md parsing


### PR DESCRIPTION
Closes #163.

All items verified against the current code.

## README
- MCP tools list now shows all **6** (added `scout-features`).
- Config table adds the **8** missing schema keys: `githubUsername`, `excludeOrgs`, `defaultStrategy`, `interPhaseDelayMs`, `broadPhaseDelayMs`, `skipBroadWhenSufficientResults`, `featuresAnchorThreshold`, `featuresSplitRatio`. (`slmTriageModel`/`slmTriageHost` were already added.)
- CLI reference adds the `features` command (`--anchor-threshold`, `--split-ratio`, `--broad`) and the search flags `--prefer-languages`, `--prefer-repos`, `--diversity-ratio`.
- Fixed the synopsis: `--json` is a per-subcommand flag, not program-level (`oss-scout --json search` errors), so it goes after the command.
- Documented all three persistence modes (`local`/`gist`/`provided`) and corrected the library example: `checkpoint()` does not push in `'provided'` mode.
- Architecture diagram lists the previously-omitted modules (anti-llm-policy, feature-discovery, personalization, linked-pr, roadmap, slm-triage).

## CLAUDE.md
- Corrected the test count (`~900 tests across 44 files`, was `331/22`), tool count (`6`, was `4`), top-level command count (`9`, was `10`), and added the omitted core modules (anti-llm-policy, feature-discovery, slm-triage, personalization, linked-pr, roadmap, preference-fields) and commands (skip, features).

## plugin.json
- `Three-strategy` -> `Four-strategy` (merged, starred, broad, maintained).

## Note
The cross-machine gist-sync prose was left as-is; it's tracked as its own behavior bug per the issue and should be rewritten once that's resolved.

Verified: 6 MCP `server.tool` registrations, 4 `CONCRETE_STRATEGIES`, 9 top-level CLI commands. Full suite 873 core + 26 mcp green; lint, format, typecheck clean.