### PR TITLE
refactor(scoring): drop the dead isResponsive weight (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Most issue finders search GitHub for `good first issue` labels and hand you a list. You could do that yourself in 30 seconds.
 
-**oss-scout is different.** It knows which repos you've contributed to, which maintainers have merged your work before, and which projects are actually responsive. It searches strategically, vets every result, and tells you where your next PR has the highest chance of getting merged.
+**oss-scout is different.** It knows which repos you've contributed to, which maintainers have merged your work before, and which projects are actively maintained. It searches strategically, vets every result, and tells you where your next PR has the highest chance of getting merged.
 
 ## Getting Started
 

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -50,6 +50,9 @@ export const CONCRETE_STRATEGIES = [
 
 export const RepoSignalsSchema = z.looseObject({
   hasActiveMaintainers: z.boolean(),
+  // Retained for backward compatibility but no longer affects the repo score
+  // (#167): nothing computes it, and hasActiveMaintainers is the live activity
+  // proxy. Kept so old persisted state and the search JSON output still parse.
   isResponsive: z.boolean(),
   hasHostileComments: z.boolean(),
 });

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -628,21 +628,24 @@ describe("OssScout checkpoint + scoring branches (#162)", () => {
       expect(scoreAfter({ signals: { hasHostileComments: true } })).toBe(3);
     });
 
-    it("adds 1 each for responsive and active maintainers", () => {
-      expect(
-        scoreAfter({
-          signals: { isResponsive: true, hasActiveMaintainers: true },
-        }),
-      ).toBe(7);
+    it("adds 1 for active maintainers", () => {
+      expect(scoreAfter({ signals: { hasActiveMaintainers: true } })).toBe(6);
     });
 
-    it("clamps the upper bound at 10", () => {
+    it("does not score isResponsive (#167: dead weight dropped)", () => {
+      // isResponsive no longer affects the score: base 5 with no other signal.
+      expect(scoreAfter({ signals: { isResponsive: true } })).toBe(5);
+    });
+
+    it("tops out at 9 with all positive signals (isResponsive unscored)", () => {
+      // base 5 + merged(+3) + active(+1) = 9; the [1,10] clamp is now
+      // defensive only since isResponsive's +1 was removed (#167).
       expect(
         scoreAfter({
           mergedPRCount: 3,
           signals: { isResponsive: true, hasActiveMaintainers: true },
         }),
-      ).toBe(10);
+      ).toBe(9);
     });
 
     it("clamps the lower bound at 1", () => {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -283,14 +283,13 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
    * calculateScore's +1 active-maintainers weight was inert; `isActive`
    * (recent commit activity) is a real, already-computed proxy.
    *
-   * `isResponsive` and `avgResponseDays` are deliberately NOT set here:
-   * `projectHealth.avgIssueResponseDays` is a hardcoded `0` placeholder
-   * (repo-health.ts), so deriving responsiveness from it would award +1 to
-   * every repo — a fake signal worse than the inert one. Real responsiveness
-   * needs an actual response-time measurement (extra API calls), deferred.
-   * `hasHostileComments` likewise stays a host-settable capability (it needs
-   * comment sentiment, out of scope). A failed health check is skipped so its
-   * neutral-default fields don't pollute the score.
+   * `isResponsive` and `avgResponseDays` are deliberately NOT set here, and
+   * `isResponsive` no longer carries a score weight at all (#167): real
+   * responsiveness needs an actual response-time measurement (extra API calls)
+   * that is out of scope, and `hasActiveMaintainers` already covers the
+   * activity proxy. `hasHostileComments` stays a host-settable capability (it
+   * needs comment sentiment, out of scope). A failed health check is skipped so
+   * its neutral-default fields don't pollute the score.
    */
   private updateRepoSignalsFromHealth(health: ProjectHealth): void {
     if (health.checkFailed) return;
@@ -980,15 +979,21 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
   }
 
   /**
-   * Calculate repo score (1-10) from observed data.
+   * Calculate repo score from observed data.
    * base 5, +1 per merged PR (max +3), -1 per closed-without-merge (max -3),
-   * +1 responsive, +1 active maintainers, -2 hostile comments, clamped 1-10
+   * +1 active maintainers, -2 hostile comments, clamped to [1, 10].
+   *
+   * `isResponsive` is intentionally NOT scored (#167): nothing in oss-scout
+   * ever computes it, so awarding +1 for it was dead weight that the
+   * now-computed `hasActiveMaintainers` signal already covers as the activity
+   * proxy. The field is retained on RepoSignals for backward compatibility but
+   * no longer affects the score. With the current signals the reachable range
+   * is [1, 9]; the upper clamp stays as defensive hygiene.
    */
   private calculateScore(repoScore: RepoScore): number {
     let score = 5;
     score += Math.min(repoScore.mergedPRCount, 3);
     score -= Math.min(repoScore.closedWithoutMergeCount, 3);
-    if (repoScore.signals.isResponsive) score += 1;
     if (repoScore.signals.hasActiveMaintainers) score += 1;
     if (repoScore.signals.hasHostileComments) score -= 2;
     return Math.max(1, Math.min(10, score));


### PR DESCRIPTION
Closes #167 (the "drop the dead weights" option).

#167 flagged the repo-score signals as dead weight. A prior PR (#230) already made `hasActiveMaintainers` a live, computed signal (from repo-health `isActive`). This PR removes the one remaining dead scoring weight.

## What

`calculateScore` awarded `+1` for `signals.isResponsive`, but nothing in oss-scout ever sets `isResponsive` to true, and it's redundant with the now-computed `hasActiveMaintainers` (both are "is this repo active/responsive"). So the `+1` was inert.

- Remove the `isResponsive` weight from `calculateScore`.
- Keep `hasActiveMaintainers` (+1, computed) and `hasHostileComments` (-2, the deliberate host-settable capability per #230).
- Retain the `isResponsive` field on `RepoSignals` for backward compatibility — old persisted state and the `search --json` output still parse and emit it — it just no longer affects the score. (Avoids a breaking schema/output change right after 1.0.0.)

## Consequence: honest range

With the current signals the reachable score is now `[1, 9]` (base 5 + merged `+3` + active `+1`); the `[1, 10]` clamp stays as defensive hygiene. The docstring, the `RepoSignals` schema comment, and the `updateRepoScore` signal-branch tests are updated to reflect this honestly (isResponsive → no score change; max 9).

Also corrects a README overclaim: "which projects are actually responsive" → "which projects are actively maintained", since the tool measures commit-activity, not response time.

## Tests

Full gate green locally: lint, format:check, typecheck, 924 core (+1) + 32 mcp tests.