### PR TITLE
feat: sync command to reconcile tracked open PRs (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ oss-scout is a standalone tool for finding open source issues personalized to yo
 
 1. **`packages/core`** (`@oss-scout/core`) — Library + CLI. Multi-strategy search engine, issue vetting, viability scoring, and the `OssScout` public API class.
 
-2. **`packages/mcp-server`** (`@oss-scout/mcp`) — MCP server exposing search, scout-features, vet, skip, config, and config-set tools plus scout:// resources.
+2. **`packages/mcp-server`** (`@oss-scout/mcp`) — MCP server exposing search, scout-features, vet, skip, config, config-set, and sync tools plus scout:// resources.
 
 ### Key Design Decisions
 
@@ -26,12 +26,13 @@ oss-scout is a standalone tool for finding open source issues personalized to yo
 packages/core/src/
 ├── index.ts              # Public API exports
 ├── scout.ts              # OssScout class + createScout() factory
-├── cli.ts                # Commander CLI (9 top-level commands)
+├── cli.ts                # Commander CLI (10 top-level commands)
 ├── commands/             # CLI subcommands
 │   ├── setup.ts          # Interactive first-run configuration
 │   ├── config.ts         # View/update preferences
 │   ├── search.ts         # Multi-strategy search with result persistence
 │   ├── features.ts       # Feature opportunities in anchor repos
+│   ├── sync.ts           # Reconcile tracked open PRs (merged/closed)
 │   ├── vet.ts            # Single issue vetting
 │   ├── vet-list.ts       # Batch re-vetting of saved results
 │   ├── skip.ts           # Manage the skip list
@@ -72,7 +73,7 @@ packages/core/src/
 
 packages/mcp-server/src/
 ├── index.ts              # MCP server entry point (stdio transport)
-├── tools.ts              # 6 tools: search, scout-features, vet, skip, config, config-set
+├── tools.ts              # 7 tools: search, scout-features, vet, skip, config, config-set, sync
 ├── resources.ts          # 3 resources: scout://config, results, scores
 └── tools.test.ts         # Tool registration tests
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Agents (dispatched automatically by Claude):
 }
 ```
 
-**Tools:** search, scout-features, vet, skip, config, config-set
+**Tools:** search, scout-features, vet, skip, config, config-set, sync
 **Resources:** scout://config, scout://results, scout://scores
 
 ### Scheduled digest (GitHub Action)
@@ -392,6 +392,7 @@ the command, e.g. `oss-scout search --json`, not `oss-scout --json search`).
 Setup:
   setup                         Interactive first-run configuration
   bootstrap                     Import starred repos and PR history from GitHub
+  sync                          Reconcile tracked open PRs (mark merged/closed)
 
 Search:
   search [count]                Search for issues (default: 10)

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -125,6 +125,26 @@ program
   );
 
 program
+  .command("sync")
+  .description(
+    "Reconcile tracked open PRs (mark merged/closed) without a full bootstrap",
+  )
+  .option("--json", "Output as JSON")
+  .action(async (options: { json?: boolean }) =>
+    runAction(options, async () => {
+      const { runSync } = await import("./commands/sync.js");
+      const result = await runSync();
+      if (options.json) {
+        console.log(formatJsonSuccess(result));
+      } else {
+        console.log(
+          `Synced ${result.checked} open PRs: ${result.merged} merged, ${result.closed} closed, ${result.stillOpen} still open${result.errors > 0 ? `, ${result.errors} unchecked` : ""}.`,
+        );
+      }
+    }),
+  );
+
+program
   .command("search [count]")
   .description("Search for contributable issues using multi-strategy discovery")
   .option("--json", "Output as JSON")

--- a/packages/core/src/commands/sync.ts
+++ b/packages/core/src/commands/sync.ts
@@ -1,0 +1,16 @@
+/**
+ * Sync command — reconcile tracked open PRs against their current GitHub state
+ * (#164). Records merges/closures, prunes resolved entries, and recomputes repo
+ * scores. Cheaper than a full bootstrap; meant for periodic / daily runs.
+ */
+
+import { withScout } from "./with-scout.js";
+import type { ScoutState } from "../core/schemas.js";
+import type { SyncResult } from "../core/types.js";
+
+export async function runSync(options?: {
+  state?: ScoutState;
+}): Promise<SyncResult> {
+  // syncOpenPRs checkpoints itself, so withScout doesn't need to persist.
+  return withScout(options?.state, (scout) => scout.syncOpenPRs());
+}

--- a/packages/core/src/core/sync.test.ts
+++ b/packages/core/src/core/sync.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ScoutStateSchema } from "./schemas.js";
+
+const { pullsGet } = vi.hoisted(() => ({ pullsGet: vi.fn() }));
+
+vi.mock("./github.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./github.js")>();
+  return {
+    ...actual,
+    getOctokit: () =>
+      ({ pulls: { get: pullsGet } }) as unknown as ReturnType<
+        typeof actual.getOctokit
+      >,
+  };
+});
+
+const { OssScout } = await import("../scout.js");
+
+function pr(n: number) {
+  return {
+    url: `https://github.com/owner/repo/pull/${n}`,
+    title: `PR ${n}`,
+    openedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function reply(state: string, merged: boolean) {
+  return {
+    data: {
+      state,
+      merged,
+      merged_at: merged ? "2026-06-01T00:00:00.000Z" : null,
+      closed_at: state === "closed" ? "2026-06-02T00:00:00.000Z" : null,
+    },
+  };
+}
+
+describe("syncOpenPRs (#164)", () => {
+  beforeEach(() => pullsGet.mockReset());
+
+  it("transitions merged and closed PRs, keeps open ones, and prunes resolved", async () => {
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.openPRs = [pr(1), pr(2), pr(3)];
+    const scout = new OssScout("token", state);
+
+    pullsGet
+      .mockResolvedValueOnce(reply("closed", true)) // #1 merged
+      .mockResolvedValueOnce(reply("closed", false)) // #2 closed-unmerged
+      .mockResolvedValueOnce(reply("open", false)); // #3 still open
+
+    const result = await scout.syncOpenPRs();
+
+    expect(result).toMatchObject({
+      checked: 3,
+      merged: 1,
+      closed: 1,
+      stillOpen: 1,
+      errors: 0,
+    });
+    // Only the still-open PR remains tracked.
+    const remaining = scout.getState().openPRs ?? [];
+    expect(remaining.map((p) => p.url)).toEqual([
+      "https://github.com/owner/repo/pull/3",
+    ]);
+    // The merge was recorded (feeds repo scoring).
+    expect(
+      scout.getState().mergedPRs.some((p) => p.url.endsWith("/pull/1")),
+    ).toBe(true);
+    expect(
+      scout.getState().closedPRs.some((p) => p.url.endsWith("/pull/2")),
+    ).toBe(true);
+  });
+
+  it("leaves an entry in place on a transient (non-fatal) error", async () => {
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.openPRs = [pr(9)];
+    const scout = new OssScout("token", state);
+
+    pullsGet.mockRejectedValueOnce(
+      Object.assign(new Error("Not Found"), { status: 404 }),
+    );
+
+    const result = await scout.syncOpenPRs();
+    expect(result).toMatchObject({ checked: 1, errors: 1, stillOpen: 0 });
+    expect((scout.getState().openPRs ?? []).length).toBe(1);
+  });
+
+  it("propagates a rate-limit error (fatal)", async () => {
+    const state = ScoutStateSchema.parse({ version: 1 });
+    state.openPRs = [pr(5)];
+    const scout = new OssScout("token", state);
+
+    pullsGet.mockRejectedValueOnce(
+      Object.assign(new Error("API rate limit exceeded"), { status: 403 }),
+    );
+
+    await expect(scout.syncOpenPRs()).rejects.toThrow("rate limit");
+  });
+});

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -188,7 +188,20 @@ export interface VetListSummary {
   errors: number;
 }
 
