### PR TITLE
feat(results): --new-only / --since filtering and --markdown export (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,9 @@ Search:
 
 Results:
   results                       Show saved search results
+    --markdown                  Render as a markdown table (for digests)
+    --new-only                  Only results first seen since the last search
+    --since <date>              Only results first seen at/after this date
   results clear                 Clear saved results
 
 Skip:

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -384,13 +384,29 @@ resultsCmd
   .command("show", { isDefault: true })
   .description("Display saved search results")
   .option("--json", "Output as JSON")
-  .action(async (options: { json?: boolean }) =>
-    runAction(options, async () => {
-      const { runResults } = await import("./commands/results.js");
-      const results = await runResults(options);
-      if (options.json) {
-        console.log(formatJsonSuccess(results));
-      } else {
+  .option("--markdown", "Output as a markdown table (for digests)")
+  .option("--new-only", "Only results first seen during/after the last search")
+  .option("--since <date>", "Only results first seen at/after this date")
+  .action(
+    async (options: {
+      json?: boolean;
+      markdown?: boolean;
+      newOnly?: boolean;
+      since?: string;
+    }) =>
+      runAction(options, async () => {
+        const { runResults } = await import("./commands/results.js");
+        const results = await runResults(options);
+        if (options.json) {
+          console.log(formatJsonSuccess(results));
+          return;
+        }
+        if (options.markdown) {
+          const { formatResultsMarkdown } =
+            await import("./formatters/markdown.js");
+          console.log(formatResultsMarkdown(results));
+          return;
+        }
         if (results.length === 0) {
           console.log(
             "\nNo saved results. Run `oss-scout search` to find issues.\n",
@@ -414,8 +430,7 @@ resultsCmd
           console.log(`  ${score}    ${repo}  ${issue}  ${rec}  ${title}`);
         }
         console.log();
-      }
-    }),
+      }),
   );
 
 resultsCmd

--- a/packages/core/src/commands/results.test.ts
+++ b/packages/core/src/commands/results.test.ts
@@ -99,6 +99,63 @@ describe("results command", () => {
       expect(results[0].repo).toBe("a/b");
       expect(results[1].recommendation).toBe("skip");
     });
+
+    describe("--since / --new-only filtering (#170)", () => {
+      async function seedTwoByAge() {
+        const state = ScoutStateSchema.parse({ version: 1 });
+        state.lastSearchAt = "2026-06-01T00:00:00.000Z";
+        state.savedResults = [
+          makeSavedCandidate({
+            issueUrl: "https://github.com/a/b/issues/1",
+            number: 1,
+            firstSeenAt: "2026-01-01T00:00:00.000Z", // old
+          }),
+          makeSavedCandidate({
+            issueUrl: "https://github.com/a/b/issues/2",
+            number: 2,
+            firstSeenAt: "2026-06-05T00:00:00.000Z", // new (after lastSearchAt)
+          }),
+        ];
+        await setMockState(state);
+      }
+
+      it("--since keeps only results first seen at/after the cutoff", async () => {
+        await seedTwoByAge();
+        const results = await runResults({ since: "2026-05-01" });
+        expect(results.map((r) => r.number)).toEqual([2]);
+      });
+
+      it("--new-only keeps results first seen at/after the last search", async () => {
+        await seedTwoByAge();
+        const results = await runResults({ newOnly: true });
+        expect(results.map((r) => r.number)).toEqual([2]);
+      });
+
+      it("--since is inclusive of a result seen exactly at the cutoff", async () => {
+        const state = ScoutStateSchema.parse({ version: 1 });
+        state.savedResults = [
+          makeSavedCandidate({ firstSeenAt: "2026-05-01T00:00:00.000Z" }),
+        ];
+        await setMockState(state);
+        const results = await runResults({ since: "2026-05-01T00:00:00.000Z" });
+        expect(results).toHaveLength(1);
+      });
+
+      it("--new-only returns all results when no search has run", async () => {
+        const state = ScoutStateSchema.parse({ version: 1 });
+        state.savedResults = [makeSavedCandidate()];
+        await setMockState(state);
+        const results = await runResults({ newOnly: true });
+        expect(results).toHaveLength(1);
+      });
+
+      it("rejects an unparseable --since date", async () => {
+        await seedTwoByAge();
+        await expect(runResults({ since: "not-a-date" })).rejects.toThrow(
+          "Invalid --since date",
+        );
+      });
+    });
   });
 
   describe("runResultsClear", () => {

--- a/packages/core/src/commands/results.ts
+++ b/packages/core/src/commands/results.ts
@@ -4,12 +4,49 @@
 
 import { loadLocalState, saveLocalState } from "../core/local-state.js";
 import type { SavedCandidate } from "../core/schemas.js";
+import { ValidationError } from "../core/errors.js";
 
-export async function runResults(_options: {
+export interface ResultsOptions {
   json?: boolean;
-}): Promise<SavedCandidate[]> {
+  /** Only results first seen at/after this ISO date (or any Date-parseable string). */
+  since?: string;
+  /** Only results first seen during/after the most recent search run. */
+  newOnly?: boolean;
+}
+
+/**
+ * Return saved results, optionally narrowed to "new" ones. `--since` takes an
+ * explicit cutoff; `--new-only` uses the last search timestamp so a scheduler
+ * can run `search` then `results --new-only` to see just that run's fresh
+ * finds (#170). Both compare against each result's `firstSeenAt`.
+ */
+export async function runResults(
+  options: ResultsOptions = {},
+): Promise<SavedCandidate[]> {
   const state = loadLocalState();
-  return state.savedResults ?? [];
+  const results = state.savedResults ?? [];
+
+  let cutoff: number | undefined;
+  if (options.since !== undefined) {
+    const parsed = Date.parse(options.since);
+    if (Number.isNaN(parsed)) {
+      throw new ValidationError(
+        `Invalid --since date: "${options.since}". Use an ISO date like 2026-06-01.`,
+      );
+    }
+    cutoff = parsed;
+  } else if (options.newOnly) {
+    // No prior search recorded → everything counts as new.
+    const parsed = state.lastSearchAt ? Date.parse(state.lastSearchAt) : NaN;
+    cutoff = Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  if (cutoff === undefined) return results;
+  const threshold = cutoff;
+  return results.filter((r) => {
+    const seen = Date.parse(r.firstSeenAt);
+    return !Number.isNaN(seen) && seen >= threshold;
+  });
 }
 
 export async function runResultsClear(): Promise<void> {

--- a/packages/core/src/formatters/markdown.test.ts
+++ b/packages/core/src/formatters/markdown.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { formatResultsMarkdown } from "./markdown.js";
+import type { SavedCandidate } from "../core/schemas.js";
+
+function candidate(overrides: Partial<SavedCandidate> = {}): SavedCandidate {
+  return {
+    issueUrl: "https://github.com/owner/repo/issues/1",
+    repo: "owner/repo",
+    number: 1,
+    title: "Fix the bug",
+    labels: [],
+    recommendation: "approve",
+    viabilityScore: 75,
+    searchPriority: "normal",
+    firstSeenAt: "2026-03-01T00:00:00.000Z",
+    lastSeenAt: "2026-03-01T00:00:00.000Z",
+    lastScore: 75,
+    ...overrides,
+  };
+}
+
+describe("formatResultsMarkdown (#170)", () => {
+  it("returns a friendly message when empty", () => {
+    expect(formatResultsMarkdown([])).toBe("_No saved results._");
+  });
+
+  it("renders a header, divider, and one row per result, sorted by score", () => {
+    const md = formatResultsMarkdown([
+      candidate({ number: 1, viabilityScore: 40 }),
+      candidate({ number: 2, viabilityScore: 90 }),
+    ]);
+    const lines = md.split("\n");
+    expect(lines[0]).toContain("oss-scout results (2)");
+    expect(lines).toContain(
+      "| Score | Repo | Issue | Recommendation | Title |",
+    );
+    // Highest score first.
+    const rows = lines.filter((l) => l.startsWith("| ") && l.includes("#"));
+    expect(rows[0]).toContain("90");
+    expect(rows[0]).toContain("[#2](");
+    expect(rows[1]).toContain("40");
+  });
+
+  it("escapes pipes and newlines in the title so the table stays valid", () => {
+    const md = formatResultsMarkdown([candidate({ title: "a | b\nc" })]);
+    const row = md.split("\n").find((l) => l.includes("[#1]"))!;
+    expect(row).toContain("a \\| b c");
+    // Exactly the 5 column separators (no extra unescaped pipe from the title).
+    expect(row.match(/(?<!\\)\|/g)).toHaveLength(6);
+  });
+});

--- a/packages/core/src/formatters/markdown.ts
+++ b/packages/core/src/formatters/markdown.ts
@@ -1,0 +1,40 @@
+/**
+ * Markdown output formatter (#170) — renders saved results as a table for
+ * digests, notes export, and scheduled GitHub-issue summaries.
+ */
+
+import type { SavedCandidate } from "../core/schemas.js";
+
+/** Escape pipe and newline so a title can't break the markdown table. */
+function cell(value: string): string {
+  return value.replace(/\r?\n/g, " ").replace(/\|/g, "\\|").trim();
+}
+
+/**
+ * Render saved results as a GitHub-flavored markdown table, sorted by
+ * viability score descending. Returns a friendly message when empty.
+ */
+export function formatResultsMarkdown(results: SavedCandidate[]): string {
+  if (results.length === 0) {
+    return "_No saved results._";
+  }
+
+  const sorted = [...results].sort(
+    (a, b) => b.viabilityScore - a.viabilityScore,
+  );
+
+  const header = "| Score | Repo | Issue | Recommendation | Title |";
+  const divider = "| ----- | ---- | ----- | -------------- | ----- |";
+  const rows = sorted.map((r) => {
+    const issueLink = `[#${r.number}](${r.issueUrl})`;
+    return `| ${r.viabilityScore} | ${cell(r.repo)} | ${issueLink} | ${cell(r.recommendation)} | ${cell(r.title)} |`;
+  });
+
+  return [
+    `## oss-scout results (${results.length})`,
+    "",
+    header,
+    divider,
+    ...rows,
+  ].join("\n");
+}


### PR DESCRIPTION
Closes #170.

Two small output additions that make oss-scout schedulable from any host without a daemon.

## `results --since <date>` / `--new-only`

`runResults` filters saved results by `firstSeenAt`:
- `--since <date>` takes an explicit cutoff and rejects an unparseable date with a `ValidationError`.
- `--new-only` uses `state.lastSearchAt`, so a scheduler can run `search` then `results --new-only` to see just that run's fresh finds. Returns all results when no search has run yet.

The cutoff is inclusive; an unparseable `firstSeenAt` on a stored result is dropped rather than crashing.

## `results --markdown`

New `formatters/markdown.ts` renders saved results as a GitHub-flavored markdown table sorted by viability score, escaping `|` and newlines in cells so a title can't break the table, with a friendly empty-state message. This is the digest format the scheduled-Action issue (#171) builds on.

## CLI

`results show` gains `--markdown`, `--new-only`, `--since <date>`. `--json` still wins when combined (its envelope is emitted first). README CLI reference documents the flags.

## Verification

New tests cover `--since`/`--new-only` filtering (incl. the inclusive boundary and the no-search-yet path), the invalid-date rejection, and the markdown formatter (sort order, empty state, pipe/newline escaping). Full suite 881 core + 26 mcp green. lint, format, typecheck clean. CLI smoke-tested.