### PR TITLE
perf(vetting): batch issue core fetch via GraphQL with REST fallback (#169)

### DIFF
--- a/packages/core/src/core/issue-graphql.test.ts
+++ b/packages/core/src/core/issue-graphql.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Octokit } from "@octokit/rest";
+import {
+  prefetchIssueCores,
+  issueCoreKey,
+  type IssueRef,
+} from "./issue-graphql.js";
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+function graphqlNode(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    databaseId: 100,
+    title: "A title",
+    body: "A body",
+    state: "OPEN",
+    labels: { nodes: [{ name: "bug" }, { name: "help wanted" }] },
+    comments: { totalCount: 4 },
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+    ...over,
+  };
+}
+
+function makeOctokit(graphql: ReturnType<typeof vi.fn>): Octokit {
+  return { graphql } as unknown as Octokit;
+}
+
+const ISSUES: IssueRef[] = [
+  { owner: "owner", repo: "repo", number: 1 },
+  { owner: "owner", repo: "repo", number: 2 },
+];
+
+describe("prefetchIssueCores", () => {
+  it("returns an empty map without calling GraphQL for no issues", async () => {
+    const graphql = vi.fn();
+    const result = await prefetchIssueCores(makeOctokit(graphql), []);
+    expect(result.size).toBe(0);
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it("normalizes GraphQL nodes into the REST-equivalent core shape", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      i0: { issue: graphqlNode({ databaseId: 11 }) },
+      i1: {
+        issue: graphqlNode({
+          databaseId: 22,
+          state: "CLOSED",
+          body: null,
+          labels: { nodes: [] },
+          comments: { totalCount: 0 },
+        }),
+      },
+    });
+    const result = await prefetchIssueCores(makeOctokit(graphql), ISSUES);
+
+    const c1 = result.get(issueCoreKey("owner", "repo", 1));
+    expect(c1).toEqual({
+      id: 11,
+      title: "A title",
+      body: "A body",
+      state: "open",
+      labels: ["bug", "help wanted"],
+      commentCount: 4,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+    });
+
+    const c2 = result.get(issueCoreKey("owner", "repo", 2));
+    // CLOSED → "closed", null body → "", empty labels → []
+    expect(c2?.state).toBe("closed");
+    expect(c2?.body).toBe("");
+    expect(c2?.labels).toEqual([]);
+    expect(c2?.commentCount).toBe(0);
+  });
+
+  it("passes owner/name/number as GraphQL variables, not interpolated text", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      i0: { issue: graphqlNode() },
+      i1: { issue: graphqlNode() },
+    });
+    await prefetchIssueCores(makeOctokit(graphql), ISSUES);
+
+    expect(graphql).toHaveBeenCalledTimes(1);
+    const [query, variables] = graphql.mock.calls[0];
+    expect(query).toContain("repository(owner: $o0, name: $n0)");
+    expect(query).toContain("issue(number: $num0)");
+    expect(variables).toMatchObject({
+      o0: "owner",
+      n0: "repo",
+      num0: 1,
+      o1: "owner",
+      n1: "repo",
+      num1: 2,
+    });
+  });
+
+  it("omits issues whose node is null (deleted/inaccessible)", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      i0: { issue: graphqlNode({ databaseId: 11 }) },
+      i1: { issue: null },
+    });
+    const result = await prefetchIssueCores(makeOctokit(graphql), ISSUES);
+    expect(result.has(issueCoreKey("owner", "repo", 1))).toBe(true);
+    expect(result.has(issueCoreKey("owner", "repo", 2))).toBe(false);
+  });
+
+  it("omits issues whose databaseId is null", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      i0: { issue: graphqlNode({ databaseId: null }) },
+      i1: { issue: graphqlNode({ databaseId: 22 }) },
+    });
+    const result = await prefetchIssueCores(makeOctokit(graphql), ISSUES);
+    expect(result.has(issueCoreKey("owner", "repo", 1))).toBe(false);
+    expect(result.has(issueCoreKey("owner", "repo", 2))).toBe(true);
+  });
+
+  it("dedups repeated issues into a single alias", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      i0: { issue: graphqlNode({ databaseId: 11 }) },
+    });
+    const dupes: IssueRef[] = [
+      { owner: "owner", repo: "repo", number: 1 },
+      { owner: "owner", repo: "repo", number: 1 },
+    ];
+    const result = await prefetchIssueCores(makeOctokit(graphql), dupes);
+
+    const [, variables] = graphql.mock.calls[0];
+    // Only one alias worth of variables for the duplicated issue.
+    expect(variables).not.toHaveProperty("num1");
+    expect(result.size).toBe(1);
+  });
+
+  it("uses partial data attached to a GraphQL error (one bad issue in batch)", async () => {
+    const err = Object.assign(new Error("Could not resolve to an Issue"), {
+      data: { i0: { issue: graphqlNode({ databaseId: 11 }) }, i1: null },
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    const result = await prefetchIssueCores(makeOctokit(graphql), ISSUES);
+    // The resolved alias survives; the errored one is absent (→ REST fallback).
+    expect(result.has(issueCoreKey("owner", "repo", 1))).toBe(true);
+    expect(result.has(issueCoreKey("owner", "repo", 2))).toBe(false);
+  });
+
+  it("returns an empty map on a non-fatal error with no partial data", async () => {
+    const graphql = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    const result = await prefetchIssueCores(makeOctokit(graphql), ISSUES);
+    expect(result.size).toBe(0);
+  });
+
+  it("propagates a 401 auth error (rethrowIfFatal)", async () => {
+    const err = Object.assign(new Error("Bad credentials"), { status: 401 });
+    const graphql = vi.fn().mockRejectedValue(err);
+    await expect(
+      prefetchIssueCores(makeOctokit(graphql), ISSUES),
+    ).rejects.toThrow("Bad credentials");
+  });
+
+  it("propagates a rate-limit error (rethrowIfFatal)", async () => {
+    const err = Object.assign(new Error("API rate limit exceeded"), {
+      status: 429,
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    await expect(
+      prefetchIssueCores(makeOctokit(graphql), ISSUES),
+    ).rejects.toThrow("rate limit");
+  });
+});

--- a/packages/core/src/core/issue-graphql.ts
+++ b/packages/core/src/core/issue-graphql.ts
@@ -1,0 +1,173 @@
+/**
+ * Batched GraphQL prefetch of issue "core" data (#169).
+ *
+ * `vetIssue` re-fetches each issue's basic fields (title, body, state, labels,
+ * timestamps, comment count) via a per-issue REST `issues.get`. When a search
+ * surfaces N issues that all need vetting, that is N separate REST calls before
+ * any of the deeper checks even start.
+ *
+ * `prefetchIssueCores` collapses those N calls into ONE aliased GraphQL query.
+ * The result is a map keyed by `owner/repo#number`; `vetIssue` consumes a hit
+ * instead of calling `issues.get`, and falls back to REST for any miss (a
+ * deleted issue, a permission error on one repo, or a non-fatal GraphQL blip).
+ *
+ * Scope is deliberately limited to the `issues.get` fields. The other vetting
+ * calls (timeline-based PR detection, claim scanning, project health,
+ * contribution guidelines) stay REST — batching those has pagination-semantics
+ * divergence risk and is left as a follow-up.
+ */
+
+import type { Octokit } from "@octokit/rest";
+import { rethrowIfFatal, errorMessage } from "./errors.js";
+import { warn } from "./logger.js";
+
+const MODULE = "issue-graphql";
+
+/**
+ * Normalized issue fields equivalent to the subset of a REST `issues.get`
+ * response that `vetIssue` reads. Produced from either GraphQL (prefetch) or
+ * REST (fallback) so the two paths are interchangeable.
+ */
+export interface PrefetchedIssueCore {
+  /** GitHub numeric database id (REST `id` / GraphQL `databaseId`). */
+  id: number;
+  title: string;
+  /** Empty string when the issue has no body (matches REST `body || ""`). */
+  body: string;
+  state: "open" | "closed";
+  /** Label names, in declared order. */
+  labels: string[];
+  /** Total comment count (REST `comments` / GraphQL `comments.totalCount`). */
+  commentCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A single issue to prefetch. */
+export interface IssueRef {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+/** Map key for a prefetched core, also used by callers to look one up. */
+export function issueCoreKey(
+  owner: string,
+  repo: string,
+  number: number,
+): string {
+  return `${owner}/${repo}#${number}`;
+}
+
+interface GraphQLIssueNode {
+  databaseId: number | null;
+  title: string;
+  body: string | null;
+  state: "OPEN" | "CLOSED";
+  labels: { nodes: { name: string }[] };
+  comments: { totalCount: number };
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Shape of the aliased batch response: `{ i0: { issue }, i1: { issue }, ... }`. */
+type BatchResponse = Record<string, { issue: GraphQLIssueNode | null } | null>;
+
+function normalizeNode(node: GraphQLIssueNode): PrefetchedIssueCore {
+  return {
+    id: node.databaseId as number,
+    title: node.title,
+    body: node.body ?? "",
+    state: node.state === "CLOSED" ? "closed" : "open",
+    labels: node.labels.nodes.map((l) => l.name),
+    commentCount: node.comments.totalCount,
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+  };
+}
+
+/**
+ * Batch-fetch issue core data with one aliased GraphQL query. Returns a map of
+ * `owner/repo#number` to the normalized core. Issues that the query could not
+ * resolve are simply absent — the caller is expected to fall back to REST for
+ * any key not in the map.
+ *
+ * Failure handling mirrors the rest of the vetter: fatal errors (401 / rate
+ * limit) propagate via `rethrowIfFatal`; a partial-data GraphQL error (one bad
+ * issue in the batch) keeps the aliases that did resolve; any other non-fatal
+ * error returns whatever resolved so the caller degrades to all-REST.
+ */
+export async function prefetchIssueCores(
+  octokit: Octokit,
+  issues: IssueRef[],
+): Promise<Map<string, PrefetchedIssueCore>> {
+  const result = new Map<string, PrefetchedIssueCore>();
+  if (issues.length === 0) return result;
+
+  // Dedup by key so a repeated issue does not allocate a redundant alias.
+  const unique = [
+    ...new Map(
+      issues.map((i) => [issueCoreKey(i.owner, i.repo, i.number), i]),
+    ).values(),
+  ];
+
+  // Build a parameterized query — owner/repo/number go through GraphQL
+  // variables, never string-interpolated into the query body, so there is no
+  // injection surface even though parseGitHubUrl already validates them.
+  const varDefs: string[] = [];
+  const selections: string[] = [];
+  const variables: Record<string, string | number> = {};
+  unique.forEach((iss, i) => {
+    varDefs.push(`$o${i}: String!, $n${i}: String!, $num${i}: Int!`);
+    variables[`o${i}`] = iss.owner;
+    variables[`n${i}`] = iss.repo;
+    variables[`num${i}`] = iss.number;
+    selections.push(
+      `i${i}: repository(owner: $o${i}, name: $n${i}) {
+        issue(number: $num${i}) {
+          databaseId
+          title
+          body
+          state
+          labels(first: 100) { nodes { name } }
+          comments { totalCount }
+          createdAt
+          updatedAt
+        }
+      }`,
+    );
+  });
+  const query = `query batchIssueCores(${varDefs.join(", ")}) {\n${selections.join("\n")}\n}`;
+
+  let data: BatchResponse | undefined;
+  try {
+    data = await octokit.graphql<BatchResponse>(query, variables);
+  } catch (err) {
+    rethrowIfFatal(err);
+    // octokit's GraphqlResponseError attaches the resolved aliases to `.data`
+    // when only some issues in the batch errored (e.g. one was deleted).
+    const partial = (err as { data?: BatchResponse }).data;
+    if (partial) {
+      data = partial;
+    } else {
+      warn(
+        MODULE,
+        `GraphQL prefetch failed, falling back to REST: ${errorMessage(err)}`,
+      );
+      return result;
+    }
+  }
+
+  unique.forEach((iss, i) => {
+    const node = data?.[`i${i}`]?.issue;
+    // A null node (deleted/inaccessible) or a null databaseId leaves the key
+    // absent so the caller fetches it via REST.
+    if (!node || node.databaseId == null) return;
+    result.set(
+      issueCoreKey(iss.owner, iss.repo, iss.number),
+      normalizeNode(node),
+    );
+  });
+
+  return result;
+}

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -44,6 +44,9 @@ vi.mock("./errors.js", () => ({
     return undefined;
   }),
   isRateLimitError: vi.fn(() => false),
+  // No-op by default: the prefetch path (#169) calls this on a GraphQL error;
+  // these tests exercise the REST fallback, so nothing here is fatal.
+  rethrowIfFatal: vi.fn(),
 }));
 
 vi.mock("./issue-scoring.js", () => ({
@@ -145,6 +148,10 @@ function makeMockOctokit(): Octokit {
         },
       }),
     },
+    // Default: an empty batch response so the #169 prefetch resolves no
+    // aliases and every issue falls back to the REST `issues.get` above.
+    // Tests exercising the prefetch path supply their own graphql mock.
+    graphql: vi.fn().mockResolvedValue({}),
   } as unknown as Octokit;
 }
 
@@ -286,6 +293,51 @@ describe("IssueVetter", () => {
       expect(result.vettingResult.passedAllChecks).toBe(true);
       expect(result.viabilityScore).toBeGreaterThan(0);
       expect(result.issueState).toBe("open");
+    });
+
+    it("uses a prefetched core instead of calling issues.get (#169)", async () => {
+      const octokit = makeMockOctokit();
+      const getSpy = (
+        octokit as unknown as { issues: { get: ReturnType<typeof vi.fn> } }
+      ).issues.get;
+      const vetter = new IssueVetter(octokit, makeStubStateReader());
+
+      const result = await vetter.vetIssue(VALID_ISSUE_URL, {
+        prefetched: {
+          id: 999,
+          title: "Prefetched title",
+          body: "1. repro\n2. expected\n```js\ncode\n```",
+          state: "open",
+          labels: ["enhancement"],
+          commentCount: 0,
+          createdAt: "2026-02-01T00:00:00Z",
+          updatedAt: "2026-04-01T00:00:00Z",
+        },
+      });
+
+      expect(getSpy).not.toHaveBeenCalled();
+      expect(result.issue.id).toBe(999);
+      expect(result.issue.title).toBe("Prefetched title");
+      expect(result.issue.labels).toEqual(["enhancement"]);
+      expect(result.issue.updatedAt).toBe("2026-04-01T00:00:00Z");
+    });
+
+    it("treats a prefetched closed core as skip (#169)", async () => {
+      const vetter = makeVetter();
+      const result = await vetter.vetIssue(VALID_ISSUE_URL, {
+        prefetched: {
+          id: 1,
+          title: "Done",
+          body: "done",
+          state: "closed",
+          labels: [],
+          commentCount: 0,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-03-01T00:00:00Z",
+        },
+      });
+      expect(result.issueState).toBe("closed");
+      expect(result.recommendation).toBe("skip");
     });
 
     it("marks a closed issue as skip with issueState closed (#120)", async () => {
@@ -700,6 +752,93 @@ describe("IssueVetter", () => {
         10,
       );
       expect(result.rateLimitHit).toBe(true);
+    });
+
+    it("batch-prefetches via GraphQL and skips per-issue issues.get (#169)", async () => {
+      const node = (databaseId: number, number: number) => ({
+        databaseId,
+        title: `Issue ${number}`,
+        body: "1. repro\n2. expected\n```code```",
+        state: "OPEN" as const,
+        labels: { nodes: [{ name: "bug" }] },
+        comments: { totalCount: 0 },
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-03-01T00:00:00Z",
+      });
+      const getSpy = vi.fn();
+      const octokit = {
+        issues: { get: getSpy },
+        graphql: vi.fn().mockResolvedValue({
+          i0: { issue: node(11, 1) },
+          i1: { issue: node(22, 2) },
+        }),
+      } as unknown as Octokit;
+      const vetter = new IssueVetter(octokit, makeStubStateReader());
+
+      const result = await vetter.vetIssuesParallel(
+        [
+          "https://github.com/owner/repo/issues/1",
+          "https://github.com/owner/repo/issues/2",
+        ],
+        10,
+      );
+
+      expect(result.candidates).toHaveLength(2);
+      expect(getSpy).not.toHaveBeenCalled();
+      expect(
+        (octokit as unknown as { graphql: ReturnType<typeof vi.fn> }).graphql,
+      ).toHaveBeenCalledTimes(1);
+      expect(result.candidates.map((c) => c.issue.id).sort()).toEqual([11, 22]);
+    });
+
+    it("falls back to issues.get for issues the GraphQL batch omits (#169)", async () => {
+      const getSpy = vi.fn().mockResolvedValue({
+        data: {
+          id: 222,
+          html_url: "https://github.com/owner/repo/issues/2",
+          title: "Fetched via REST",
+          body: "1. repro\n2. expected\n```code```",
+          comments: 0,
+          labels: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-03-01T00:00:00Z",
+        },
+      });
+      const octokit = {
+        issues: { get: getSpy },
+        // Only issue 1 resolves in the batch; issue 2 is absent.
+        graphql: vi.fn().mockResolvedValue({
+          i0: {
+            issue: {
+              databaseId: 111,
+              title: "Issue 1",
+              body: "1. repro\n2. expected\n```code```",
+              state: "OPEN",
+              labels: { nodes: [] },
+              comments: { totalCount: 0 },
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-03-01T00:00:00Z",
+            },
+          },
+          i1: { issue: null },
+        }),
+      } as unknown as Octokit;
+      const vetter = new IssueVetter(octokit, makeStubStateReader());
+
+      const result = await vetter.vetIssuesParallel(
+        [
+          "https://github.com/owner/repo/issues/1",
+          "https://github.com/owner/repo/issues/2",
+        ],
+        10,
+      );
+
+      expect(result.candidates).toHaveLength(2);
+      // Exactly one REST fetch — for the issue the batch could not resolve.
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ issue_number: 2 }),
+      );
     });
 
     it("propagates 401 auth errors instead of swallowing per-item", async () => {

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -44,6 +44,11 @@ import {
   fetchContributionGuidelines,
 } from "./repo-health.js";
 import { fetchAndScanAntiLLMPolicy } from "./anti-llm-policy.js";
+import {
+  prefetchIssueCores,
+  issueCoreKey,
+  type PrefetchedIssueCore,
+} from "./issue-graphql.js";
 import { getHttpCache } from "./http-cache.js";
 import {
   triageWithSLM,
@@ -304,7 +309,16 @@ export class IssueVetter {
    */
   async vetIssue(
     issueUrl: string,
-    opts?: { featureSignals?: FeatureSignals },
+    opts?: {
+      featureSignals?: FeatureSignals;
+      /**
+       * Issue core data already fetched in a batch GraphQL query (#169). When
+       * present it replaces the per-issue REST `issues.get`; otherwise the
+       * core is fetched via REST. The two paths are normalized to the same
+       * shape so behaviour is identical either way.
+       */
+      prefetched?: PrefetchedIssueCore;
+    },
   ): Promise<IssueCandidate> {
     // Check vetting cache first — avoids ~6+ API calls per issue
     const cache = getHttpCache();
@@ -332,12 +346,12 @@ export class IssueVetter {
     const { owner, repo, number } = parsed;
     const repoFullName = `${owner}/${repo}`;
 
-    // Fetch issue data
-    const { data: ghIssue } = await this.octokit.issues.get({
-      owner,
-      repo,
-      issue_number: number,
-    });
+    // Issue core data: use the batch-prefetched GraphQL result when the caller
+    // supplied one (#169), otherwise fetch it per-issue via REST. Both paths
+    // normalize to the same shape (fetchIssueCore), so downstream logic is
+    // identical regardless of source.
+    const core =
+      opts?.prefetched ?? (await this.fetchIssueCore(owner, repo, number));
 
     // Check if the user already has merged PRs in this repo (skip the Search API call)
     const reposWithMergedPRs = this.stateReader.getReposWithMergedPRs();
@@ -352,7 +366,7 @@ export class IssueVetter {
       userMergedPRCount,
     ] = await Promise.all([
       checkNoExistingPR(this.octokit, owner, repo, number),
-      checkNotClaimed(this.octokit, owner, repo, number, ghIssue.comments),
+      checkNotClaimed(this.octokit, owner, repo, number, core.commentCount),
       checkProjectHealth(this.octokit, owner, repo),
       fetchContributionGuidelines(this.octokit, owner, repo),
       hasMergedPRsInRepo
@@ -389,7 +403,7 @@ export class IssueVetter {
       linkedPR.author.toLowerCase() === username.toLowerCase();
 
     // Analyze issue quality
-    const clearRequirements = analyzeRequirements(ghIssue.body || "");
+    const clearRequirements = analyzeRequirements(core.body);
 
     // When the health check itself failed (API error), use a neutral default:
     // don't penalize the repo as inactive, but don't credit it as active either.
@@ -415,17 +429,15 @@ export class IssueVetter {
     // Create tracked issue. It holds a reference to vettingResult, whose
     // notes are filled in by deriveRecommendation below.
     const trackedIssue: TrackedIssue = {
-      id: ghIssue.id,
+      id: core.id,
       url: issueUrl,
       repo: repoFullName,
       number,
-      title: ghIssue.title,
+      title: core.title,
       status: "candidate",
-      labels: ghIssue.labels.map((l) =>
-        typeof l === "string" ? l : l.name || "",
-      ),
-      createdAt: ghIssue.created_at,
-      updatedAt: ghIssue.updated_at,
+      labels: core.labels,
+      createdAt: core.createdAt,
+      updatedAt: core.updatedAt,
       vetted: true,
       vettingResult,
     };
@@ -456,7 +468,7 @@ export class IssueVetter {
 
     // GitHub answers 200 for closed issues, so without an explicit state
     // check a closed issue would vet as still available (#120).
-    const issueClosed = ghIssue.state === "closed";
+    const issueClosed = core.state === "closed";
 
     // Never cache a verdict built on inconclusive/failed checks (e.g. a
     // transient 5xx): that would pin a degraded result for the whole TTL.
@@ -508,7 +520,7 @@ export class IssueVetter {
       isClaimed: !notClaimed,
       clearRequirements,
       hasContributionGuidelines: !!contributionGuidelines,
-      issueUpdatedAt: ghIssue.updated_at,
+      issueUpdatedAt: core.updatedAt,
       closedWithoutMergeCount:
         this.stateReader.getClosedWithoutMergeCount?.(repoFullName) ?? 0,
       mergedPRCount: effectiveMergedCount,
@@ -538,7 +550,7 @@ export class IssueVetter {
       if (slmConfig.host) slmOpts.host = slmConfig.host;
       slmTriage = await triageWithSLM(
         buildTriageInput({
-          issue: { ...trackedIssue, body: ghIssue.body ?? "" },
+          issue: { ...trackedIssue, body: core.body },
           linkedPR: existingPRCheck.linkedPR ?? null,
         }),
         slmOpts,
@@ -572,6 +584,35 @@ export class IssueVetter {
   }
 
   /**
+   * Fetch a single issue's core fields via REST and normalize them to the same
+   * shape as a GraphQL prefetch (#169). The REST fallback path when no
+   * prefetched core was supplied.
+   */
+  private async fetchIssueCore(
+    owner: string,
+    repo: string,
+    number: number,
+  ): Promise<PrefetchedIssueCore> {
+    const { data: ghIssue } = await this.octokit.issues.get({
+      owner,
+      repo,
+      issue_number: number,
+    });
+    return {
+      id: ghIssue.id,
+      title: ghIssue.title,
+      body: ghIssue.body || "",
+      state: ghIssue.state === "closed" ? "closed" : "open",
+      labels: ghIssue.labels.map((l) =>
+        typeof l === "string" ? l : l.name || "",
+      ),
+      commentCount: ghIssue.comments,
+      createdAt: ghIssue.created_at,
+      updatedAt: ghIssue.updated_at,
+    };
+  }
+
+  /**
    * Vet multiple issues in parallel with concurrency limit
    */
   async vetIssuesParallel(
@@ -600,12 +641,35 @@ export class IssueVetter {
     // vet still runs (#129). Callers dedup today, but nothing enforced it.
     const uniqueUrls = [...new Set(urls)];
 
+    // Batch-prefetch issue core data in one GraphQL query (#169), replacing N
+    // per-issue REST `issues.get` calls. Any URL the prefetch can't resolve
+    // (parse failure, deleted issue, non-fatal GraphQL error) is simply absent
+    // from the map and vetIssue falls back to REST for it. A fatal error (401 /
+    // rate limit) propagates out of prefetchIssueCores and aborts the batch,
+    // matching the per-issue auth-error handling below.
+    const prefetched = await prefetchIssueCores(
+      this.octokit,
+      uniqueUrls.flatMap((url) => {
+        const p = parseGitHubUrl(url);
+        return p && p.type === "issues"
+          ? [{ owner: p.owner, repo: p.repo, number: p.number }]
+          : [];
+      }),
+    );
+    const prefetchFor = (url: string): PrefetchedIssueCore | undefined => {
+      const p = parseGitHubUrl(url);
+      return p && p.type === "issues"
+        ? prefetched.get(issueCoreKey(p.owner, p.repo, p.number))
+        : undefined;
+    };
+
     for (const url of uniqueUrls) {
       if (candidates.length >= maxResults) break;
       if (firstAuthError) break; // stop scheduling once auth has failed
       attemptedCount++;
 
-      const task = this.vetIssue(url)
+      const core = prefetchFor(url);
+      const task = this.vetIssue(url, core ? { prefetched: core } : undefined)
         .then((candidate) => {
           if (candidates.length < maxResults) {
             // Override the priority if provided


### PR DESCRIPTION
Closes #169 (safe increment; see Deferred below).

## What

`vetIssue` re-fetched each issue's core fields (title, body, state, labels, timestamps, comment count) with a per-issue REST `issues.get`. A search that surfaces N issues for vetting made N separate REST calls before any of the deeper checks ran.

This adds `prefetchIssueCores`: one aliased GraphQL query that fetches the same fields for the whole batch and returns a `Map` keyed by `owner/repo#number`. `vetIssuesParallel` calls it once and threads each issue's prefetched core into `vetIssue`, which consumes it instead of calling `issues.get`.

## Equivalence and safety

Both paths normalize to one shape (`PrefetchedIssueCore`), so the GraphQL and REST fields stay provably equivalent for everything `vetIssue` reads:

- `databaseId` to `id` (same numeric GitHub id)
- `body` null to `""` (matches REST `body || ""`)
- `state` OPEN/CLOSED to open/closed
- `labels` nodes to `string[]`
- `comments.totalCount` to the REST `comments` count
- `createdAt` / `updatedAt` pass through as ISO-8601 strings

Failure handling mirrors the rest of the vetter:

- Fatal errors (401, rate limit) propagate via `rethrowIfFatal`
- A partial-data GraphQL error (one bad issue in the batch) keeps the aliases that resolved; the rest fall back to REST
- Any other non-fatal error returns an empty map, so every issue falls back to REST

Net effect: any issue the batch cannot resolve (deleted, permission error, non-fatal blip) is simply absent from the map and `vetIssue` fetches it via REST exactly as before. Behaviour is unchanged; the only difference is N `issues.get` calls collapse to one GraphQL call for the issues that resolve.

Query building is injection-safe: owner/repo/number flow through GraphQL variables, never string interpolation.

## Deferred

Scope is limited to the `issues.get` fields. The other vetting calls (timeline-based PR detection in `checkNoExistingPR`, claim scanning in `checkNotClaimed`, project health, contribution guidelines) stay REST. Batching those has real pagination-semantics divergence risk (the timeline and comment paginators fetch specific page ranges), so they are a separate follow-up rather than part of this safe increment.

## Tests

- New `issue-graphql.test.ts`: normalization (OPEN/CLOSED, null body, empty labels), variable-based query building, null-node and null-databaseId omission, dedup, partial-data via `err.data`, non-fatal to empty map, 401 and rate-limit propagation.
- `issue-vetting.test.ts`: `vetIssue` uses a prefetched core without calling `issues.get`; prefetched closed core skips; `vetIssuesParallel` batches via GraphQL and skips per-issue `issues.get`; falls back to `issues.get` for issues the batch omits.

Full gate green locally: lint, format:check, typecheck, 911 core + 26 mcp tests.