### PR TITLE
feat: scheduled-digest GitHub Action (#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,28 @@ Agents (dispatched automatically by Claude):
 **Tools:** search, scout-features, vet, skip, config, config-set
 **Resources:** scout://config, scout://results, scout://scores
 
+### Scheduled digest (GitHub Action)
+
+Run search on a schedule and open/update a digest issue in your repo with the top candidates. Copy [`examples/weekly-digest.yml`](examples/weekly-digest.yml) into `.github/workflows/` in your own repo:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 14 * * 1" # Mondays 14:00 UTC
+permissions:
+  issues: write
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: costajohnt/oss-scout@v1
+        with:
+          github-username: your-github-login
+          search-token: ${{ secrets.OSS_SCOUT_TOKEN }} # PAT for personalization (optional)
+```
+
+Inputs: `github-username`, `search-token`, `issue-token`, `max-results`, `strategy`, `issue-title`, `issue-label`, `version`. The action reuses the existing CLI (`search` + `results --markdown`); no extra machinery.
+
 ### As a Library
 
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,98 @@
+name: "oss-scout digest"
+description: "Run oss-scout search on a schedule and open/update a digest issue with the top candidates."
+author: "John Costa"
+branding:
+  icon: "search"
+  color: "purple"
+
+inputs:
+  github-username:
+    description: "GitHub login to personalize search for. Defaults to the repository owner."
+    required: false
+    default: ${{ github.repository_owner }}
+  search-token:
+    description: >-
+      Token used for bootstrap + search (reads your starred repos and PR
+      history). A personal access token with repo read scope gives the best
+      personalization; defaults to the workflow GITHUB_TOKEN, which only sees
+      this repository.
+    required: false
+    default: ${{ github.token }}
+  issue-token:
+    description: "Token used to create/update the digest issue (needs issues: write). Defaults to GITHUB_TOKEN."
+    required: false
+    default: ${{ github.token }}
+  max-results:
+    description: "Number of candidates to surface."
+    required: false
+    default: "10"
+  strategy:
+    description: "Search strategies (comma-separated): merged, starred, broad, maintained, all."
+    required: false
+    default: "all"
+  issue-title:
+    description: "Title of the digest issue."
+    required: false
+    default: "oss-scout digest"
+  issue-label:
+    description: "Label used to find and update the existing digest issue."
+    required: false
+    default: "oss-scout-digest"
+  version:
+    description: "Version of @oss-scout/core to run."
+    required: false
+    default: "latest"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Bootstrap and search
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.search-token }}
+      run: |
+        set -euo pipefail
+        PKG="@oss-scout/core@${{ inputs.version }}"
+        npx -y "$PKG" config set githubUsername "${{ inputs.github-username }}"
+        # Bootstrap is best-effort: a repo-scoped token may not see full history.
+        npx -y "$PKG" bootstrap || echo "bootstrap skipped (limited token scope)"
+        npx -y "$PKG" search "${{ inputs.max-results }}" --strategy "${{ inputs.strategy }}" > /dev/null
+
+    - name: Render digest
+      shell: bash
+      run: |
+        set -euo pipefail
+        PKG="@oss-scout/core@${{ inputs.version }}"
+        npx -y "$PKG" results --markdown > digest.md
+        {
+          echo ""
+          echo "_Updated $(date -u '+%Y-%m-%d %H:%M UTC') by [oss-scout](https://github.com/costajohnt/oss-scout)._"
+        } >> digest.md
+
+    - name: Open or update the digest issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.issue-token }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        # Ensure the label exists (ignore "already exists").
+        gh label create "${{ inputs.issue-label }}" --color ededed \
+          --description "oss-scout scheduled digest" 2>/dev/null || true
+
+        existing=$(gh issue list --label "${{ inputs.issue-label }}" --state open \
+          --json number --jq '.[0].number // empty')
+
+        if [ -n "$existing" ]; then
+          gh issue edit "$existing" --body-file digest.md
+          echo "Updated digest issue #$existing"
+        else
+          gh issue create --title "${{ inputs.issue-title }}" \
+            --label "${{ inputs.issue-label }}" --body-file digest.md
+          echo "Created a new digest issue"
+        fi

--- a/examples/weekly-digest.yml
+++ b/examples/weekly-digest.yml
@@ -1,0 +1,29 @@
+# Example: schedule oss-scout to post a weekly digest issue.
+#
+# Copy this into `.github/workflows/oss-scout-digest.yml` in your own repo.
+# The digest issue is created/updated in the repo this workflow runs in.
+#
+# For personalized results (your starred repos + merged-PR history), set a
+# repository secret `OSS_SCOUT_TOKEN` to a personal access token with `repo`
+# read scope. Without it the action still runs, just with less personalization.
+
+name: oss-scout digest
+
+on:
+  schedule:
+    - cron: "0 14 * * 1" # Mondays at 14:00 UTC
+  workflow_dispatch: {} # allow manual runs
+
+permissions:
+  issues: write
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: costajohnt/oss-scout@v1
+        with:
+          github-username: your-github-login
+          search-token: ${{ secrets.OSS_SCOUT_TOKEN }}
+          max-results: "10"
+          strategy: all


### PR DESCRIPTION
Closes #171.

A reusable composite GitHub Action that runs search on a schedule and opens/updates a labeled digest issue in the caller's repo with the top candidates. Zero new core machinery, it drives the existing CLI.

## `action.yml` (composite)

Steps: `config set githubUsername` → `bootstrap` (best-effort; a repo-scoped token may not see full history) → `search` → `results --markdown` (from #170) → find the existing digest issue by label and `gh issue edit --body-file`, or `gh issue create` if none exists. Inputs: `github-username`, `search-token`, `issue-token`, `max-results`, `strategy`, `issue-title`, `issue-label`, `version`.

## `examples/weekly-digest.yml`

A copy-paste scheduled workflow (`cron` + `workflow_dispatch`, `permissions: issues: write`) that `uses: costajohnt/oss-scout@v1`.

## README

A "Scheduled digest (GitHub Action)" section under Install Options.

## Notes / follow-ups (not blockers)

- The example references `costajohnt/oss-scout@v1`; a `v1` tag on this repo needs to be created for that ref to resolve (release-please currently tags per-component as `core-vX` / `mcp-server-vY`).
- The action runs the published `@oss-scout/core` (default `version: latest`), so the `results --markdown` step needs a published release that includes #170. Until then, pin `version` to a build that has it.

## Verification

`examples/weekly-digest.yml` passes `actionlint` (exit 0). `action.yml` is a valid composite-action schema (validated by parse: 4 steps, 8 inputs; actionlint flags it only because it mis-classifies a `.yml` action file as a workflow). Both YAML files parse. Full suite 881 core + 26 mcp green; lint, format, typecheck clean.