### PR TITLE
feat(scoring): populate the hasActiveMaintainers repo signal (#167)

### DIFF
--- a/packages/core/src/core/repo-signals.test.ts
+++ b/packages/core/src/core/repo-signals.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ScoutStateSchema } from "./schemas.js";
+import type { IssueCandidate, ProjectHealth } from "./types.js";
+
+const { searchResult } = vi.hoisted(() => ({
+  searchResult: { current: null as { candidates: IssueCandidate[] } | null },
+}));
+
+vi.mock("./issue-discovery.js", () => ({
+  IssueDiscovery: class {
+    rateLimitWarning: string | null = null;
+    async searchIssues() {
+      return {
+        candidates: searchResult.current?.candidates ?? [],
+        strategiesUsed: ["broad"],
+      };
+    }
+  },
+}));
+
+vi.mock("./http-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./http-cache.js")>();
+  return {
+    ...actual,
+    getHttpCache: () =>
+      ({ evictStale: () => 0 }) as unknown as ReturnType<
+        typeof actual.getHttpCache
+      >,
+  };
+});
+
+const { OssScout } = await import("../scout.js");
+
+function candidateWithHealth(health: Partial<ProjectHealth>): IssueCandidate {
+  return {
+    issue: {
+      id: 1,
+      url: "https://github.com/owner/repo/issues/1",
+      repo: "owner/repo",
+      number: 1,
+      title: "t",
+      status: "candidate",
+      labels: [],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      vetted: true,
+    },
+    vettingResult: {
+      passedAllChecks: true,
+      checks: {
+        noExistingPR: true,
+        notClaimed: true,
+        projectActive: true,
+        clearRequirements: true,
+        contributionGuidelinesFound: true,
+      },
+      notes: [],
+    },
+    projectHealth: {
+      repo: "owner/repo",
+      lastCommitAt: "2026-03-01T00:00:00Z",
+      daysSinceLastCommit: 1,
+      openIssuesCount: 10,
+      avgIssueResponseDays: 2,
+      ciStatus: "passing",
+      isActive: true,
+      ...health,
+    },
+    recommendation: "approve",
+    reasonsToSkip: [],
+    reasonsToApprove: [],
+    viabilityScore: 70,
+    searchPriority: "normal",
+  };
+}
+
+describe("repo-score active-maintainers signal from search (#167)", () => {
+  beforeEach(() => {
+    searchResult.current = null;
+  });
+
+  it("sets hasActiveMaintainers from an active projectHealth and bumps the score", async () => {
+    searchResult.current = {
+      candidates: [candidateWithHealth({ isActive: true })],
+    };
+    const scout = new OssScout("token", ScoutStateSchema.parse({ version: 1 }));
+    await scout.search({ maxResults: 5 });
+
+    const record = scout.getRepoScoreRecord("owner/repo");
+    expect(record).toBeDefined();
+    expect(record!.signals.hasActiveMaintainers).toBe(true);
+    // base 5 + active(+1) = 6. isResponsive is NOT set (no real measurement).
+    expect(record!.signals.isResponsive).toBe(false);
+    expect(record!.score).toBe(6);
+  });
+
+  it("leaves hasActiveMaintainers false for an inactive repo", async () => {
+    searchResult.current = {
+      candidates: [candidateWithHealth({ isActive: false })],
+    };
+    const scout = new OssScout("token", ScoutStateSchema.parse({ version: 1 }));
+    await scout.search({ maxResults: 5 });
+
+    const record = scout.getRepoScoreRecord("owner/repo");
+    expect(record!.signals.hasActiveMaintainers).toBe(false);
+    expect(record!.score).toBe(5); // no signal adjustments
+  });
+
+  it("does not write signals when the health check failed", async () => {
+    searchResult.current = {
+      candidates: [candidateWithHealth({ checkFailed: true })],
+    };
+    const scout = new OssScout("token", ScoutStateSchema.parse({ version: 1 }));
+    await scout.search({ maxResults: 5 });
+
+    // No score record created from a failed health check.
+    expect(scout.getRepoScoreRecord("owner/repo")).toBeUndefined();
+  });
+});

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -34,6 +34,7 @@ import type {
   OpenPRRecord,
   RepoScoreUpdate,
   ProjectCategory,
+  ProjectHealth,
   VetListOptions,
   VetListResult,
   VetListEntry,
@@ -251,6 +252,12 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       broadPhaseDelayMs: options?.broadPhaseDelayMs,
     });
 
