### PR TITLE
feat(vet-list): claim-watch status deltas (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,14 @@ $ oss-scout vet-list --prune
   🔒 user/library#789 — claimed [78/100]
   🔀 org/project#456 — has_pr [85/100]
 
+🔔 Changes since last check (1):
+  user/library#789: still_available → claimed
+
 Summary: 5 available, 1 claimed, 1 has PR, 1 closed
 Pruned 3 unavailable issues from saved results.
 ```
+
+Each run records every saved result's status, so the next `vet-list` reports just what changed ("was available, now claimed"). The transitions are also in the `--json` envelope (`transitions[]`), so a scheduler can act on them without re-diffing.
 
 ## Saved Results
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -561,6 +561,14 @@ program
             );
             console.log(`     ${r.title}`);
           }
+          if (result.transitions.length > 0) {
+            console.log(
+              `\n🔔 Changes since last check (${result.transitions.length}):`,
+            );
+            for (const t of result.transitions) {
+              console.log(`  ${t.repo}#${t.number}: ${t.from} → ${t.to}`);
+            }
+          }
           console.log(
             `\nSummary: ${result.summary.stillAvailable} available, ${result.summary.claimed} claimed, ${result.summary.hasPR} has PR, ${result.summary.closed} closed, ${result.summary.errors} errors`,
           );

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -191,6 +191,58 @@ describe("vetList", () => {
     expect(result.summary.hasPR).toBe(1);
   });
 
+  it("reports a status transition and persists the new status (#165)", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [
+      makeSavedCandidate({ lastStatus: "still_available" }),
+    ];
+    const scout = new OssScout("fake-token", state);
+
+    // Now claimed.
+    vi.spyOn(scout, "vetIssue").mockResolvedValue(
+      makeIssueCandidate({ notClaimed: false, recommendation: "skip" }),
+    );
+
+    const result = await scout.vetList();
+
+    expect(result.transitions).toHaveLength(1);
+    expect(result.transitions[0]).toMatchObject({
+      from: "still_available",
+      to: "claimed",
+    });
+    // New status persisted for the next run.
+    expect(scout.getSavedResults()[0].lastStatus).toBe("claimed");
+  });
+
+  it("emits no transitions on a first run (no prior status) but records status (#165)", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [makeSavedCandidate()]; // no lastStatus
+    const scout = new OssScout("fake-token", state);
+
+    vi.spyOn(scout, "vetIssue").mockResolvedValue(makeIssueCandidate());
+
+    const result = await scout.vetList();
+
+    expect(result.transitions).toEqual([]);
+    expect(scout.getSavedResults()[0].lastStatus).toBe("still_available");
+  });
+
+  it("does not report a transition when the status is unchanged (#165)", async () => {
+    const { OssScout } = await import("../scout.js");
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.savedResults = [
+      makeSavedCandidate({ lastStatus: "still_available" }),
+    ];
+    const scout = new OssScout("fake-token", state);
+
+    vi.spyOn(scout, "vetIssue").mockResolvedValue(makeIssueCandidate());
+
+    const result = await scout.vetList();
+    expect(result.transitions).toEqual([]);
+  });
+
   it("propagates 401 auth errors instead of swallowing per-item", async () => {
     const { OssScout } = await import("../scout.js");
     const state = ScoutStateSchema.parse({ version: 1 });

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -173,6 +173,14 @@ export const SavedCandidateSchema = z.looseObject({
   lastSeenAt: z.string(),
   lastScore: z.number(),
   horizon: HorizonSchema.optional(),
+  /**
+   * Availability status recorded by the previous `vet-list` run, so the next
+   * run can report transitions ("was available, now claimed") instead of
+   * re-diffing full snapshots (#165). "error" is never stored.
+   */
+  lastStatus: z
+    .enum(["still_available", "claimed", "closed", "has_pr"])
+    .optional(),
 });
 
 // ── Scout preferences schema ────────────────────────────────────────

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -189,10 +189,24 @@ export interface VetListSummary {
 }
 
 /** Result of a batch vet-list operation. */
+/** A saved result whose availability status changed since the last vet-list (#165). */
+export interface VetStatusTransition {
+  issueUrl: string;
+  repo: string;
+  number: number;
+  from: VetListEntry["status"];
+  to: VetListEntry["status"];
+}
+
 export interface VetListResult {
   results: VetListEntry[];
   summary: VetListSummary;
   prunedCount?: number;
+  /**
+   * Status changes since the previous vet-list run, computed from each saved
+   * result's `lastStatus`. Empty on a first run (no prior status to compare).
+   */
+  transitions: VetStatusTransition[];
 }
 
 // ── Config types for the OssScout API ───────────────────────────────

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -398,6 +398,36 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       errors: results.filter((r) => r.status === "error").length,
     };
 
+    // Claim-watch (#165): compare each result's current status to the status
+    // recorded on the saved result last time, then persist the new status so
+    // the next run can diff again. "error" is transient — never a transition
+    // target and never stored.
+    const prevStatus = new Map(
+      (this.state.savedResults ?? []).map((r) => [r.issueUrl, r.lastStatus]),
+    );
+    const transitions = results
+      .filter((r) => r.status !== "error")
+      .filter((r) => {
+        const prev = prevStatus.get(r.issueUrl);
+        return prev !== undefined && prev !== r.status;
+      })
+      .map((r) => ({
+        issueUrl: r.issueUrl,
+        repo: r.repo,
+        number: r.number,
+        from: prevStatus.get(r.issueUrl)!,
+        to: r.status,
+      }));
+
+    const currentStatus = new Map(results.map((r) => [r.issueUrl, r.status]));
+    for (const saved of this.state.savedResults ?? []) {
+      const status = currentStatus.get(saved.issueUrl);
+      if (status !== undefined && status !== "error") {
+        saved.lastStatus = status;
+      }
+    }
+    if (results.length > 0) this.dirty = true;
+
     let prunedCount: number | undefined;
     if (options?.prune) {
       const unavailableUrls = new Set(
@@ -414,7 +444,7 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       this.dirty = true;
     }
 
-    return { results, summary, prunedCount };
+    return { results, summary, prunedCount, transitions };
   }
 
   private classifyVetResult(candidate: IssueCandidate): VetListEntry["status"] {


### PR DESCRIPTION
Closes #165.

`vet-list` already classifies each saved result (still_available / claimed / has_pr / closed). This adds the missing piece: report which results **changed** status since the last run, so a host can act on transitions instead of re-diffing full snapshots.

## Change

- `SavedCandidateSchema` persists `lastStatus` (the prior run's classification; `"error"` is never stored).
- `OssScout.vetList` computes a `transitions[]` array by comparing each non-error result's current status to its prior `lastStatus` (skipping first-run and unchanged), then writes the new status back. Transitions are computed and persisted **before** pruning, so a `still_available → claimed` change is still reported even with `--prune`.
- `VetListResult` gains `transitions`; the CLI prints a "🔔 Changes since last check" section and the `--json` envelope carries `transitions[]` automatically.

```
🔔 Changes since last check (1):
  user/library#789: still_available → claimed
```

## Correctness
- First run (no prior status) → no transition, but the status is recorded for next time.
- Unchanged status → no transition.
- An `error` result never overwrites a known-good `lastStatus` nor fabricates a transition.

Additive and backward-compatible: `lastStatus` is optional on the loose `SavedCandidateSchema`, so old persisted state parses unchanged and reads as a first run.

## Verification

New tests cover the transition (with persisted new status), first-run, and unchanged cases. Full suite 888 core + 26 mcp green; lint, format, typecheck clean.