### PR TITLE
fix(mcp): surface checkpoint persistence failures in search/features/config-set (#212)

### DIFF
--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -113,6 +113,49 @@ describe("registerTools", () => {
       };
       expect(result.content[0].text).toContain("failed to persist");
     });
+
+    // #212: the JSON tools (search, scout-features, config-set) used to await
+    // checkpoint() and discard the boolean, silently swallowing a persist
+    // failure. They now carry a top-level persistWarning field on failure.
+    it.each([
+      ["search", { maxResults: 5 }],
+      ["scout-features", { maxResults: 5 }],
+      ["config-set", { key: "minStars", value: "100" }],
+    ] as const)(
+      "%s surfaces persistWarning in the JSON envelope when checkpoint fails (#212)",
+      async (toolName, args) => {
+        const local = createMockScout({
+          checkpoint: vi.fn().mockResolvedValue(false),
+        } as Partial<OssScout>);
+        const localServer = new McpServer({ name: "t", version: "0.0.1" });
+        vi.spyOn(localServer, "tool");
+        registerTools(localServer, local);
+        const handler = getToolHandler(localServer, toolName);
+        const result = (await handler(args, {})) as {
+          content: Array<{ text: string }>;
+          isError?: boolean;
+        };
+        expect(result.isError).toBeUndefined();
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.persistWarning).toMatch(/could not be persisted/);
+      },
+    );
+
+    it.each([
+      ["search", { maxResults: 5 }],
+      ["scout-features", { maxResults: 5 }],
+      ["config-set", { key: "minStars", value: "100" }],
+    ] as const)(
+      "%s omits persistWarning when checkpoint succeeds (#212)",
+      async (toolName, args) => {
+        const handler = getToolHandler(server, toolName);
+        const result = (await handler(args, {})) as {
+          content: Array<{ text: string }>;
+        };
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.persistWarning).toBeUndefined();
+      },
+    );
   });
 
   describe("skip tool execution", () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -14,6 +14,22 @@ import {
 // under the budget tracker's sliding-window pacing can take minutes (#143).
 const TOOL_TIMEOUT_MS = 300000;
 
+// Surfaced on the JSON envelope when scout.checkpoint() returns false (#212).
+// The skip tool reports this inline because it returns a short status line;
+// the JSON tools (search, scout-features, config-set) carry it as a top-level
+// field so a persist failure isn't silently swallowed.
+const PERSIST_WARNING =
+  "Checkpoint failed: changes were applied in memory but could not be persisted. They may be lost when the server restarts.";
+
+/**
+ * Serialize a tool result, attaching a top-level `persistWarning` field when
+ * the preceding checkpoint failed (#212). Spreads onto the existing object so
+ * the happy-path payload is byte-for-byte unchanged.
+ */
+function withPersistWarning<T extends object>(payload: T, persisted: boolean) {
+  return persisted ? payload : { ...payload, persistWarning: PERSIST_WARNING };
+}
+
 function withTimeout<T>(
   promise: Promise<T>,
   ms: number = TOOL_TIMEOUT_MS,
@@ -93,10 +109,19 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         );
 
         scout.saveResults(result.candidates);
-        await scout.checkpoint();
+        const persisted = await scout.checkpoint();
 
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                withPersistWarning(result, persisted),
+                null,
+                2,
+              ),
+            },
+          ],
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -140,9 +165,18 @@ export function registerTools(server: McpServer, scout: OssScout): void {
           }),
         );
         scout.saveResults([...result.quickWins, ...result.biggerBets]);
-        await scout.checkpoint();
+        const persisted = await scout.checkpoint();
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                withPersistWarning(result, persisted),
+                null,
+                2,
+              ),
+            },
+          ],
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -362,10 +396,19 @@ export function registerTools(server: McpServer, scout: OssScout): void {
       scout.updatePreferences({
         [key]: validated[key as keyof typeof validated],
       });
-      await scout.checkpoint();
+      const persisted = await scout.checkpoint();
       const updated = scout.getPreferences();
       return {
-        content: [{ type: "text", text: JSON.stringify(updated, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              withPersistWarning(updated, persisted),
+              null,
+              2,
+            ),
+          },
+        ],
       };
     },
   );


### PR DESCRIPTION
Closes #212.

The `skip` tool reports a "(warning: failed to persist to disk)" note when `scout.checkpoint()` returns false, but three other MCP tool handlers awaited checkpoint and discarded the boolean, so a persist failure was silent:

- `search`
- `scout-features`
- `config-set`

These return large JSON payloads rather than a short status line, so a parenthetical note doesn't fit cleanly. Per the issue's first suggested option, this attaches a top-level `persistWarning` field to the JSON envelope when checkpoint fails.

## How

A small `withPersistWarning(payload, persisted)` helper spreads a `persistWarning` field onto the result only when `persisted` is false. When checkpoint succeeds it returns the original object unchanged, so successful responses are byte-for-byte identical (no new field on the happy path). The calling agent sees the warning in the structured payload it already parses.

## Tests

Parameterized over all three tools: `persistWarning` present (and `isError` undefined) when `checkpoint` resolves false, and absent when it resolves true.

Full gate green locally: lint, format:check, typecheck, 912 core + 32 mcp tests.