+    // Feed the freshly observed maintainer-responsiveness signals back into the
+    // repo scores so the next search ranks responsive/active repos higher (#167).
+    for (const c of candidates) {
+      this.updateRepoSignalsFromHealth(c.projectHealth);
+    }
+
     this.state.lastSearchAt = new Date().toISOString();
     this.dirty = true;
 
@@ -261,6 +268,28 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       rateLimitWarning: discovery.rateLimitWarning ?? undefined,
       strategiesUsed,
     };
+  }
+
+  /**
+   * Populate the `hasActiveMaintainers` repo-score signal from a freshly
+   * computed projectHealth (#167). It was initialized false and never set, so
+   * calculateScore's +1 active-maintainers weight was inert; `isActive`
+   * (recent commit activity) is a real, already-computed proxy.
+   *
+   * `isResponsive` and `avgResponseDays` are deliberately NOT set here:
+   * `projectHealth.avgIssueResponseDays` is a hardcoded `0` placeholder
+   * (repo-health.ts), so deriving responsiveness from it would award +1 to
+   * every repo — a fake signal worse than the inert one. Real responsiveness
+   * needs an actual response-time measurement (extra API calls), deferred.
+   * `hasHostileComments` likewise stays a host-settable capability (it needs
+   * comment sentiment, out of scope). A failed health check is skipped so its
+   * neutral-default fields don't pollute the score.
+   */
+  private updateRepoSignalsFromHealth(health: ProjectHealth): void {
+    if (health.checkFailed) return;
+    this.updateRepoScore(health.repo, {
+      signals: { hasActiveMaintainers: health.isActive },
+    });
   }
 
   /**


### PR DESCRIPTION
Part of #167. Makes one of the three dead scoring weights real; the other two are deferred for the honest reasons below, so this does not auto-close the issue.

## Change

`calculateScore`'s `+1` active-maintainers weight was inert because `signals.hasActiveMaintainers` was initialized `false` and never set by the pipeline. Search now feeds each candidate's `projectHealth` back into the repo score, setting `hasActiveMaintainers` from `projectHealth.isActive` (recent commit activity — a real, already-computed proxy). This affects the **next** search's ranking (the current results' viability is already scored), which is the intended feedback loop.

- A failed health check is skipped, so its neutral-default fields don't pollute the score.
- The partial signal update preserves any host-set `hasHostileComments`.
- Idempotent: the same repo across multiple candidates writes the same signal.

## Deliberately NOT done (would be fake signals)

A first pass of this PR also set `isResponsive` / `avgResponseDays` — but `projectHealth.avgIssueResponseDays` is a hardcoded `0` placeholder in `repo-health.ts` ("Would need more API calls to calculate"), so `isResponsive = avgIssueResponseDays <= 7` would be **true for every repo** — replacing a perpetually-false dead weight with a perpetually-true one. Removed.

Deferred:
- **`isResponsive` / `avgResponseDays`**: needs a real response-time measurement (fetch recent issues + first-maintainer-response times — extra API calls), which is why the placeholder exists. A focused follow-up.
- **`hasHostileComments`**: needs comment sentiment, out of scope; stays a host-settable capability.

## Verification

Tests cover the active/inactive cases and the checkFailed skip. Full suite 894 core + 26 mcp green; lint, format, typecheck clean.