### PR TITLE
feat(personalization): implement avoidRepos and boostIssueTypes (#168)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -161,6 +161,14 @@ program
     "Comma-separated `owner/repo` slugs to soft-boost in ranking (#1244). Stronger weight than language match. Does not filter results.",
   )
   .option(
+    "--avoid-repos <list>",
+    "Comma-separated `owner/repo` slugs to soft-penalize in ranking (#168). Milder than excludeRepos: pushes them down but does not filter them out.",
+  )
+  .option(
+    "--boost-issue-types <list>",
+    "Comma-separated issue label types to soft-boost in ranking (#168), case-insensitive (e.g. `bug,good first issue`). Does not filter results.",
+  )
+  .option(
     "--diversity-ratio <n>",
     "Fraction of result slots (0-1) reserved for candidates that matched NEITHER preference list (#1244). Counterweights echo-chamber bias as boosts accumulate. Default 0 (disabled).",
   )
@@ -172,6 +180,8 @@ program
         strategy?: string;
         preferLanguages?: string;
         preferRepos?: string;
+        avoidRepos?: string;
+        boostIssueTypes?: string;
         diversityRatio?: string;
       },
     ) =>
@@ -243,6 +253,8 @@ program
           strategies,
           preferLanguages: splitCsv(options.preferLanguages),
           preferRepos: splitCsv(options.preferRepos),
