### PR TITLE
refactor(types)!: tighten exported types for the next major (#158)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -574,8 +574,7 @@ program
                     : r.status === "closed"
                       ? "🚫"
                       : "❌";
-            const score =
-              r.viabilityScore != null ? ` [${r.viabilityScore}/100]` : "";
+            const score = r.ok ? ` [${r.viabilityScore}/100]` : "";
             console.log(
               `  ${icon} ${r.repo}#${r.number} — ${r.status}${score}`,
             );
@@ -730,13 +729,19 @@ program
           console.log("Reasons to skip:");
           for (const r of result.reasonsToSkip) console.log(`  - ${r}`);
         }
-        console.log(
-          `\nProject health: ${result.projectHealth.isActive ? "Active" : "Inactive"}`,
-        );
-        console.log(
-          `  Last commit: ${result.projectHealth.daysSinceLastCommit} days ago`,
-        );
-        console.log(`  CI status: ${result.projectHealth.ciStatus}`);
+        if (result.projectHealth.checkFailed) {
+          console.log(
+            `\nProject health: unknown (check failed: ${result.projectHealth.failureReason})`,
+          );
+        } else {
+          console.log(
+            `\nProject health: ${result.projectHealth.isActive ? "Active" : "Inactive"}`,
+          );
+          console.log(
+            `  Last commit: ${result.projectHealth.daysSinceLastCommit} days ago`,
+          );
+          console.log(`  CI status: ${result.projectHealth.ciStatus}`);
+        }
       }
     }),
   );

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -125,9 +125,19 @@ export async function runSearch(
                   isStalled: isLinkedPRStalled(c.vettingResult.linkedPR),
                 }
               : undefined,
-            boostScore: c.boostScore,
-            boostReasons: c.boostReasons,
-            diversitySlot: c.diversitySlot,
+            // Keep the JSON output shape stable across the #158 internal
+            // refactor: derive the flat boost fields from the structural
+            // `personalization` marker.
+            boostScore:
+              c.personalization?.kind === "boosted"
+                ? c.personalization.score
+                : undefined,
+            boostReasons:
+              c.personalization?.kind === "boosted"
+                ? c.personalization.reasons
+                : undefined,
+            diversitySlot:
+              c.personalization?.kind === "diversity" ? true : undefined,
           };
         }),
         excludedRepos: result.excludedRepos,