-/** Result of a batch vet-list operation. */
+/** Result of reconciling tracked open PRs against their current GitHub state (#164). */
+export interface SyncResult {
+  /** Open PRs checked. */
+  checked: number;
+  /** Transitioned to merged. */
+  merged: number;
+  /** Transitioned to closed-without-merge. */
+  closed: number;
+  /** Still open (kept). */
+  stillOpen: number;
+  /** Could not be checked (parse failure or transient API error). */
+  errors: number;
+}
+
 /** A saved result whose availability status changed since the last vet-list (#165). */
 export interface VetStatusTransition {
   issueUrl: string;
@@ -198,6 +211,7 @@ export interface VetStatusTransition {
   to: VetListEntry["status"];
 }
 
+/** Result of a batch vet-list operation. */
 export interface VetListResult {
   results: VetListEntry[];
   summary: VetListSummary;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export type {
   VetListResult,
   VetListEntry,
   VetListSummary,
+  SyncResult,
 } from "./core/types.js";
 
 export type {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -35,6 +35,7 @@ import type {
   RepoScoreUpdate,
   ProjectCategory,
   ProjectHealth,
+  SyncResult,
   VetListOptions,
   VetListResult,
   VetListEntry,
@@ -48,11 +49,12 @@ import { getOctokit } from "./core/github.js";
 import type { Octokit } from "@octokit/rest";
 import { loadLocalState, saveLocalState } from "./core/local-state.js";
 import { warn, setLogLevel } from "./core/logger.js";
-import { extractRepoFromUrl } from "./core/utils.js";
+import { extractRepoFromUrl, parseGitHubUrl } from "./core/utils.js";
 import {
   errorMessage,
   getHttpStatusCode,
   isRateLimitError,
+  rethrowIfFatal,
 } from "./core/errors.js";
 import { getHttpCache } from "./core/http-cache.js";
 
@@ -627,6 +629,78 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       { url: pr.url, title: pr.title, openedAt: pr.openedAt },
     ];
     this.dirty = true;
+  }
+
+  /**
+   * Reconcile tracked open PRs against their current GitHub state (#164).
+   *
+   * `state.openPRs` was append-only — nothing transitioned an open PR to
+   * merged/closed, so getReposWithOpenPRs() over-reported forever once a PR
+   * merged. This checks each open PR, records merges/closures (which updates
+   * the repo score), prunes resolved entries, and checkpoints. Cheaper than a
+   * full bootstrap, so a host can call it on daily startup. Transient errors
+   * leave the entry in place; auth/rate-limit failures propagate.
+   */
+  async syncOpenPRs(): Promise<SyncResult> {
+    const octokit = getOctokit(this.githubToken);
+    const open = this.state.openPRs ?? [];
+    const result: SyncResult = {
+      checked: open.length,
+      merged: 0,
+      closed: 0,
+      stillOpen: 0,
+      errors: 0,
+    };
+    const remaining: typeof open = [];
+
+    for (const pr of open) {
+      const parsed = parseGitHubUrl(pr.url);
+      if (!parsed || parsed.type !== "pull") {
+        remaining.push(pr);
+        result.errors++;
+        continue;
+      }
+      const repoFullName = `${parsed.owner}/${parsed.repo}`;
+      try {
+        const { data } = await octokit.pulls.get({
+          owner: parsed.owner,
+          repo: parsed.repo,
+          pull_number: parsed.number,
+        });
+        if (data.merged) {
+          this.recordMergedPR({
+            url: pr.url,
+            title: pr.title,
+            mergedAt: data.merged_at ?? new Date().toISOString(),
+            repo: repoFullName,
+          });
+          result.merged++;
+        } else if (data.state === "closed") {
+          this.recordClosedPR({
+            url: pr.url,
+            title: pr.title,
+            closedAt: data.closed_at ?? new Date().toISOString(),
+            repo: repoFullName,
+          });
+          result.closed++;
+        } else {
+          remaining.push(pr);
+          result.stillOpen++;
+        }
+      } catch (err) {
+        // Auth/rate-limit aborts the whole sync; a transient/404 leaves the
+        // entry untouched so a later sync can retry rather than losing it.
+        rethrowIfFatal(err);
+        warn("scout", `sync: could not check ${pr.url}: ${errorMessage(err)}`);
+        remaining.push(pr);
+        result.errors++;
+      }
+    }
+
+    this.state.openPRs = remaining;
+    this.dirty = true;
+    await this.checkpoint();
+    return result;
   }
 
   /**

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -70,8 +70,8 @@ describe("registerTools", () => {
     registerTools(server, scout);
   });
 
-  it("registers all six tools", () => {
-    expect(server.tool).toHaveBeenCalledTimes(6);
+  it("registers all seven tools", () => {
+    expect(server.tool).toHaveBeenCalledTimes(7);
 
     const calls = vi.mocked(server.tool).mock.calls;
     const names = calls.map((c) => c[0]);
@@ -81,6 +81,7 @@ describe("registerTools", () => {
     expect(names).toContain("config");
     expect(names).toContain("config-set");
     expect(names).toContain("scout-features");
+    expect(names).toContain("sync");
   });
 
   describe("persistence reporting (#113)", () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -192,6 +192,25 @@ export function registerTools(server: McpServer, scout: OssScout): void {
   );
 
   server.tool(
+    "sync",
+    "Reconcile tracked open PRs against GitHub — mark merged/closed and recompute repo scores. Cheap; good for a daily startup call.",
+    async () => {
+      try {
+        const result = await withTimeout(scout.syncOpenPRs());
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error: ${msg}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     "skip",
     "Skip, unskip, list, or clear skipped issues. Skipped issues are excluded from future searches and auto-expire after 90 days.",
     {


### PR DESCRIPTION
Closes #164.

`state.openPRs` was append-only — nothing transitioned an open PR to merged/closed, so `getReposWithOpenPRs()` (consumed by search prioritization) over-reported forever once a PR merged.

## Change

- **`OssScout.syncOpenPRs()`**: checks each tracked open PR via `pulls.get`, records merges/closures through the existing `recordMergedPR`/`recordClosedPR` (which recompute the repo score), prunes resolved entries from `openPRs`, and checkpoints. Returns `{checked, merged, closed, stillOpen, errors}`.
  - **Merged is checked before closed** — a merged PR is also `state: "closed"`, so the order matters.
  - Auth / rate-limit failures abort the whole sync (`rethrowIfFatal`); a transient/404 leaves the entry in place for a later retry (conservative — no fabricated state).
- Exposed as a CLI **`sync`** command and an MCP **`sync`** tool so the autopilot host can call it on daily startup. `SyncResult` is exported from the package root.
- README / CLAUDE docs and the MCP tool count (now 7) updated.

## REST vs GraphQL

Uses REST (one `pulls.get` per open PR). The GraphQL batch the issue proposed (~50 PRs/query, ~1-2 calls vs bootstrap's ~14) is a follow-up optimization that matters for users with many open PRs; the REST version is simpler, fully testable, and delivers the reconciliation + score-recompute the feedback loop needs.

## Verification

New tests cover the merged/closed/still-open transitions + prune, a non-fatal 404 (entry kept), and a fatal rate-limit (propagates). Full suite 897 core + 26 mcp green (MCP 7-tool count updated); lint, format, typecheck clean. CLI `sync --json` smoke returns the auth-required error envelope without a token.