+          avoidRepos: splitCsv(options.avoidRepos),
+          boostIssueTypes: splitCsv(options.boostIssueTypes),
           diversityRatio,
         });
         if (options.json) {
@@ -261,8 +273,11 @@ program
             // (matched a preference) or a diversity slot (matched none and
             // filled a reserved slot); never both.
             let personalizationTag = "";
-            if (c.boostScore && c.boostReasons && c.boostReasons.length > 0) {
-              personalizationTag = ` [boosted: ${c.boostReasons.join("; ")}]`;
+            if (c.boostReasons && c.boostReasons.length > 0) {
+              // Net score can be negative when avoidRepos applied (#168).
+              const verb =
+                (c.boostScore ?? 0) >= 0 ? "boosted" : "deprioritized";
+              personalizationTag = ` [${verb}: ${c.boostReasons.join("; ")}]`;
             } else if (c.diversitySlot) {
               personalizationTag = " [diversity slot]";
             }

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -69,6 +69,10 @@ interface SearchCommandOptions {
   preferLanguages?: string[];
   /** Soft sort boost for candidates in these `owner/repo` slugs (#1244). */
   preferRepos?: string[];
+  /** Soft sort penalty for candidates in these `owner/repo` slugs (#168). */
+  avoidRepos?: string[];
+  /** Soft sort boost for candidates whose labels match these types (#168). */
+  boostIssueTypes?: string[];
   /** Diversity counterweight: fraction of slots reserved for unboosted candidates (#1244). */
   diversityRatio?: number;
 }
@@ -84,6 +88,8 @@ export async function runSearch(
         strategies: options.strategies,
         preferLanguages: options.preferLanguages,
         preferRepos: options.preferRepos,
+        avoidRepos: options.avoidRepos,
+        boostIssueTypes: options.boostIssueTypes,
         diversityRatio: options.diversityRatio,
       });
 

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -507,6 +507,8 @@ export class IssueDiscovery {
       skippedUrls?: Set<string>;
       preferLanguages?: string[];
       preferRepos?: string[];
+      avoidRepos?: string[];
+      boostIssueTypes?: string[];
       diversityRatio?: number;
       interPhaseDelayMs?: number;
       broadPhaseDelayMs?: number;
@@ -848,15 +850,17 @@ export class IssueDiscovery {
         `Try again after the rate limit resets for complete results.`;
     }
 
-    // Personalization annotation (#1244): tag matched candidates with a
-    // `personalization` marker before sorting so the new sort tier has values
-    // to read. Returns a new array (no in-place candidate mutation, #158);
-    // a no-op when neither preference list is supplied.
-    const ranked = annotateBoost(
-      allCandidates,
-      options.preferLanguages,
-      options.preferRepos,
-    );
+    // Personalization annotation (#1244, extended #168): tag candidates with a
+    // net `personalization` marker (preferRepos/preferLanguages/boostIssueTypes
+    // add, avoidRepos subtracts) before sorting so the sort tier has values to
+    // read. Returns a new array (no in-place candidate mutation, #158); a no-op
+    // when none of the bias lists are supplied.
+    const ranked = annotateBoost(allCandidates, {
+      preferLanguages: options.preferLanguages,
+      preferRepos: options.preferRepos,
+      avoidRepos: options.avoidRepos,
+      boostIssueTypes: options.boostIssueTypes,
+    });
 
     // Sort by priority, recommendation, boost (#1244), then viability score
     ranked.sort((a, b) => {

--- a/packages/core/src/core/personalization.test.ts
+++ b/packages/core/src/core/personalization.test.ts
@@ -13,6 +13,8 @@ import {
   applyDiversityRatio,
   LANGUAGE_BOOST,
   REPO_BOOST,
+  ISSUE_TYPE_BOOST,
+  AVOID_PENALTY,
 } from "./personalization.js";
 import type { IssueCandidate } from "./types.js";
 
@@ -38,6 +40,7 @@ function isDiversity(c: IssueCandidate): boolean {
 function makeCandidate(
   repo: string,
   language: string | null | undefined,
+  labels: string[] = [],
 ): IssueCandidate {
   return {
     issue: {
@@ -47,7 +50,7 @@ function makeCandidate(
       number: 1,
       title: "Test issue",
       status: "candidate",
-      labels: [],
+      labels,
       createdAt: "2026-01-01T00:00:00Z",
       updatedAt: "2026-03-01T00:00:00Z",
       vetted: true,
@@ -102,7 +105,7 @@ describe("annotateBoost", () => {
       makeCandidate("rails/rails", "Ruby"),
     ];
 
-    const out = annotateBoost(candidates, undefined, undefined);
+    const out = annotateBoost(candidates, {});
 
     for (const c of out) {
       expect(c.personalization).toBeUndefined();
@@ -112,7 +115,10 @@ describe("annotateBoost", () => {
   it("is a no-op when preference lists are empty", () => {
     const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
 
-    const out = annotateBoost(candidates, [], []);
+    const out = annotateBoost(candidates, {
+      preferLanguages: [],
+      preferRepos: [],
+    });
 
     expect(out[0].personalization).toBeUndefined();
   });
@@ -120,51 +126,47 @@ describe("annotateBoost", () => {
   it("does not mutate the input candidates", () => {
     const candidates = [makeCandidate("vercel/next.js", "TypeScript")];
 
-    annotateBoost(candidates, ["typescript"], ["vercel/next.js"]);
+    annotateBoost(candidates, {
+      preferLanguages: ["typescript"],
+      preferRepos: ["vercel/next.js"],
+    });
 
     // The original object is untouched; the boost lives on the returned copy.
     expect(candidates[0].personalization).toBeUndefined();
   });
 
   it("matches language case-insensitively and tags reason", () => {
-    const out = annotateBoost(
-      [makeCandidate("vercel/next.js", "TypeScript")],
-      ["typescript"],
-      undefined,
-    );
+    const out = annotateBoost([makeCandidate("vercel/next.js", "TypeScript")], {
+      preferLanguages: ["typescript"],
+    });
 
     expect(boostScore(out[0])).toBe(LANGUAGE_BOOST);
     expect(boostReasons(out[0])).toEqual(["language match: TypeScript"]);
   });
 
   it("matches repo slug exactly and tags reason", () => {
-    const out = annotateBoost(
-      [makeCandidate("vercel/next.js", "TypeScript")],
-      undefined,
-      ["vercel/next.js"],
-    );
+    const out = annotateBoost([makeCandidate("vercel/next.js", "TypeScript")], {
+      preferRepos: ["vercel/next.js"],
+    });
 
     expect(boostScore(out[0])).toBe(REPO_BOOST);
     expect(boostReasons(out[0])).toEqual(["repo affinity: vercel/next.js"]);
   });
 
   it("matches repo slug case-insensitively (#130)", () => {
-    const out = annotateBoost(
-      [makeCandidate("vercel/next.js", "TypeScript")],
-      undefined,
-      ["Vercel/Next.js"],
-    );
+    const out = annotateBoost([makeCandidate("vercel/next.js", "TypeScript")], {
+      preferRepos: ["Vercel/Next.js"],
+    });
 
     expect(boostScore(out[0])).toBe(REPO_BOOST);
     expect(boostReasons(out[0])).toEqual(["repo affinity: vercel/next.js"]);
   });
 
   it("stacks repo and language boosts when both match", () => {
-    const out = annotateBoost(
-      [makeCandidate("vercel/next.js", "TypeScript")],
-      ["typescript"],
-      ["vercel/next.js"],
-    );
+    const out = annotateBoost([makeCandidate("vercel/next.js", "TypeScript")], {
+      preferLanguages: ["typescript"],
+      preferRepos: ["vercel/next.js"],
+    });
 
     expect(boostScore(out[0])).toBe(REPO_BOOST + LANGUAGE_BOOST);
     expect(boostReasons(out[0])).toEqual([
@@ -179,8 +181,10 @@ describe("annotateBoost", () => {
         makeCandidate("rails/rails", "Ruby"),
         makeCandidate("vercel/next.js", "TypeScript"),
       ],
-      ["typescript"],
-      ["vercel/next.js"],
+      {
+        preferLanguages: ["typescript"],
+        preferRepos: ["vercel/next.js"],
+      },
     );
 
     expect(out[0].personalization).toBeUndefined();
@@ -190,8 +194,7 @@ describe("annotateBoost", () => {
   it("handles candidates with null/undefined language without crashing", () => {
     const out = annotateBoost(
       [makeCandidate("foo/bar", null), makeCandidate("baz/qux", undefined)],
-      ["typescript"],
-      undefined,
+      { preferLanguages: ["typescript"] },
     );
 
     expect(out[0].personalization).toBeUndefined();
@@ -199,13 +202,58 @@ describe("annotateBoost", () => {
   });
 
   it("trims whitespace and ignores empty entries in preference lists", () => {
-    const out = annotateBoost(
-      [makeCandidate("vercel/next.js", "TypeScript")],
-      [" typescript ", "", "  "],
-      [" ", "vercel/next.js"],
-    );
+    const out = annotateBoost([makeCandidate("vercel/next.js", "TypeScript")], {
+      preferLanguages: [" typescript ", "", "  "],
+      preferRepos: [" ", "vercel/next.js"],
+    });
 
     expect(boostScore(out[0])).toBe(REPO_BOOST + LANGUAGE_BOOST);
+  });
+
+  // ── avoidRepos + boostIssueTypes (#168) ──────────────────────────
+
+  it("boosts a candidate whose label matches a boostIssueType (#168)", () => {
+    const out = annotateBoost(
+      [makeCandidate("a/b", "Go", ["bug", "help wanted"])],
+      { boostIssueTypes: ["BUG"] },
+    );
+    expect(boostScore(out[0])).toBe(ISSUE_TYPE_BOOST);
+    expect(boostReasons(out[0])).toEqual(["issue type: bug"]);
+  });
+
+  it("does not boost when no label matches a boostIssueType (#168)", () => {
+    const out = annotateBoost([makeCandidate("a/b", "Go", ["docs"])], {
+      boostIssueTypes: ["bug"],
+    });
+    expect(out[0].personalization).toBeUndefined();
+  });
+
+  it("penalizes a candidate in an avoidRepos slug (#168)", () => {
+    const out = annotateBoost([makeCandidate("spam/repo", "Go")], {
+      avoidRepos: ["spam/repo"],
+    });
+    expect(boostScore(out[0])).toBe(-AVOID_PENALTY);
+    expect(boostReasons(out[0])).toEqual(["avoided repo: spam/repo"]);
+  });
+
+  it("avoidRepos is case-insensitive (#168)", () => {
+    const out = annotateBoost([makeCandidate("Spam/Repo", "Go")], {
+      avoidRepos: ["spam/repo"],
+    });
+    expect(boostScore(out[0])).toBe(-AVOID_PENALTY);
+  });
+
+  it("nets a preferRepos boost against an avoidRepos penalty (#168)", () => {
+    // A strong repo affinity (+20) outweighs the avoid penalty (-15) → +5 net.
+    const out = annotateBoost([makeCandidate("a/b", "Go")], {
+      preferRepos: ["a/b"],
+      avoidRepos: ["a/b"],
+    });
+    expect(boostScore(out[0])).toBe(REPO_BOOST - AVOID_PENALTY);
+    expect(boostReasons(out[0])).toEqual([
+      "repo affinity: a/b",
+      "avoided repo: a/b",
+    ]);
   });
 });
 
@@ -233,6 +281,31 @@ describe("applyDiversityRatio", () => {
     expect(picks[0].issue.repo).toBe("a/b");
     expect(picks[1].issue.repo).toBe("c/d");
     expect(picks.some(isDiversity)).toBe(false);
+  });
+
+  function avoided(repo: string): IssueCandidate {
+    const c = makeCandidate(repo, "Go");
+    c.personalization = {
+      kind: "boosted",
+      score: -AVOID_PENALTY,
+      reasons: [`avoided repo: ${repo}`],
+    };
+    return c;
+  }
+
+  it("does not fill a diversity slot with an avoided candidate (#168)", () => {
+    // Only the truly-neutral candidate should take the reserved slot; the
+    // avoided one must not be resurfaced via diversity.
+    const candidates = [
+      boosted("a/b"),
+      avoided("spam/x"),
+      makeCandidate("neutral/y", "Rust"),
+    ];
+    const picks = applyDiversityRatio(candidates, 2, 0.5);
+    expect(picks).toHaveLength(2);
+    const diversityPick = picks.find(isDiversity);
+    expect(diversityPick?.issue.repo).toBe("neutral/y");
+    expect(picks.map((p) => p.issue.repo)).not.toContain("spam/x");
   });
 
   it("reserves diversity slots for unboosted candidates", () => {

--- a/packages/core/src/core/personalization.ts
+++ b/packages/core/src/core/personalization.ts
@@ -29,12 +29,27 @@ import type { IssueCandidate } from "./types.js";
  */
 export const REPO_BOOST = 20;
 export const LANGUAGE_BOOST = 10;
+/** Soft boost for an issue-label ("issue type") match (#168). Language-tier. */
+export const ISSUE_TYPE_BOOST = 10;
+/**
+ * Soft penalty for an avoidRepos match (#168). Milder than the hard
+ * excludeRepos filter: it pushes the candidate down but a strong boost (e.g. a
+ * preferRepos affinity, +20) can still outweigh it.
+ */
+export const AVOID_PENALTY = 15;
+
+/** Per-call personalization bias lists (#168). All optional; empty = no effect. */
+export interface PersonalizationBias {
+  preferLanguages?: string[];
+  preferRepos?: string[];
+  avoidRepos?: string[];
+  boostIssueTypes?: string[];
+}
 
 /**
- * The personalization sort weight of a candidate: its boost score, or 0 when it
- * is not boosted (unboosted or a diversity slot). Reads the structural
- * `personalization` field (#158) so callers never poke at the old loose
- * `boostScore` field.
+ * The personalization sort weight of a candidate: its net score, or 0 when it
+ * carries no personalization marker. Reads the structural `personalization`
+ * field (#158). The score can be negative when avoidRepos applied (#168).
  */
 export function boostScoreOf(candidate: IssueCandidate): number {
   return candidate.personalization?.kind === "boosted"
@@ -42,34 +57,46 @@ export function boostScoreOf(candidate: IssueCandidate): number {
     : 0;
 }
 
+function normalizeSet(values: string[] | undefined): Set<string> {
+  return new Set(
+    (values ?? []).map((v) => v.trim().toLowerCase()).filter(Boolean),
+  );
+}
+
 /**
- * Return a new candidate list where each candidate that matches a
- * caller-supplied preference carries `personalization: { kind: "boosted", ... }`.
- * Does NOT mutate the input candidates (#158) — matched candidates are shallow
- * copies with the field set; unmatched candidates are passed through unchanged.
- * The caller re-sorts the returned array.
+ * Return a new candidate list where each candidate matching a caller-supplied
+ * bias carries a `personalization` marker with a NET score (#168): preferRepos,
+ * preferLanguages and boostIssueTypes add; avoidRepos subtracts. The score may
+ * be negative (avoid-only) — boostScoreOf sorts those below neutral candidates.
+ * Does NOT mutate the input (#158): matched candidates are shallow copies,
+ * unmatched ones pass through unchanged.
  *
- * No-op when both preference lists are empty or undefined: the input array is
- * returned as-is and the sort tier collapses to 0 for every candidate.
+ * No-op when every bias list is empty/undefined: the input array is returned
+ * as-is and the sort tier collapses to 0 for every candidate.
  */
 export function annotateBoost(
   candidates: IssueCandidate[],
-  preferLanguages?: string[],
-  preferRepos?: string[],
+  bias: PersonalizationBias = {},
 ): IssueCandidate[] {
-  const langSet = new Set(
-    (preferLanguages ?? []).map((l) => l.trim().toLowerCase()).filter(Boolean),
-  );
-  const repoSet = new Set(
-    (preferRepos ?? []).map((r) => r.trim().toLowerCase()).filter(Boolean),
-  );
-  if (langSet.size === 0 && repoSet.size === 0) return candidates;
+  const langSet = normalizeSet(bias.preferLanguages);
+  const repoSet = normalizeSet(bias.preferRepos);
+  const avoidSet = normalizeSet(bias.avoidRepos);
+  const typeSet = normalizeSet(bias.boostIssueTypes);
+  if (
+    langSet.size === 0 &&
+    repoSet.size === 0 &&
+    avoidSet.size === 0 &&
+    typeSet.size === 0
+  ) {
+    return candidates;
+  }
 
   return candidates.map((c) => {
     let score = 0;
     const reasons: string[] = [];
+    const repoLower = c.issue.repo.toLowerCase();
 
-    if (repoSet.size > 0 && repoSet.has(c.issue.repo.toLowerCase())) {
+    if (repoSet.size > 0 && repoSet.has(repoLower)) {
       score += REPO_BOOST;
       reasons.push(`repo affinity: ${c.issue.repo}`);
     }
@@ -80,7 +107,20 @@ export function annotateBoost(
       reasons.push(`language match: ${lang}`);
     }
 
-    if (score === 0) return c;
+    if (typeSet.size > 0) {
+      const matched = c.issue.labels.find((l) => typeSet.has(l.toLowerCase()));
+      if (matched) {
+        score += ISSUE_TYPE_BOOST;
+        reasons.push(`issue type: ${matched}`);
+      }
+    }
+
+    if (avoidSet.size > 0 && avoidSet.has(repoLower)) {
+      score -= AVOID_PENALTY;
+      reasons.push(`avoided repo: ${c.issue.repo}`);
+    }
+
+    if (reasons.length === 0) return c;
     return { ...c, personalization: { kind: "boosted", score, reasons } };
   });
 }
@@ -134,7 +174,10 @@ export function applyDiversityRatio(
   for (const c of candidates) {
     if (picks.length >= maxResults) break;
     if (seen.has(c.issue.url)) continue;
-    if (boostScoreOf(c) > 0) continue;
+    // Diversity slots are for candidates that matched NO personalization bias.
+    // Exclude both boosted (>0) and avoided (<0) candidates — resurfacing an
+    // avoided repo via a diversity slot would defeat the avoid (#168).
+    if (boostScoreOf(c) !== 0) continue;
     // Tag a shallow copy rather than mutating the shared candidate (#158).
     picks.push({ ...c, personalization: { kind: "diversity" } });
     seen.add(c.issue.url);

--- a/packages/core/src/core/preference-fields.ts
+++ b/packages/core/src/core/preference-fields.ts
@@ -49,6 +49,8 @@ export const FIELD_CONFIGS: Record<string, FieldConfig> = {
   preferLanguages: { type: "array" },
   preferRepos: { type: "array" },
   diversityRatio: { type: "float" },
+  avoidRepos: { type: "array" },
+  boostIssueTypes: { type: "array" },
   slmTriageModel: { type: "string" },
   slmTriageHost: { type: "string" },
   featuresAnchorThreshold: { type: "number" },

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -218,6 +218,12 @@ export const ScoutPreferencesSchema = z.looseObject({
   preferLanguages: z.array(z.string()).default([]),
   preferRepos: z.array(z.string()).default([]),
   diversityRatio: z.number().min(0).max(1).default(0),
+  // Soft penalty (milder than the hard excludeRepos filter): candidates in
+  // these `owner/repo` slugs are pushed down the ranking but not removed (#168).
+  avoidRepos: z.array(z.string()).default([]),
+  // Soft boost for candidates whose issue labels match one of these types,
+  // case-insensitive (e.g. "bug", "good first issue") (#168).
+  boostIssueTypes: z.array(z.string()).default([]),
   broadPhaseDelayMs: z.number().min(0).max(300000).default(90000),
   /**
    * Skip the expensive broad phase once this many candidates were found by

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -310,6 +310,21 @@ export interface SearchOptions {
    */
   preferRepos?: string[];
   /**
+   * Per-call personalization bias: a SOFT penalty (milder than the hard
+   * `excludeRepos` filter) for candidates in one of these `owner/repo` slugs
+   * (#168). They are pushed below equally-recommended non-matches but not
+   * removed; a strong boost can still outweigh the penalty. Empty / undefined
+   * disables it.
+   */
+  avoidRepos?: string[];
+  /**
+   * Per-call personalization bias: a soft boost for candidates whose issue
+   * labels match one of these types, case-insensitive (e.g. "bug",
+   * "good first issue") (#168). Same tier as a language match. Does not filter
+   * results, does not change `viabilityScore`. Empty / undefined disables it.
+   */
+  boostIssueTypes?: string[];
+  /**
    * Counterweight against echo-chamber bias as `preferLanguages` /
    * `preferRepos` boosts accumulate over time (#1244). A value of 0.2
    * means "reserve roughly 20% of the final slots for candidates that

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -246,6 +246,13 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       (prefLangs.length > 0 ? prefLangs : undefined);
     const preferRepos =
       options?.preferRepos ?? (prefRepos.length > 0 ? prefRepos : undefined);
+    const prefAvoid = prefs.avoidRepos ?? [];
+    const prefBoostTypes = prefs.boostIssueTypes ?? [];
+    const avoidRepos =
+      options?.avoidRepos ?? (prefAvoid.length > 0 ? prefAvoid : undefined);
+    const boostIssueTypes =
+      options?.boostIssueTypes ??
+      (prefBoostTypes.length > 0 ? prefBoostTypes : undefined);
     const diversityRatio = options?.diversityRatio ?? prefs.diversityRatio ?? 0;
 
     const { candidates, strategiesUsed } = await discovery.searchIssues({
@@ -254,6 +261,8 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       skippedUrls,
       preferLanguages,
       preferRepos,
+      avoidRepos,
+      boostIssueTypes,
       diversityRatio,
       interPhaseDelayMs: options?.interPhaseDelayMs,
       broadPhaseDelayMs: options?.broadPhaseDelayMs,

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -71,6 +71,18 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         .describe(
           "Soft-boost ranking for candidates in one of these `owner/repo` slugs. Stronger weight than language match (#1244). Not a filter; only reorders.",
         ),
+      avoidRepos: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Soft PENALTY (milder than excludeRepos) for candidates in one of these `owner/repo` slugs (#168). Pushes them down the ranking but does not remove them; a strong boost can still outweigh it.",
+        ),
+      boostIssueTypes: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Soft-boost ranking for candidates whose issue labels match one of these types, case-insensitive (e.g. "bug", "good first issue") (#168). Not a filter; only reorders.',
+        ),
       diversityRatio: z
         .number()
         .min(0)
@@ -85,6 +97,8 @@ export function registerTools(server: McpServer, scout: OssScout): void {
       strategies,
       preferLanguages,
       preferRepos,
+      avoidRepos,
+      boostIssueTypes,
       diversityRatio,
     }) => {
       try {
@@ -100,6 +114,8 @@ export function registerTools(server: McpServer, scout: OssScout): void {
             strategies: parsedStrategies,
             preferLanguages,
             preferRepos,
+            avoidRepos,
+            boostIssueTypes,
             diversityRatio,
             // No fixed inter-phase sleeps in the request/response MCP context;
             // the budget tracker still paces the GitHub calls (#143)


### PR DESCRIPTION
Closes #168.

The persisted-preference half (preferLanguages / preferRepos / diversityRatio) shipped in #229. This implements the two biases the personalization module header had explicitly deferred.

## What

- **`avoidRepos`** — a SOFT penalty (-15), milder than the hard `excludeRepos` filter. Candidates in an avoided `owner/repo` are pushed down the ranking but **not removed**; a strong boost (e.g. a `preferRepos` affinity at +20) can still outweigh it.
- **`boostIssueTypes`** — a soft boost (+10) for candidates whose issue labels match one of the configured types, case-insensitive exact-label match (e.g. `bug`, `good first issue`).

## How

`annotateBoost` now takes a `PersonalizationBias` object and computes a **net** score per candidate: `preferRepos` (+20), `preferLanguages` (+10), `boostIssueTypes` (+10) add; `avoidRepos` (-15) subtracts. `boostScoreOf` returns the net score, so the sort tier ranks negative-net (avoided) candidates below neutral ones. `applyDiversityRatio` now excludes any personalization-touched candidate (boosted **or** avoided) from diversity slots, so an avoided repo isn't resurfaced through the diversity counterweight.

Wired through everywhere the existing biases live: persisted prefs (`ScoutPreferencesSchema` + `config-set` via the field map), `SearchOptions`, CLI flags (`--avoid-repos` / `--boost-issue-types`), and the MCP `search` tool. Flags override persisted prefs (an empty pref array reads as "no bias").

### One design note

The `personalization` field keeps `kind:"boosted"` even when the net score is negative (an avoid-only candidate), rather than adding a new `"penalized"` union member — that would be another breaking change to a public type right after the 1.0.0 cut. The score is simply allowed to be negative, the public `search --json` output keeps its flat `boostScore`/`boostReasons` shape (a negative number reads naturally), and the CLI render labels negative-net candidates `[deprioritized: ...]`. A dedicated `"penalized"` kind would be a clean future refinement in a later major.

## Tests

New personalization tests: boostIssueTypes match / no-match / case-insensitive, avoidRepos penalty / case-insensitive, the preferRepos-vs-avoidRepos net case, and diversity-slot exclusion of avoided candidates. Full gate green locally: lint, format:check, typecheck, 941 core (+6) + 32 mcp tests.