--- a/packages/core/src/commands/with-scout.ts
+++ b/packages/core/src/commands/with-scout.ts
@@ -23,7 +23,7 @@ const GIST_SYNC_WARNING =
  * stderr if the gist push failed (local save still succeeded).
  */
 export async function persistScout(scout: OssScout): Promise<void> {
-  saveLocalState(scout.getState() as ScoutState);
+  saveLocalState(scout.getState());
   const persisted = await scout.checkpoint();
   if (!persisted) {
     console.error(GIST_SYNC_WARNING);

--- a/packages/core/src/core/anti-llm-policy.test.ts
+++ b/packages/core/src/core/anti-llm-policy.test.ts
@@ -46,6 +46,7 @@ vi.mock("./errors.js", () => ({
 }));
 
 vi.mock("./http-cache.js", () => ({
+  versionedCacheKey: (key: string) => key,
   getHttpCache: vi.fn(() => ({
     getIfFresh: vi.fn(() => null),
     set: vi.fn(),

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -16,7 +16,7 @@ import {
   rethrowIfFatal,
 } from "./errors.js";
 import { warn } from "./logger.js";
-import { getHttpCache } from "./http-cache.js";
+import { getHttpCache, versionedCacheKey } from "./http-cache.js";
 import type { AntiLLMPolicyResult, AntiLLMPolicySourceFile } from "./types.js";
 
 const MODULE = "anti-llm-policy";
@@ -224,7 +224,7 @@ export async function fetchAndScanAntiLLMPolicy(
   options?: AntiLLMPolicyOptions,
 ): Promise<AntiLLMPolicyResult> {
   const cache = getHttpCache();
-  const cacheKey = `anti-llm-policy:${owner}/${repo}`;
+  const cacheKey = versionedCacheKey(`anti-llm-policy:${owner}/${repo}`);
   const cached = cache.getIfFresh(cacheKey, POLICY_SCAN_CACHE_TTL_MS);
   if (isAntiLLMPolicyResult(cached)) return cached;
 

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -18,6 +18,7 @@ import { _clearRoadmapCacheForTests } from "./roadmap.js";
 // Broad mode routes through cachedSearchIssues (#121); stub its singletons
 // so tests never touch the real ~/.oss-scout cache or budget pacing.
 vi.mock("./http-cache.js", () => ({
+  versionedCacheKey: (key: string) => key,
   getHttpCache: vi.fn(() => ({
     getIfFresh: vi.fn(() => null),
     set: vi.fn(),

--- a/packages/core/src/core/http-cache.ts
+++ b/packages/core/src/core/http-cache.ts
@@ -19,6 +19,27 @@ import { errorMessage, getHttpStatusCode } from "./errors.js";
 
 const MODULE = "http-cache";
 
+/**
+ * Schema version for cache entries whose body is an oss-scout-defined shape
+ * (vetting results, search payloads, policy scans, merged-PR counts) rather
+ * than a raw GitHub API response. These are deserialized with an unchecked
+ * cast, so a shape change between releases would otherwise let a new build read
+ * a stale-shaped entry. Bump this whenever one of those cached shapes changes:
+ * old entries then miss the version-prefixed key and are refetched instead of
+ * misread (#158). Raw ETag-keyed GitHub responses are not versioned — their
+ * shape is owned by GitHub, not us.
+ */
+export const CACHE_SCHEMA_VERSION = "v1";
+
+/**
+ * Prefix a synthetic (non-URL) cache key with the schema version so a shape
+ * change invalidates old entries. Use for every key whose body is read back
+ * with an unchecked cast.
+ */
+export function versionedCacheKey(key: string): string {
+  return `${CACHE_SCHEMA_VERSION}:${key}`;
+}
+
 /** Shape of a single cache entry on disk. */
 export interface CacheEntry {
   etag: string;

--- a/packages/core/src/core/issue-discovery-strategies.test.ts
+++ b/packages/core/src/core/issue-discovery-strategies.test.ts
@@ -154,6 +154,7 @@ const baseStateReader = {
   getStarredRepos: () => [] as string[],
   getProjectCategories: () => [] as string[],
   getRepoScore: () => null,
+  getSLMTriageConfig: () => null,
 };
 
 describe("Strategy Selection", () => {

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -211,6 +211,7 @@ function makeStateReader(
     getStarredRepos: vi.fn(() => []),
     getProjectCategories: vi.fn(() => []),
     getRepoScore: vi.fn(() => null),
+    getSLMTriageConfig: vi.fn(() => null),
     ...overrides,
   };
 }

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -51,7 +51,11 @@ import {
   fetchIssuesFromKnownRepos,
   searchAcrossLanguagesAndLabels,
 } from "./search-phases.js";
-import { annotateBoost, applyDiversityRatio } from "./personalization.js";
+import {
+  annotateBoost,
+  applyDiversityRatio,
+  boostScoreOf,
+} from "./personalization.js";
 
 const MODULE = "issue-discovery";
 
@@ -844,13 +848,18 @@ export class IssueDiscovery {
         `Try again after the rate limit resets for complete results.`;
     }
 
-    // Personalization annotation (#1244): tag each candidate with
-    // boostScore + boostReasons before sorting so the new sort tier has
-    // values to read. No-op when neither preference list is supplied.
-    annotateBoost(allCandidates, options.preferLanguages, options.preferRepos);
+    // Personalization annotation (#1244): tag matched candidates with a
+    // `personalization` marker before sorting so the new sort tier has values
+    // to read. Returns a new array (no in-place candidate mutation, #158);
+    // a no-op when neither preference list is supplied.
+    const ranked = annotateBoost(
+      allCandidates,
+      options.preferLanguages,
+      options.preferRepos,
+    );
 
     // Sort by priority, recommendation, boost (#1244), then viability score
-    allCandidates.sort((a, b) => {
+    ranked.sort((a, b) => {
       const priorityOrder: Record<SearchPriority, number> = {
         merged_pr: 0,
         starred: 1,
@@ -866,18 +875,18 @@ export class IssueDiscovery {
         recommendationOrder[b.recommendation];
       if (recDiff !== 0) return recDiff;
 
-      // Personalization tier (#1244): higher boostScore wins. Treats
-      // undefined as 0 so unboosted candidates rank below boosted peers
-      // but stay ordered among themselves by viabilityScore. No-op when
-      // `preferLanguages`/`preferRepos` are absent — all candidates carry
-      // `boostScore: undefined` and the difference collapses to 0.
-      const boostDiff = (b.boostScore ?? 0) - (a.boostScore ?? 0);
+      // Personalization tier (#1244): higher boost wins. boostScoreOf treats
+      // an unboosted candidate as 0 so they rank below boosted peers but stay
+      // ordered among themselves by viabilityScore. No-op when
+      // `preferLanguages`/`preferRepos` are absent — every candidate scores 0
+      // and the difference collapses.
+      const boostDiff = boostScoreOf(b) - boostScoreOf(a);
       if (boostDiff !== 0) return boostDiff;
 
       return b.viabilityScore - a.viabilityScore;
     });
 
-    const capped = applyPerRepoCap(allCandidates, 2);
+    const capped = applyPerRepoCap(ranked, 2);
 
     // Diversity counterweight (#1244): when `diversityRatio > 0`, reserve
     // a fraction of the final slots for candidates that matched neither

--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -16,6 +16,7 @@ vi.mock("./search-budget.js", () => ({
 }));
 
 vi.mock("./http-cache.js", () => ({
+  versionedCacheKey: (key: string) => key,
   getHttpCache: vi.fn(() => ({
     getIfFresh: vi.fn(() => null),
     set: vi.fn(),

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -10,14 +10,22 @@ import { Octokit } from "@octokit/rest";
 import { paginateAll } from "./pagination.js";
 import { errorMessage, rethrowIfFatal } from "./errors.js";
 import { warn } from "./logger.js";
-import { getHttpCache, withInflightDedup } from "./http-cache.js";
+import {
+  getHttpCache,
+  withInflightDedup,
+  versionedCacheKey,
+} from "./http-cache.js";
 import { getSearchBudgetTracker } from "./search-budget.js";
 import type { CheckResult, LinkedPR } from "./types.js";
 
-/** Result of the existing-PR check, including metadata for the first linked PR (if any). */
-export interface ExistingPRCheckResult extends CheckResult {
+/**
+ * Result of the existing-PR check, including metadata for the first linked PR
+ * (if any). An intersection (not `extends`) because CheckResult is now a
+ * discriminated union (#158); the `& { linkedPR }` distributes over both arms.
+ */
+export type ExistingPRCheckResult = CheckResult & {
   linkedPR: LinkedPR | null;
-}
+};
 
 /** Shape of a cross-referenced PR event from the GitHub issue timeline API. */
 type CrossRefEvent = {
@@ -224,7 +232,7 @@ export async function checkUserMergedPRsInRepo(
   repo: string,
 ): Promise<number | null> {
   const cache = getHttpCache();
-  const cacheKey = `merged-prs:${owner}/${repo}`;
+  const cacheKey = versionedCacheKey(`merged-prs:${owner}/${repo}`);
 
   // In-flight dedup: parallel vetting frequently hits several issues from
   // one repo at once, and each used to pay a separate Search API call

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -94,6 +94,7 @@ vi.mock("./anti-llm-policy.js", () => ({
 }));
 
 vi.mock("./http-cache.js", () => ({
+  versionedCacheKey: (key: string) => key,
   getHttpCache: vi.fn(() => ({
     getIfFresh: vi.fn(() => null),
     set: vi.fn(),
@@ -128,6 +129,7 @@ function makeStubStateReader(
     getStarredRepos: vi.fn(() => []),
     getProjectCategories: vi.fn(() => []),
     getRepoScore: vi.fn(() => null),
+    getSLMTriageConfig: vi.fn(() => null),
     ...overrides,
   };
 }

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -49,7 +49,7 @@ import {
   issueCoreKey,
   type PrefetchedIssueCore,
 } from "./issue-graphql.js";
-import { getHttpCache } from "./http-cache.js";
+import { getHttpCache, versionedCacheKey } from "./http-cache.js";
 import {
   triageWithSLM,
   buildTriageInput,
@@ -88,6 +88,16 @@ export type FeatureSignals = {
 };
 
 /**
+ * SLM pre-triage configuration (oss-autopilot#1122). `host` is the Ollama
+ * endpoint; an empty `host` means "use the triage default". A `null` config
+ * (not this shape) means SLM triage is disabled (#158).
+ */
+export interface SLMConfig {
+  model: string;
+  host: string;
+}
+
+/**
  * Read-only interface for accessing scout state during issue vetting.
  * Implementations may be backed by gist persistence, in-memory state, etc.
  */
@@ -103,11 +113,13 @@ export interface ScoutStateReader {
   /** Numeric quality score for a repo, or null if not evaluated. */
   getRepoScore(repo: string): number | null;
   /**
-   * SLM pre-triage config (oss-autopilot#1122). Returns the configured
-   * model id and Ollama host, or empty strings when not configured —
-   * vetIssue treats either of these as "skip the SLM call".
+   * SLM pre-triage config (oss-autopilot#1122). Returns the configured model
+   * id and Ollama host, or `null` when SLM triage is not configured — vetIssue
+   * skips the SLM call on `null`. Required (#158): the old optional method with
+   * an empty-string sentinel could not distinguish "not configured" from "host
+   * defaulted"; `SLMConfig | null` makes the absence explicit.
    */
-  getSLMTriageConfig?(): { model: string; host: string };
+  getSLMTriageConfig(): SLMConfig | null;
   /**
    * Number of the user's PRs closed without merge in this repo (#125).
    * Optional so existing implementations keep compiling; absent reads as 0.
@@ -325,7 +337,7 @@ export class IssueVetter {
     const sigKey = opts?.featureSignals
       ? `:r${opts.featureSignals.reactions}c${opts.featureSignals.comments}m${opts.featureSignals.hasMilestone ? 1 : 0}o${opts.featureSignals.onRoadmap ? 1 : 0}w${opts.featureSignals.wontfixNoContributor ? 1 : 0}`
       : "";
-    const cacheKey = `vet:${issueUrl}${sigKey}`;
+    const cacheKey = versionedCacheKey(`vet:${issueUrl}${sigKey}`);
     const cached = cache.getIfFresh(cacheKey, VETTING_CACHE_TTL_MS);
     if (
       cached &&
@@ -485,13 +497,17 @@ export class IssueVetter {
         notClaimed,
         clearRequirements,
         contributionGuidelinesFound: !!contributionGuidelines,
-        projectIsActive: projectHealth.isActive,
+        projectIsActive: projectHealth.checkFailed
+          ? false
+          : projectHealth.isActive,
         projectCheckFailed: !!projectHealth.checkFailed,
         projectFailureReason: projectHealth.failureReason,
         existingPRInconclusive: !!existingPRCheck.inconclusive,
-        existingPRReason: existingPRCheck.reason,
+        existingPRReason: existingPRCheck.inconclusive
+          ? existingPRCheck.reason
+          : undefined,
         claimInconclusive: !!claimCheck.inconclusive,
-        claimReason: claimCheck.reason,
+        claimReason: claimCheck.inconclusive ? claimCheck.reason : undefined,
         mergedCountInconclusive,
         effectiveMergedCount,
         orgName,
@@ -502,11 +518,14 @@ export class IssueVetter {
       });
     vettingResult.notes = notes;
 
-    // Calculate repo quality bonus from star/fork counts
-    const repoQualityBonus = calculateRepoQualityBonus(
-      projectHealth.stargazersCount ?? 0,
-      projectHealth.forksCount ?? 0,
-    );
+    // Calculate repo quality bonus from star/fork counts. A failed health
+    // check carries no counts (#158), so the bonus is 0 in that case.
+    const repoQualityBonus = projectHealth.checkFailed
+      ? 0
+      : calculateRepoQualityBonus(
+          projectHealth.stargazersCount ?? 0,
+          projectHealth.forksCount ?? 0,
+        );
     if (projectHealth.checkFailed && repoQualityBonus === 0) {
       vettingResult.notes.push(
         "Repo quality bonus unavailable: could not fetch star/fork counts due to API error",
@@ -539,13 +558,11 @@ export class IssueVetter {
     }
 
     // Optional SLM pre-triage (oss-autopilot#1122). Fail-open: any error
-    // path returns null and the rest of the pipeline is unaffected.
-    const slmConfig = this.stateReader.getSLMTriageConfig?.() ?? {
-      model: "",
-      host: "",
-    };
+    // path returns null and the rest of the pipeline is unaffected. A null
+    // config means SLM triage is disabled (#158).
+    const slmConfig = this.stateReader.getSLMTriageConfig();
     let slmTriage: IssueCandidate["slmTriage"] = null;
-    if (slmConfig.model) {
+    if (slmConfig) {
       const slmOpts: SLMTriageOptions = { model: slmConfig.model };
       if (slmConfig.host) slmOpts.host = slmConfig.host;
       slmTriage = await triageWithSLM(

--- a/packages/core/src/core/local-state.ts
+++ b/packages/core/src/core/local-state.ts
@@ -66,7 +66,7 @@ let tmpCounter = 0;
  * is still last-writer-wins (no lock), but each save is now atomic and
  * crash-free on its own.
  */
-export function saveLocalState(state: ScoutState): void {
+export function saveLocalState(state: Readonly<ScoutState>): void {
   const statePath = getStatePath();
   const tmpPath = `${statePath}.tmp.${process.pid}.${tmpCounter++}`;
 

--- a/packages/core/src/core/personalization.test.ts
+++ b/packages/core/src/core/personalization.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for personalization boost (#1244).
+ * Tests for personalization boost (#1244, retyped in #158).
  *
- * Mutation semantics: `annotateBoost` sets `boostScore`/`boostReasons`
- * on each matched candidate. The caller (issue-discovery) re-sorts
- * using those values; these tests just verify the annotation itself.
+ * `annotateBoost` returns a NEW candidate list (no in-place mutation) where
+ * matched candidates carry `personalization: { kind: "boosted", ... }`.
+ * `applyDiversityRatio` tags reserved picks with `{ kind: "diversity" }` on
+ * shallow copies. These tests verify both annotations.
  */
 
 import { describe, it, expect } from "vitest";
@@ -14,6 +15,25 @@ import {
   REPO_BOOST,
 } from "./personalization.js";
 import type { IssueCandidate } from "./types.js";
+
+/** Boost score of a candidate, or undefined if it is not boosted. */
+function boostScore(c: IssueCandidate): number | undefined {
+  return c.personalization?.kind === "boosted"
+    ? c.personalization.score
+    : undefined;
+}
+
+/** Boost reasons of a candidate, or undefined if it is not boosted. */
+function boostReasons(c: IssueCandidate): string[] | undefined {
+  return c.personalization?.kind === "boosted"
+    ? c.personalization.reasons
+    : undefined;
+}
+
+/** Whether a candidate filled a diversity slot. */
+function isDiversity(c: IssueCandidate): boolean {
+  return c.personalization?.kind === "diversity";
+}
 
 function makeCandidate(
   repo: string,
@@ -82,109 +102,121 @@ describe("annotateBoost", () => {
       makeCandidate("rails/rails", "Ruby"),
     ];
 
-    annotateBoost(candidates, undefined, undefined);
+    const out = annotateBoost(candidates, undefined, undefined);
 
-    for (const c of candidates) {
-      expect(c.boostScore).toBeUndefined();
-      expect(c.boostReasons).toBeUndefined();
+    for (const c of out) {
+      expect(c.personalization).toBeUndefined();
     }
   });
 
   it("is a no-op when preference lists are empty", () => {
     const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
 
-    annotateBoost(candidates, [], []);
+    const out = annotateBoost(candidates, [], []);
 
-    expect(candidates[0].boostScore).toBeUndefined();
-    expect(candidates[0].boostReasons).toBeUndefined();
+    expect(out[0].personalization).toBeUndefined();
   });
 
-  it("matches language case-insensitively and tags reason", () => {
-    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
-
-    annotateBoost(candidates, ["typescript"], undefined);
-
-    expect(candidates[0].boostScore).toBe(LANGUAGE_BOOST);
-    expect(candidates[0].boostReasons).toEqual(["language match: TypeScript"]);
-  });
-
-  it("matches repo slug exactly and tags reason", () => {
-    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
-
-    annotateBoost(candidates, undefined, ["vercel/next.js"]);
-
-    expect(candidates[0].boostScore).toBe(REPO_BOOST);
-    expect(candidates[0].boostReasons).toEqual([
-      "repo affinity: vercel/next.js",
-    ]);
-  });
-
-  it("matches repo slug case-insensitively (#130)", () => {
-    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
-
-    annotateBoost(candidates, undefined, ["Vercel/Next.js"]);
-
-    expect(candidates[0].boostScore).toBe(REPO_BOOST);
-    expect(candidates[0].boostReasons).toEqual([
-      "repo affinity: vercel/next.js",
-    ]);
-  });
-
-  it("stacks repo and language boosts when both match", () => {
+  it("does not mutate the input candidates", () => {
     const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
 
     annotateBoost(candidates, ["typescript"], ["vercel/next.js"]);
 
-    expect(candidates[0].boostScore).toBe(REPO_BOOST + LANGUAGE_BOOST);
-    expect(candidates[0].boostReasons).toEqual([
+    // The original object is untouched; the boost lives on the returned copy.
+    expect(candidates[0].personalization).toBeUndefined();
+  });
+
+  it("matches language case-insensitively and tags reason", () => {
+    const out = annotateBoost(
+      [makeCandidate("vercel/next.js", "TypeScript")],
+      ["typescript"],
+      undefined,
+    );
+
+    expect(boostScore(out[0])).toBe(LANGUAGE_BOOST);
+    expect(boostReasons(out[0])).toEqual(["language match: TypeScript"]);
+  });
+
+  it("matches repo slug exactly and tags reason", () => {
+    const out = annotateBoost(
+      [makeCandidate("vercel/next.js", "TypeScript")],
+      undefined,
+      ["vercel/next.js"],
+    );
+
+    expect(boostScore(out[0])).toBe(REPO_BOOST);
+    expect(boostReasons(out[0])).toEqual(["repo affinity: vercel/next.js"]);
+  });
+
+  it("matches repo slug case-insensitively (#130)", () => {
+    const out = annotateBoost(
+      [makeCandidate("vercel/next.js", "TypeScript")],
+      undefined,
+      ["Vercel/Next.js"],
+    );
+
+    expect(boostScore(out[0])).toBe(REPO_BOOST);
+    expect(boostReasons(out[0])).toEqual(["repo affinity: vercel/next.js"]);
+  });
+
+  it("stacks repo and language boosts when both match", () => {
+    const out = annotateBoost(
+      [makeCandidate("vercel/next.js", "TypeScript")],
+      ["typescript"],
+      ["vercel/next.js"],
+    );
+
+    expect(boostScore(out[0])).toBe(REPO_BOOST + LANGUAGE_BOOST);
+    expect(boostReasons(out[0])).toEqual([
       "repo affinity: vercel/next.js",
       "language match: TypeScript",
     ]);
   });
 
-  it("leaves boostScore undefined on candidates that match nothing", () => {
-    const candidates = [
-      makeCandidate("rails/rails", "Ruby"),
-      makeCandidate("vercel/next.js", "TypeScript"),
-    ];
+  it("leaves personalization undefined on candidates that match nothing", () => {
+    const out = annotateBoost(
+      [
+        makeCandidate("rails/rails", "Ruby"),
+        makeCandidate("vercel/next.js", "TypeScript"),
+      ],
+      ["typescript"],
+      ["vercel/next.js"],
+    );
 
-    annotateBoost(candidates, ["typescript"], ["vercel/next.js"]);
-
-    expect(candidates[0].boostScore).toBeUndefined();
-    expect(candidates[0].boostReasons).toBeUndefined();
-    expect(candidates[1].boostScore).toBe(REPO_BOOST + LANGUAGE_BOOST);
+    expect(out[0].personalization).toBeUndefined();
+    expect(boostScore(out[1])).toBe(REPO_BOOST + LANGUAGE_BOOST);
   });
 
   it("handles candidates with null/undefined language without crashing", () => {
-    const candidates = [
-      makeCandidate("foo/bar", null),
-      makeCandidate("baz/qux", undefined),
-    ];
+    const out = annotateBoost(
+      [makeCandidate("foo/bar", null), makeCandidate("baz/qux", undefined)],
+      ["typescript"],
+      undefined,
+    );
 
-    annotateBoost(candidates, ["typescript"], undefined);
-
-    expect(candidates[0].boostScore).toBeUndefined();
-    expect(candidates[1].boostScore).toBeUndefined();
+    expect(out[0].personalization).toBeUndefined();
+    expect(out[1].personalization).toBeUndefined();
   });
 
   it("trims whitespace and ignores empty entries in preference lists", () => {
-    const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
-
-    annotateBoost(
-      candidates,
+    const out = annotateBoost(
+      [makeCandidate("vercel/next.js", "TypeScript")],
       [" typescript ", "", "  "],
       [" ", "vercel/next.js"],
     );
 
-    expect(candidates[0].boostScore).toBe(REPO_BOOST + LANGUAGE_BOOST);
+    expect(boostScore(out[0])).toBe(REPO_BOOST + LANGUAGE_BOOST);
   });
 });
 
 describe("applyDiversityRatio", () => {
   function boosted(repo: string): IssueCandidate {
     const c = makeCandidate(repo, "TypeScript");
-    c.boostScore = REPO_BOOST;
-    c.boostReasons = [`repo affinity: ${repo}`];
+    c.personalization = {
+      kind: "boosted",
+      score: REPO_BOOST,
+      reasons: [`repo affinity: ${repo}`],
+    };
     return c;
   }
 
@@ -200,7 +232,7 @@ describe("applyDiversityRatio", () => {
     expect(picks).toHaveLength(2);
     expect(picks[0].issue.repo).toBe("a/b");
     expect(picks[1].issue.repo).toBe("c/d");
-    expect(picks.some((p) => p.diversitySlot)).toBe(false);
+    expect(picks.some(isDiversity)).toBe(false);
   });
 
   it("reserves diversity slots for unboosted candidates", () => {
@@ -217,11 +249,11 @@ describe("applyDiversityRatio", () => {
     const picks = applyDiversityRatio(candidates, 5, 0.4);
 
     expect(picks).toHaveLength(5);
-    expect(picks.slice(0, 3).every((p) => p.boostScore === REPO_BOOST)).toBe(
+    expect(picks.slice(0, 3).every((p) => boostScore(p) === REPO_BOOST)).toBe(
       true,
     );
-    expect(picks.slice(3).every((p) => p.diversitySlot === true)).toBe(true);
-    expect(picks.slice(3).every((p) => !p.boostScore)).toBe(true);
+    expect(picks.slice(3).every(isDiversity)).toBe(true);
+    expect(picks.slice(3).every((p) => boostScore(p) === undefined)).toBe(true);
     expect(picks[3].issue.repo).toBe("i/j");
     expect(picks[4].issue.repo).toBe("k/l");
   });
@@ -242,9 +274,10 @@ describe("applyDiversityRatio", () => {
     expect(picks[0].issue.repo).toBe("a/b");
     expect(picks[1].issue.repo).toBe("c/d");
     expect(picks[2].issue.repo).toBe("i/j");
-    expect(picks[2].diversitySlot).toBe(true);
+    expect(isDiversity(picks[2])).toBe(true);
     expect(picks[3].issue.repo).toBe("e/f");
-    expect(picks[3].diversitySlot).toBeUndefined();
+    // e/f is a boosted top-up pick, not a diversity slot.
+    expect(isDiversity(picks[3])).toBe(false);
   });
 
   it("clamps ratio above 1 to a full diversity pass", () => {
@@ -262,9 +295,9 @@ describe("applyDiversityRatio", () => {
 
     expect(picks).toHaveLength(4);
     expect(picks[0].issue.repo).toBe("i/j");
-    expect(picks[0].diversitySlot).toBe(true);
+    expect(isDiversity(picks[0])).toBe(true);
     expect(picks[1].issue.repo).toBe("k/l");
-    expect(picks[1].diversitySlot).toBe(true);
+    expect(isDiversity(picks[1])).toBe(true);
     expect(picks[2].issue.repo).toBe("a/b");
     expect(picks[3].issue.repo).toBe("c/d");
   });

--- a/packages/core/src/core/personalization.ts
+++ b/packages/core/src/core/personalization.ts
@@ -31,31 +31,41 @@ export const REPO_BOOST = 20;
 export const LANGUAGE_BOOST = 10;
 
 /**
- * Annotate each candidate with `boostScore` and `boostReasons` based on
- * the caller-supplied preference lists. Mutates the array in place; the
- * caller is responsible for re-sorting afterwards.
+ * The personalization sort weight of a candidate: its boost score, or 0 when it
+ * is not boosted (unboosted or a diversity slot). Reads the structural
+ * `personalization` field (#158) so callers never poke at the old loose
+ * `boostScore` field.
+ */
+export function boostScoreOf(candidate: IssueCandidate): number {
+  return candidate.personalization?.kind === "boosted"
+    ? candidate.personalization.score
+    : 0;
+}
+
+/**
+ * Return a new candidate list where each candidate that matches a
+ * caller-supplied preference carries `personalization: { kind: "boosted", ... }`.
+ * Does NOT mutate the input candidates (#158) — matched candidates are shallow
+ * copies with the field set; unmatched candidates are passed through unchanged.
+ * The caller re-sorts the returned array.
  *
- * Mutation (rather than returning new objects) keeps the personalization
- * step a single linear pass over the array the caller already holds —
- * the sort step reads back from the same objects.
- *
- * No-op when both preference lists are empty or undefined: candidates
- * retain `boostScore: undefined` and the sort tier collapses to 0.
+ * No-op when both preference lists are empty or undefined: the input array is
+ * returned as-is and the sort tier collapses to 0 for every candidate.
  */
 export function annotateBoost(
   candidates: IssueCandidate[],
   preferLanguages?: string[],
   preferRepos?: string[],
-): void {
+): IssueCandidate[] {
   const langSet = new Set(
     (preferLanguages ?? []).map((l) => l.trim().toLowerCase()).filter(Boolean),
   );
   const repoSet = new Set(
     (preferRepos ?? []).map((r) => r.trim().toLowerCase()).filter(Boolean),
   );
-  if (langSet.size === 0 && repoSet.size === 0) return;
+  if (langSet.size === 0 && repoSet.size === 0) return candidates;
 
-  for (const c of candidates) {
+  return candidates.map((c) => {
     let score = 0;
     const reasons: string[] = [];
 
@@ -64,17 +74,15 @@ export function annotateBoost(
       reasons.push(`repo affinity: ${c.issue.repo}`);
     }
 
-    const lang = c.projectHealth.language;
+    const lang = c.projectHealth.checkFailed ? null : c.projectHealth.language;
     if (langSet.size > 0 && lang && langSet.has(lang.toLowerCase())) {
       score += LANGUAGE_BOOST;
       reasons.push(`language match: ${lang}`);
     }
 
-    if (score > 0) {
-      c.boostScore = score;
-      c.boostReasons = reasons;
-    }
-  }
+    if (score === 0) return c;
+    return { ...c, personalization: { kind: "boosted", score, reasons } };
+  });
 }
 
 /**
@@ -126,9 +134,9 @@ export function applyDiversityRatio(
   for (const c of candidates) {
     if (picks.length >= maxResults) break;
     if (seen.has(c.issue.url)) continue;
-    if (c.boostScore && c.boostScore > 0) continue;
-    c.diversitySlot = true;
-    picks.push(c);
+    if (boostScoreOf(c) > 0) continue;
+    // Tag a shallow copy rather than mutating the shared candidate (#158).
+    picks.push({ ...c, personalization: { kind: "diversity" } });
     seen.add(c.issue.url);
   }
 

--- a/packages/core/src/core/repo-health.test.ts
+++ b/packages/core/src/core/repo-health.test.ts
@@ -13,6 +13,7 @@ vi.mock("./logger.js", () => ({
 
 // Mock http-cache to pass through to the real fetcher (no caching in tests)
 vi.mock("./http-cache.js", () => ({
+  versionedCacheKey: (key: string) => key,
   getHttpCache: () => ({}),
   cachedRequest: async (
     _cache: unknown,
@@ -107,8 +108,11 @@ describe("checkProjectHealth", () => {
 
     const health = await checkProjectHealth(octokit, "error-org", "error-repo");
     expect(health.checkFailed).toBe(true);
-    expect(health.failureReason).toBeDefined();
-    expect(health.isActive).toBe(false);
+    if (health.checkFailed) {
+      expect(health.failureReason).toBeDefined();
+    }
+    // The slim failure shape (#158) carries no snapshot fields.
+    expect(health).not.toHaveProperty("isActive");
   });
 
   it("propagates 401 auth errors instead of swallowing", async () => {

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -132,14 +132,11 @@ export async function checkProjectHealth(
       MODULE,
       `Error checking project health for ${owner}/${repo}: ${errMsg}`,
     );
+    // The check failed: only the repo and the reason are known. The
+    // discriminated ProjectHealth type intentionally has no place for the
+    // neutral-default snapshot fields this used to fabricate (#158).
     return {
       repo: `${owner}/${repo}`,
-      lastCommitAt: "",
-      daysSinceLastCommit: 999,
-      openIssuesCount: 0,
-      avgIssueResponseDays: 0,
-      ciStatus: "unknown",
-      isActive: false,
       checkFailed: true,
       failureReason: errMsg,
     };

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -168,7 +168,10 @@ export const SavedCandidateSchema = z.looseObject({
   labels: z.array(z.string()),
   recommendation: z.enum(["approve", "skip", "needs_review"]),
   viabilityScore: z.number(),
-  searchPriority: z.string(),
+  // Tightened from z.string() to the actual 3-value union (#158). `.catch`
+  // keeps old persisted state loadable: any unrecognized stored value (or a
+  // future-version value) decodes to "normal" instead of failing the parse.
+  searchPriority: z.enum(["merged_pr", "starred", "normal"]).catch("normal"),
   firstSeenAt: z.string(),
   lastSeenAt: z.string(),
   lastScore: z.number(),

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -59,6 +59,7 @@ const mockCache = {
   set: vi.fn(),
 };
 vi.mock("./http-cache.js", () => ({
+  versionedCacheKey: (key: string) => key,
   getHttpCache: vi.fn(() => mockCache),
 }));
 

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -14,7 +14,7 @@ import {
 } from "./types.js";
 import { errorMessage, getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { debug, warn } from "./logger.js";
-import { getHttpCache } from "./http-cache.js";
+import { getHttpCache, versionedCacheKey } from "./http-cache.js";
 import {
   type GitHubSearchItem,
   detectLabelFarmingRepos,
@@ -118,7 +118,9 @@ export async function cachedSearchIssues(
     per_page: number;
   },
 ): Promise<{ total_count: number; items: GitHubSearchItem[] }> {
-  const cacheKey = `search:${params.q}:${params.sort}:${params.order}:${params.per_page}`;
+  const cacheKey = versionedCacheKey(
+    `search:${params.q}:${params.sort}:${params.order}:${params.per_page}`,
+  );
   const cache = getHttpCache();
 
   // Check cache first

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -32,8 +32,8 @@ export type {
 
 // ── Ephemeral types ─────────────────────────────────────────────────
 
-/** Health snapshot of a GitHub repository. */
-export interface ProjectHealth {
+/** A successful health snapshot of a GitHub repository. */
+export interface ProjectHealthData {
   repo: string;
   lastCommitAt: string;
   daysSinceLastCommit: number;
@@ -44,9 +44,28 @@ export interface ProjectHealth {
   stargazersCount?: number;
   forksCount?: number;
   language?: string | null;
-  checkFailed?: boolean;
-  failureReason?: string;
+  /** Discriminant: a real snapshot is never `checkFailed`. */
+  checkFailed?: false;
+  failureReason?: undefined;
 }
+
+/**
+ * The health check itself failed (transient API error). Only the repo and the
+ * failure reason are known — none of the snapshot fields are meaningful, so the
+ * type does not carry them. Narrow on `checkFailed` to reach a real snapshot.
+ */
+export interface ProjectHealthFailure {
+  repo: string;
+  checkFailed: true;
+  failureReason: string;
+}
+
+/**
+ * Health snapshot of a GitHub repository, or a marker that the check failed.
+ * A discriminated union (on `checkFailed`) so the "failure" shape can't be read
+ * as if it carried real snapshot data. Narrow before reading snapshot fields.
+ */
+export type ProjectHealth = ProjectHealthData | ProjectHealthFailure;
 
 /** Priority tier for issue search results. */
 export type SearchPriority = "merged_pr" | "starred" | "normal";
@@ -98,26 +117,18 @@ export interface IssueCandidate {
   viabilityScore: number;
   searchPriority: SearchPriority;
   /**
-   * Personalization sort tier (#1244). Populated only when the caller
-   * passes `preferLanguages` / `preferRepos` to `search()` *and* the
-   * candidate matches at least one. Affects sort order between the
-   * `recommendation` tier and `viabilityScore`; never used as a filter.
+   * Personalization marker (#1244). A candidate is EITHER boosted (it matched
+   * a `preferLanguages` / `preferRepos` bias and gets a soft sort boost between
+   * the `recommendation` tier and `viabilityScore`) OR a diversity slot (it
+   * matched no bias and filled a slot reserved by `diversityRatio`) — never
+   * both. Modelling it as a single discriminated field makes that mutual
+   * exclusivity structural instead of prose across three optional fields.
+   * Absent when no personalization was requested or the candidate matched
+   * nothing.
    */
-  boostScore?: number;
-  /**
-   * Human-readable reasons the candidate matched personalization bias
-   * (#1244). Mirrors `reasonsToApprove`/`reasonsToSkip` shape for
-   * symmetry with the existing surface.
-   */
-  boostReasons?: string[];
-  /**
-   * Marks a candidate that filled a reserved diversity slot (#1244).
-   * Populated only when `diversityRatio > 0` was passed AND the
-   * candidate matched no personalization bias. Mutually exclusive with
-   * a non-zero `boostScore` (a candidate cannot be both biased-toward
-   * and a diversity slot in the same result set).
-   */
-  diversitySlot?: boolean;
+  personalization?:
+    | { kind: "boosted"; score: number; reasons: string[] }
+    | { kind: "diversity" };
 }
 
 /** Subset of RepoScore fields that callers may update. */
@@ -131,12 +142,16 @@ export interface RepoScoreUpdate {
   language?: string | null;
 }
 
-/** Result of a check (e.g., no existing PR, not claimed). */
-export interface CheckResult {
-  passed: boolean;
-  inconclusive?: boolean;
-  reason?: string;
-}
+/**
+ * Result of a check (e.g., no existing PR, not claimed). Discriminated on
+ * `inconclusive`: a `reason` exists only when the check could not be completed
+ * (a transient API error), and an inconclusive check always reports `passed:
+ * true` because the caller assumes the issue is still eligible. A conclusive
+ * result carries no `reason`.
+ */
+export type CheckResult =
+  | { passed: boolean; inconclusive?: false; reason?: undefined }
+  | { passed: true; inconclusive: true; reason: string };
 
 // ── Const arrays and mappings ───────────────────────────────────────
 
@@ -166,17 +181,32 @@ export interface VetListOptions {
   prune?: boolean;
 }
 
-/** A single entry in the vet-list result. */
-export interface VetListEntry {
+/** Identity fields shared by every vet-list entry, regardless of outcome. */
+export interface VetListEntryBase {
   issueUrl: string;
   repo: string;
   number: number;
   title: string;
   status: "still_available" | "claimed" | "closed" | "has_pr" | "error";
-  recommendation?: "approve" | "skip" | "needs_review";
-  viabilityScore?: number;
-  errorMessage?: string;
 }
+
+/**
+ * A single entry in the vet-list result. Discriminated on `ok`: a completed vet
+ * (`ok: true`) carries `recommendation` + `viabilityScore` and never an
+ * `errorMessage`; a vet that threw (`ok: false`, including a 404/410 that
+ * classifies the issue as `closed`) carries only the `errorMessage`. This makes
+ * the "score xor error" invariant structural instead of prose.
+ */
+export type VetListEntry =
+  | (VetListEntryBase & {
+      ok: true;
+      recommendation: "approve" | "skip" | "needs_review";
+      viabilityScore: number;
+    })
+  | (VetListEntryBase & {
+      ok: false;
+      errorMessage: string;
+    });
 
 /** Summary counts for a vet-list run. */
 export interface VetListSummary {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,8 @@ export type {
   OpenPRRecord,
   RepoScoreUpdate,
   ProjectHealth,
+  ProjectHealthData,
+  ProjectHealthFailure,
   SearchPriority,
   CheckResult,
   AntiLLMPolicyResult,
@@ -36,6 +38,7 @@ export type {
   VetListOptions,
   VetListResult,
   VetListEntry,
+  VetListEntryBase,
   VetListSummary,
   SyncResult,
 } from "./core/types.js";
@@ -91,6 +94,7 @@ export {
   IssueVetter,
   type ScoutStateReader,
   type ScoutStateWriter,
+  type SLMConfig,
   type FeatureSignals,
 } from "./core/issue-vetting.js";
 export {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -10,6 +10,7 @@ import { IssueVetter } from "./core/issue-vetting.js";
 import type {
   ScoutStateReader,
   ScoutStateWriter,
+  SLMConfig,
 } from "./core/issue-vetting.js";
 import {
   discoverFeatures,
@@ -390,6 +391,7 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
             number: item.number,
             title: item.title,
             status: this.classifyVetResult(candidate),
+            ok: true,
             recommendation: candidate.recommendation,
             viabilityScore: candidate.viabilityScore,
           });
@@ -407,6 +409,7 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
             number: item.number,
             title: item.title,
             status: isGone ? "closed" : "error",
+            ok: false,
             errorMessage: errorMessage(error),
           });
         })
@@ -562,14 +565,14 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
   }
 
   /**
-   * Optional SLM pre-triage config read from preferences (oss-autopilot#1122).
-   * Empty `model` disables the call; the vetter treats it as a no-op.
+   * SLM pre-triage config read from preferences (oss-autopilot#1122). Returns
+   * `null` when no `slmTriageModel` is configured — the vetter skips the SLM
+   * call entirely (#158).
    */
-  getSLMTriageConfig(): { model: string; host: string } {
-    return {
-      model: this.state.preferences.slmTriageModel ?? "",
-      host: this.state.preferences.slmTriageHost ?? "",
-    };
+  getSLMTriageConfig(): SLMConfig | null {
+    const model = this.state.preferences.slmTriageModel ?? "";
+    if (!model) return null;
+    return { model, host: this.state.preferences.slmTriageHost ?? "" };
   }
 
   /** Get current preferences (read-only). */


### PR DESCRIPTION
Closes #158.

Six breaking type-tightening changes batched into one major-prep PR. Exported types are consumed downstream in `provided` mode, so they ship together rather than dribbling out across minors.

## Changes

### 1. Discriminated unions (kills the optional-flag soup)
- **`ProjectHealth`** is now `ProjectHealthData | ProjectHealthFailure`, discriminated on `checkFailed`. The failure arm carries only `{ repo, checkFailed: true, failureReason }`; the old shape fabricated neutral-default snapshot fields (`lastCommitAt: ""`, `daysSinceLastCommit: 999`, ...) that no consumer should have trusted. Every consumer now narrows on `checkFailed` before reading snapshot fields.
- **`CheckResult`** is now `{ passed; inconclusive?: false } | { passed: true; inconclusive: true; reason: string }`. `reason` is reachable only when the check was inconclusive, which always implies `passed: true`. `ExistingPRCheckResult` switches from `extends` to an intersection (CheckResult is no longer an interface).
- **`VetListEntry`** is discriminated on a new `ok` flag: `{ ok: true; recommendation; viabilityScore } | { ok: false; errorMessage }`. The "score xor error" invariant is now structural instead of prose. The 404/410 "gone" path is `ok: false` with `status: "closed"`.

### 2. Personalization (#1244) made structural + immutable
- Removed `boostScore?` / `boostReasons?` / `diversitySlot?` from `IssueCandidate`, replaced with one `personalization?: { kind: "boosted"; score; reasons } | { kind: "diversity" }`. The boosted-xor-diversity invariant is now enforced by the type.
- `annotateBoost` returns a new array and `applyDiversityRatio` tags shallow copies, instead of mutating candidates in place. New `boostScoreOf()` helper.
- The `search --json` output still emits the flat `boostScore` / `boostReasons` / `diversitySlot` fields (derived from the new marker) so JSON consumers are unaffected.

### 3. Persisted enum honesty
`SavedCandidateSchema.searchPriority` tightens from `z.string()` to `z.enum(["merged_pr", "starred", "normal"]).catch("normal")`. The `.catch` keeps old or future-version persisted state loadable (any unrecognized value decodes to `"normal"`).

### 4. Readonly honesty
`saveLocalState` now accepts `Readonly<ScoutState>`, dropping an `as ScoutState` cast in `with-scout.ts`.

### 5. Versioned cache entries
New `CACHE_SCHEMA_VERSION` / `versionedCacheKey` in `http-cache.ts`, applied to the four synthetic-typed cache keys (`vet:`, `search:`, `anti-llm-policy:`, `merged-prs:`) whose bodies are oss-scout shapes read back with an unchecked cast. Bumping the version invalidates old entries instead of misreading a changed shape. Raw ETag GitHub-response keys are intentionally not versioned (GitHub owns their shape).

### 6. Required SLM config
`ScoutStateReader.getSLMTriageConfig` is now required and returns `SLMConfig | null` (was optional with an empty-string sentinel). The sentinel could not tell "not configured" from "host defaulted"; `null` makes absence explicit. Breaking for third-party `ScoutStateReader` implementers.

## Behavior

These are type changes. Runtime behavior is unchanged except where intended: the failure-health shape no longer carries fabricated snapshot fields, and SLM triage is skipped on a `null` config exactly as it was on the old empty-model sentinel.

## Tests

Full gate green locally: lint, format:check, typecheck (both packages), 912 core + 26 mcp tests. Personalization tests rewritten for the returns-a-new-array API; a "does not mutate the input candidates" test added; repo-health failure-shape assertion updated; all three `ScoutStateReader` stubs implement the now-required method.