### PR TITLE
feat(vetting): classify the user's own in-flight PR vs competition (#166)

### DIFF
--- a/packages/core/src/core/derive-recommendation.test.ts
+++ b/packages/core/src/core/derive-recommendation.test.ts
@@ -10,6 +10,7 @@ function baseInput(
 ): RecommendationInput {
   return {
     noExistingPR: true,
+    ownPR: false,
     notClaimed: true,
     clearRequirements: true,
     contributionGuidelinesFound: true,
@@ -45,6 +46,24 @@ describe("deriveRecommendation (#157)", () => {
       "Recommendation downgraded: one or more checks were inconclusive",
     );
     expect(out.notes).toContain("Could not verify claim status: API error");
+  });
+
+  it("reframes the user's own open PR as 'you're already on it' (#166)", () => {
+    const out = deriveRecommendation(
+      baseInput({ noExistingPR: false, ownPR: true, passedAllChecks: false }),
+    );
+    expect(out.recommendation).toBe("skip");
+    expect(out.reasonsToSkip).toContain("You already have a PR in flight");
+    expect(out.reasonsToSkip).not.toContain("Has existing PR");
+    expect(out.notes).toContain("Your PR is already in flight for this issue");
+  });
+
+  it("treats a competing existing PR as 'Has existing PR' (not own)", () => {
+    const out = deriveRecommendation(
+      baseInput({ noExistingPR: false, ownPR: false, passedAllChecks: false }),
+    );
+    expect(out.reasonsToSkip).toContain("Has existing PR");
+    expect(out.reasonsToSkip).not.toContain("You already have a PR in flight");
   });
 
   it("skips a closed issue regardless of other checks", () => {

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -405,6 +405,47 @@ describe("IssueVetter", () => {
       expect(result.vettingResult.linkedPR).toBeNull();
     });
 
+    it("classifies the user's own open PR as 'you're already on it' (#166)", async () => {
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({
+        passed: false,
+        linkedPR: {
+          number: 99,
+          author: "octocat",
+          state: "open",
+          merged: false,
+          url: "https://github.com/owner/repo/pull/99",
+        },
+      });
+      const vetter = makeVetter({
+        getGitHubUsername: vi.fn(() => "OctoCat"), // case-insensitive match
+      });
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.recommendation).toBe("skip");
+      expect(result.reasonsToSkip).toContain("You already have a PR in flight");
+      expect(result.reasonsToSkip).not.toContain("Has existing PR");
+    });
+
+    it("treats a competing PR (different author) as existing-PR competition", async () => {
+      vi.mocked(checkNoExistingPR).mockResolvedValueOnce({
+        passed: false,
+        linkedPR: {
+          number: 99,
+          author: "someone-else",
+          state: "open",
+          merged: false,
+          url: "https://github.com/owner/repo/pull/99",
+        },
+      });
+      const vetter = makeVetter({
+        getGitHubUsername: vi.fn(() => "octocat"),
+      });
+      const result = await vetter.vetIssue(VALID_ISSUE_URL);
+      expect(result.reasonsToSkip).toContain("Has existing PR");
+      expect(result.reasonsToSkip).not.toContain(
+        "You already have a PR in flight",
+      );
+    });
+
     it("attaches antiLLMPolicy default (no match) when scan finds nothing", async () => {
       const vetter = makeVetter();
       const result = await vetter.vetIssue(VALID_ISSUE_URL);

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -108,6 +108,11 @@ export interface ScoutStateReader {
    * Optional so existing implementations keep compiling; absent reads as 0.
    */
   getClosedWithoutMergeCount?(repo: string): number;
+  /**
+   * The configured GitHub username, used to tell the user's own in-flight PR
+   * apart from a competing one (#166). Optional; absent reads as "unknown".
+   */
+  getGitHubUsername?(): string;
 }
 
 /**
@@ -138,6 +143,12 @@ export interface ScoutStateWriter {
  */
 export interface RecommendationInput {
   noExistingPR: boolean;
+  /**
+   * The linked PR is the user's own open PR (#166). When true, the existing-PR
+   * block is reframed as "you're already on it" — a skip with a clear reason —
+   * instead of a competing-PR penalty.
+   */
+  ownPR: boolean;
   notClaimed: boolean;
   clearRequirements: boolean;
   contributionGuidelinesFound: boolean;
@@ -179,7 +190,12 @@ export function deriveRecommendation(
   const reasonsToSkip: string[] = [];
 
   // Notes (order preserved from the original vetIssue body).
-  if (!input.noExistingPR) notes.push("Existing PR found for this issue");
+  if (!input.noExistingPR)
+    notes.push(
+      input.ownPR
+        ? "Your PR is already in flight for this issue"
+        : "Existing PR found for this issue",
+    );
   if (!input.notClaimed) notes.push("Issue appears to be claimed by someone");
   if (input.existingPRInconclusive) {
     notes.push(
@@ -203,7 +219,10 @@ export function deriveRecommendation(
     notes.push("No CONTRIBUTING.md found");
 
   // Reasons to skip / approve.
-  if (!input.noExistingPR) reasonsToSkip.push("Has existing PR");
+  if (!input.noExistingPR)
+    reasonsToSkip.push(
+      input.ownPR ? "You already have a PR in flight" : "Has existing PR",
+    );
   if (!input.notClaimed) reasonsToSkip.push("Already claimed");
   if (!input.projectIsActive && !input.projectCheckFailed)
     reasonsToSkip.push("Inactive project");
@@ -236,6 +255,9 @@ export function deriveRecommendation(
   // Recommendation.
   let recommendation: "approve" | "skip" | "needs_review";
   if (input.issueClosed) {
+    recommendation = "skip";
+  } else if (input.ownPR) {
+    // You're already working on this; don't re-surface it as competition.
     recommendation = "skip";
   } else if (input.passedAllChecks) {
     recommendation = "approve";
@@ -354,6 +376,18 @@ export class IssueVetter {
     const noExistingPR = existingPRCheck.passed;
     const notClaimed = claimCheck.passed;
 
+    // Is the linked PR the user's own open PR (#166)? If so the issue is
+    // "you're already on it", not competition.
+    const username = this.stateReader.getGitHubUsername?.() ?? "";
+    const linkedPR = existingPRCheck.linkedPR;
+    const ownPR =
+      !noExistingPR &&
+      !!linkedPR &&
+      linkedPR.state === "open" &&
+      !linkedPR.merged &&
+      username !== "" &&
+      linkedPR.author.toLowerCase() === username.toLowerCase();
+
     // Analyze issue quality
     const clearRequirements = analyzeRequirements(ghIssue.body || "");
 
@@ -435,6 +469,7 @@ export class IssueVetter {
     const { notes, reasonsToApprove, reasonsToSkip, recommendation } =
       deriveRecommendation({
         noExistingPR,
+        ownPR,
         notClaimed,
         clearRequirements,
         contributionGuidelinesFound: !!contributionGuidelines,

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -465,6 +465,11 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
     return this.state.preferences.projectCategories;
   }
 
+  /** Configured GitHub username (used to classify own vs competing PRs, #166). */
+  getGitHubUsername(): string {
+    return this.state.preferences.githubUsername;
+  }
+
   getRepoScore(repo: string): number | null {
     const score = this.state.repoScores[repo];
     return score ? score.score : null;


### PR DESCRIPTION
Closes #166.

The existing-PR check applied a flat `Has existing PR` skip reason and the competing-PR treatment regardless of who opened the linked PR, so an issue the user is actively fixing looked like competition and could be re-surfaced.

## Change

- Added an optional `getGitHubUsername()` to `ScoutStateReader` (`OssScout` returns the configured `githubUsername`).
- `vetIssue` computes `ownPR`: the linked PR is **open**, **not merged**, and **authored by the user** (case-insensitive). The timeline already captures the PR author, so no extra API call.
- `deriveRecommendation` reframes an own PR: the note becomes "Your PR is already in flight for this issue", the skip reason becomes "You already have a PR in flight" (instead of "Has existing PR"), and the recommendation is a **skip** ("you're already on it"). A competing PR (different author) keeps the original behavior.

## Notes
- The `ownPR` skip branch sits after the closed-issue check and before `passedAllChecks` (which is always false when `ownPR` is true, since a PR exists). The approve-downgrade-on-inconclusive logic never interacts (it only fires on `approve`).
- The viability `-30` existing-PR penalty is intentionally left unchanged: an own-PR candidate is a skip regardless, so its rank is irrelevant; the reclassification happens at the recommendation/reason layer the user sees.
- Backward compatible: a `ScoutStateReader` without `getGitHubUsername` reads as `""`, so `ownPR` is false and the original competing-PR behavior holds.

## Verification

New tests cover the own-PR skip (incl. case-insensitive `OctoCat` vs `octocat`), the competing-PR path, both at the `deriveRecommendation` unit level and end-to-end through `vetIssue`. Full suite 885 core + 26 mcp green; lint, format, typecheck clean.