### PR TITLE
test(core): cover issue-eligibility cache contract and repo-health parsers (#162)

### DIFF
--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -15,12 +15,18 @@ vi.mock("./search-budget.js", () => ({
   })),
 }));
 
+// A single shared cache instance (#162): the old mock returned a fresh object
+// per getHttpCache() call, so a test could never assert that a value written by
+// one call was read by the next. Hoisting one instance makes the cache contract
+// (cache-hit short-circuits the API; errors are not cached) assertable.
+const sharedCache = vi.hoisted(() => ({
+  getIfFresh: vi.fn((): unknown => null),
+  set: vi.fn(),
+}));
+
 vi.mock("./http-cache.js", () => ({
   versionedCacheKey: (key: string) => key,
-  getHttpCache: vi.fn(() => ({
-    getIfFresh: vi.fn(() => null),
-    set: vi.fn(),
-  })),
+  getHttpCache: vi.fn(() => sharedCache),
   // Passthrough: dedup behavior itself is covered in http-cache.test.ts
   withInflightDedup: vi.fn(
     async (_cache: unknown, _key: string, fn: () => Promise<unknown>) => fn(),
@@ -516,6 +522,48 @@ describe("checkNotClaimed", () => {
 describe("checkUserMergedPRsInRepo", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default to a cache miss so the existing tests exercise the API path.
+    sharedCache.getIfFresh.mockReturnValue(null);
+  });
+
+  it("short-circuits on a cache hit without calling the Search API (#162)", async () => {
+    sharedCache.getIfFresh.mockReturnValue(7);
+    const search = vi.fn();
+    const octokit = makeMockOctokit({
+      search: { issuesAndPullRequests: search },
+    });
+    const result = await checkUserMergedPRsInRepo(octokit, "owner", "repo");
+    expect(result).toBe(7);
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it("caches a successful count under the versioned key (#162)", async () => {
+    const octokit = makeMockOctokit({
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 3, items: [{}, {}, {}] },
+        }),
+      },
+    });
+    await checkUserMergedPRsInRepo(octokit, "owner", "repo");
+    expect(sharedCache.set).toHaveBeenCalledWith(
+      "merged-prs:owner/repo",
+      "",
+      3,
+    );
+  });
+
+  it("does not cache the result on a non-fatal API error (#162)", async () => {
+    const octokit = makeMockOctokit({
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockRejectedValue(new Error("Search failed")),
+      },
+    });
+    const result = await checkUserMergedPRsInRepo(octokit, "owner", "repo");
+    expect(result).toBeNull();
+    expect(sharedCache.set).not.toHaveBeenCalled();
   });
 
   it("returns the count when merged PRs are found", async () => {

--- a/packages/core/src/core/repo-health.test.ts
+++ b/packages/core/src/core/repo-health.test.ts
@@ -349,6 +349,56 @@ describe("fetchContributionGuidelines", () => {
   });
 });
 
+describe("parseContributionGuidelines branches (#162)", () => {
+  function octokitWithContent(content: string): Octokit {
+    return {
+      repos: {
+        getContent: vi.fn().mockResolvedValue({
+          data: { content: Buffer.from(content).toString("base64") },
+        }),
+      },
+    } as unknown as Octokit;
+  }
+
+  // repo-health keeps a module-level guideline cache keyed by owner/repo, so
+  // each case must use a distinct repo slug or it would read a prior result.
+  async function parse(content: string, repo: string) {
+    return fetchContributionGuidelines(octokitWithContent(content), "o", repo);
+  }
+
+  it.each([
+    ["jest", "testFramework", "Jest"],
+    ["rspec", "testFramework", "RSpec"],
+    ["pytest", "testFramework", "pytest"],
+    ["mocha", "testFramework", "Mocha"],
+    ["rubocop", "linter", "RuboCop"],
+    ["prettier", "formatter", "Prettier"],
+  ] as const)("detects %s as %s=%s", async (keyword, field, expected) => {
+    const g = await parse(`# Contributing\n\nWe use ${keyword} here.`, keyword);
+    expect(g?.[field as keyof typeof g]).toBe(expected);
+  });
+
+  it("extracts a quoted non-conventional commit message format", async () => {
+    const g = await parse(
+      "# Contributing\n\nYour commit message must match `[JIRA-123] summary`.",
+      "commit-fmt",
+    );
+    expect(g?.commitMessageFormat).toBe("[JIRA-123] summary");
+  });
+
+  it("leaves parser fields undefined when no keywords are present", async () => {
+    const g = await parse(
+      "# Contributing\n\nBe nice and open a PR.",
+      "no-keywords",
+    );
+    expect(g?.testFramework).toBeUndefined();
+    expect(g?.linter).toBeUndefined();
+    expect(g?.formatter).toBeUndefined();
+    expect(g?.commitMessageFormat).toBeUndefined();
+    expect(g?.claRequired).toBeUndefined();
+  });
+});
+
 describe("fetchContributionGuidelines in-flight dedup (#124)", () => {
   it("concurrent same-repo callers share one probe round", async () => {
     const resolvers: Array<(v: unknown) => void> = [];


### PR DESCRIPTION
Closes #162.

The scout-side gaps (createScout gist path, toGistOctokit, vetList discard) landed in #236. This PR closes the two remaining ones.

## issue-eligibility cache contract

The `http-cache` mock returned a fresh object from every `getHttpCache()` call, so no test could assert that a value written by one call was read by the next. Hoisted a single shared cache instance and added:
- a **cache hit** short-circuits and never calls the Search API
- a **successful count is cached** under the versioned key
- a **non-fatal API error is not cached** (so a transient failure can't poison the 15-minute TTL)

## repo-health parsers

`parseContributionGuidelines` had several untested detection branches. Added coverage for test framework (jest / rspec / pytest / mocha), linter (rubocop), formatter (prettier), the quoted non-conventional commit-message format, and a no-keywords baseline. Each case uses a distinct repo slug because repo-health keeps a module-level guideline cache keyed by `owner/repo` (the same singleton #156 will make injectable) — sharing a slug would return a prior case's cached result.

## Tests

Test-only. Full gate green locally: lint, format:check, typecheck, 935 core + 32 mcp tests.