### PR TITLE
refactor(cli): extract human renderers into formatters/human.ts (#157)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -9,6 +9,15 @@ import { enableDebug } from "./core/logger.js";
 import { getCLIVersion } from "./core/utils.js";
 import { formatJsonSuccess, formatJsonError } from "./formatters/json.js";
 import {
+  renderSearch,
+  renderFeatures,
+  renderResults,
+  renderVetList,
+  renderVet,
+  RESULTS_EMPTY_MESSAGE,
+  VET_LIST_EMPTY_MESSAGE,
+} from "./formatters/human.js";
+import {
   ValidationError,
   errorMessage,
   resolveErrorCode,
@@ -43,15 +52,6 @@ async function runAction(
   } catch (err) {
     handleCommandError(err, options);
   }
-}
-
-/** Emoji for a vetting recommendation, shared by the search and vet renderers. */
-function recommendationIcon(
-  recommendation: "approve" | "skip" | "needs_review",
-): string {
-  if (recommendation === "approve") return "✅";
-  if (recommendation === "skip") return "❌";
-  return "⚠️";
 }
 
 const program = new Command();
@@ -261,38 +261,10 @@ program
           console.log(formatJsonSuccess(results));
         } else {
           // Human-readable output
-          console.log(
-            `\nFound ${results.candidates.length} issue candidates:\n`,
-          );
-          for (const c of results.candidates) {
-            const icon = recommendationIcon(c.recommendation);
-            const stalledTag = c.linkedPR?.isStalled
-              ? " (stalled PR, revive opportunity)"
-              : "";
-            // Personalization tag (#1244). A candidate is either boosted
-            // (matched a preference) or a diversity slot (matched none and
-            // filled a reserved slot); never both.
-            let personalizationTag = "";
-            if (c.boostReasons && c.boostReasons.length > 0) {
-              // Net score can be negative when avoidRepos applied (#168).
-              const verb =
-                (c.boostScore ?? 0) >= 0 ? "boosted" : "deprioritized";
-              personalizationTag = ` [${verb}: ${c.boostReasons.join("; ")}]`;
-            } else if (c.diversitySlot) {
-              personalizationTag = " [diversity slot]";
-            }
-            console.log(
-              `  ${icon} ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100]${personalizationTag}${stalledTag}`,
-            );
-            console.log(`     ${c.issue.title}`);
-            console.log(`     ${c.issue.url}`);
-            if (c.repoScore) {
-              console.log(
-                `     Repo: ${c.repoScore.score}/10, ${c.repoScore.mergedPRCount} merged PRs`,
-              );
-            }
-            console.log();
-          }
+          console.log(renderSearch(results));
+          // Rate-limit warning stays on stderr (NOT folded into the stdout
+          // render), so --json stdout purity and the stdout/stderr split are
+          // both preserved.
           if (results.rateLimitWarning) {
             console.error(`\n⚠️  ${results.rateLimitWarning}`);
           }
@@ -361,50 +333,10 @@ program
         if (options.json) {
           console.log(formatJsonSuccess(result));
         } else {
-          const total = result.quickWins.length + result.biggerBets.length;
-          if (result.message) {
-            console.log(`\n${result.message}\n`);
-          }
-          if (total === 0) return;
-          const headerScope = options.broad
-            ? "across the ecosystem"
-            : "in your anchor repos";
-          console.log(
-            `\n🎯 Feature opportunities ${headerScope} (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
-          );
-          if (!options.broad) {
-            console.log(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
-          }
-          if (result.quickWins.length) {
-            console.log(
-              "── Quick wins ─────────────────────────────────────────",
-            );
-            for (const c of result.quickWins) {
-              const stalledTag = c.linkedPR?.isStalled
-                ? " (stalled PR, revive opportunity)"
-                : "";
-              console.log(
-                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,
-              );
-              console.log(`     ${c.issue.url}`);
-            }
-            console.log("");
-          }
-          if (result.biggerBets.length) {
-            console.log(
-              "── Bigger bets ────────────────────────────────────────",
-            );
-            for (const c of result.biggerBets) {
-              const stalledTag = c.linkedPR?.isStalled
-                ? " (stalled PR, revive opportunity)"
-                : "";
-              console.log(
-                `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,
-              );
-              console.log(`     ${c.issue.url}`);
-            }
-            console.log("");
-          }
+          // renderFeatures returns "" only when there is no message AND
+          // nothing to list; guard so the caller never logs a blank line.
+          const out = renderFeatures(result, { broad: options.broad });
+          if (out) console.log(out);
         }
       }),
   );
@@ -443,28 +375,10 @@ resultsCmd
           return;
         }
         if (results.length === 0) {
-          console.log(
-            "\nNo saved results. Run `oss-scout search` to find issues.\n",
-          );
+          console.log(RESULTS_EMPTY_MESSAGE);
           return;
         }
-        console.log(`\nSaved results (${results.length}):\n`);
-        console.log(
-          "  Score  Repo                              Issue   Recommendation  Title",
-        );
-        console.log(
-          "  ─────  ────────────────────────────────  ──────  ──────────────  ─────",
-        );
-        for (const r of results) {
-          const score = String(r.viabilityScore).padStart(3);
-          const repo = r.repo.padEnd(32).slice(0, 32);
-          const issue = `#${r.number}`.padEnd(6);
-          const rec = r.recommendation.padEnd(14);
-          const title =
-            r.title.length > 50 ? r.title.slice(0, 47) + "..." : r.title;
-          console.log(`  ${score}    ${repo}  ${issue}  ${rec}  ${title}`);
-        }
-        console.log();
+        console.log(renderResults(results));
       }),
   );
 
@@ -572,46 +486,10 @@ program
           console.log(formatJsonSuccess(result));
         } else {
           if (result.results.length === 0) {
-            console.log(
-              "\nNo saved results to vet. Run `oss-scout search` first.\n",
-            );
+            console.log(VET_LIST_EMPTY_MESSAGE);
             return;
           }
-          console.log(`\nVet-list results (${result.summary.total}):\n`);
-          for (const r of result.results) {
-            const icon =
-              r.status === "still_available"
-                ? "✅"
-                : r.status === "claimed"
-                  ? "🔒"
-                  : r.status === "has_pr"
-                    ? "🔀"
-                    : r.status === "closed"
-                      ? "🚫"
-                      : "❌";
-            const score = r.ok ? ` [${r.viabilityScore}/100]` : "";
-            console.log(
-              `  ${icon} ${r.repo}#${r.number} — ${r.status}${score}`,
-            );
-            console.log(`     ${r.title}`);
-          }
-          if (result.transitions.length > 0) {
-            console.log(
-              `\n🔔 Changes since last check (${result.transitions.length}):`,
-            );
-            for (const t of result.transitions) {
-              console.log(`  ${t.repo}#${t.number}: ${t.from} → ${t.to}`);
-            }
-          }
-          console.log(
-            `\nSummary: ${result.summary.stillAvailable} available, ${result.summary.claimed} claimed, ${result.summary.hasPR} has PR, ${result.summary.closed} closed, ${result.summary.errors} errors`,
-          );
-          if (result.prunedCount != null) {
-            console.log(
-              `Pruned ${result.prunedCount} unavailable issues from saved results.`,
-            );
-          }
-          console.log();
+          console.log(renderVetList(result));
         }
       }),
   );
@@ -730,33 +608,7 @@ program
       if (options.json) {
         console.log(formatJsonSuccess(result));
       } else {
-        const icon = recommendationIcon(result.recommendation);
-        console.log(
-          `\n${icon} ${result.issue.repo}#${result.issue.number}: ${result.recommendation.toUpperCase()}`,
-        );
-        console.log(`   ${result.issue.title}`);
-        console.log(`   ${result.issue.url}\n`);
-        if (result.reasonsToApprove.length > 0) {
-          console.log("Reasons to approve:");
-          for (const r of result.reasonsToApprove) console.log(`  + ${r}`);
-        }
-        if (result.reasonsToSkip.length > 0) {
-          console.log("Reasons to skip:");
-          for (const r of result.reasonsToSkip) console.log(`  - ${r}`);
-        }
-        if (result.projectHealth.checkFailed) {
-          console.log(
-            `\nProject health: unknown (check failed: ${result.projectHealth.failureReason})`,
-          );
-        } else {
-          console.log(
-            `\nProject health: ${result.projectHealth.isActive ? "Active" : "Inactive"}`,
-          );
-          console.log(
-            `  Last commit: ${result.projectHealth.daysSinceLastCommit} days ago`,
-          );
-          console.log(`  CI status: ${result.projectHealth.ciStatus}`);
-        }
+        console.log(renderVet(result));
       }
     }),
   );

--- a/packages/core/src/formatters/human.test.ts
+++ b/packages/core/src/formatters/human.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect } from "vitest";
+import {
+  recommendationIcon,
+  renderSearch,
+  renderFeatures,
+  renderResults,
+  renderVetList,
+  renderVet,
+  RESULTS_EMPTY_MESSAGE,
+  VET_LIST_EMPTY_MESSAGE,
+} from "./human.js";
+import type { SearchOutput } from "../commands/search.js";
+import type { FeaturesOutput } from "../commands/features.js";
+import type { SavedCandidate } from "../core/schemas.js";
+import type { VetListResult } from "../core/types.js";
+import type { VetOutput } from "../commands/vet.js";
+
+// ── recommendationIcon ──────────────────────────────────────────────
+
+describe("recommendationIcon", () => {
+  it("maps each recommendation to its emoji", () => {
+    expect(recommendationIcon("approve")).toBe("✅");
+    expect(recommendationIcon("skip")).toBe("❌");
+    expect(recommendationIcon("needs_review")).toBe("⚠️");
+  });
+});
+
+// ── renderSearch ────────────────────────────────────────────────────
+
+function searchCandidate(
+  overrides: Partial<SearchOutput["candidates"][number]> = {},
+): SearchOutput["candidates"][number] {
+  return {
+    issue: {
+      repo: "owner/repo",
+      repoUrl: "https://github.com/owner/repo",
+      number: 1,
+      title: "Fix the bug",
+      url: "https://github.com/owner/repo/issues/1",
+      labels: [],
+    },
+    recommendation: "approve",
+    reasonsToApprove: [],
+    reasonsToSkip: [],
+    searchPriority: "normal",
+    viabilityScore: 80,
+    ...overrides,
+  };
+}
+
+function searchOutput(
+  candidates: SearchOutput["candidates"],
+  overrides: Partial<SearchOutput> = {},
+): SearchOutput {
+  return {
+    candidates,
+    excludedRepos: [],
+    aiPolicyBlocklist: [],
+    strategiesUsed: [],
+    ...overrides,
+  };
+}
+
+describe("renderSearch", () => {
+  it("renders the header with the candidate count", () => {
+    const out = renderSearch(searchOutput([searchCandidate()]));
+    expect(out).toContain("Found 1 issue candidates:");
+  });
+
+  it("renders zero candidates without throwing", () => {
+    const out = renderSearch(searchOutput([]));
+    expect(out).toBe("\nFound 0 issue candidates:\n");
+  });
+
+  it("renders the icon, slug, score, title, and url per candidate", () => {
+    const out = renderSearch(searchOutput([searchCandidate()]));
+    expect(out).toContain("✅ owner/repo#1 [80/100]");
+    expect(out).toContain("     Fix the bug");
+    expect(out).toContain("     https://github.com/owner/repo/issues/1");
+  });
+
+  it("uses the skip icon for skip recommendations", () => {
+    const out = renderSearch(
+      searchOutput([searchCandidate({ recommendation: "skip" })]),
+    );
+    expect(out).toContain("❌ owner/repo#1");
+  });
+
+  it("renders the repoScore line when present", () => {
+    const out = renderSearch(
+      searchOutput([
+        searchCandidate({
+          repoScore: {
+            score: 7,
+            mergedPRCount: 3,
+            closedWithoutMergeCount: 0,
+            isResponsive: true,
+          },
+        }),
+      ]),
+    );
+    expect(out).toContain("     Repo: 7/10, 3 merged PRs");
+  });
+
+  it("renders a stalled-PR tag when the linked PR is stalled", () => {
+    const out = renderSearch(
+      searchOutput([
+        searchCandidate({
+          linkedPR: {
+            number: 9,
+            state: "open",
+            url: "https://github.com/owner/repo/pull/9",
+            isStalled: true,
+          },
+        }),
+      ]),
+    );
+    expect(out).toContain("(stalled PR, revive opportunity)");
+  });
+
+  it("tags a positively boosted candidate", () => {
+    const out = renderSearch(
+      searchOutput([
+        searchCandidate({
+          boostScore: 5,
+          boostReasons: ["repo affinity: owner/repo"],
+        }),
+      ]),
+    );
+    expect(out).toContain("[boosted: repo affinity: owner/repo]");
+  });
+
+  it("tags a net-negative boost as deprioritized", () => {
+    const out = renderSearch(
+      searchOutput([
+        searchCandidate({
+          boostScore: -3,
+          boostReasons: ["avoid: owner/repo"],
+        }),
+      ]),
+    );
+    expect(out).toContain("[deprioritized: avoid: owner/repo]");
+  });
+
+  it("tags a diversity-slot candidate", () => {
+    const out = renderSearch(
+      searchOutput([searchCandidate({ diversitySlot: true })]),
+    );
+    expect(out).toContain("[diversity slot]");
+  });
+
+  it("does NOT include the rate-limit warning in the returned stdout string", () => {
+    const out = renderSearch(
+      searchOutput([searchCandidate()], {
+        rateLimitWarning: "rate limit low",
+      }),
+    );
+    expect(out).not.toContain("rate limit low");
+  });
+});
+
+// ── renderFeatures ──────────────────────────────────────────────────
+
+function featureCandidate(
+  overrides: Partial<FeaturesOutput["quickWins"][number]> = {},
+): FeaturesOutput["quickWins"][number] {
+  return {
+    issue: {
+      repo: "owner/repo",
+      number: 2,
+      title: "Add a feature",
+      url: "https://github.com/owner/repo/issues/2",
+      labels: [],
+    },
+    recommendation: "approve",
+    viabilityScore: 70,
+    horizon: "quick-win",
+    ...overrides,
+  };
+}
+
+function featuresOutput(
+  overrides: Partial<FeaturesOutput> = {},
+): FeaturesOutput {
+  return {
+    quickWins: [],
+    biggerBets: [],
+    anchorRepos: ["owner/repo"],
+    message: null,
+    ...overrides,
+  };
+}
+
+describe("renderFeatures", () => {
+  it("returns an empty string when there is no message and nothing to list", () => {
+    expect(renderFeatures(featuresOutput(), {})).toBe("");
+  });
+
+  it("returns just the message when total is zero but a message is present", () => {
+    const out = renderFeatures(
+      featuresOutput({ message: "No anchor repos yet." }),
+      {},
+    );
+    expect(out).toBe("\nNo anchor repos yet.\n");
+  });
+
+  it("renders the anchor-scoped header and anchor repos line", () => {
+    const out = renderFeatures(
+      featuresOutput({ quickWins: [featureCandidate()] }),
+      {},
+    );
+    expect(out).toContain("🎯 Feature opportunities in your anchor repos");
+    expect(out).toContain("(1 quick wins + 0 bigger bets)");
+    expect(out).toContain("Anchor repos: owner/repo");
+  });
+
+  it("renders the ecosystem header and omits anchor repos in broad mode", () => {
+    const out = renderFeatures(
+      featuresOutput({ quickWins: [featureCandidate()] }),
+      { broad: true },
+    );
+    expect(out).toContain("🎯 Feature opportunities across the ecosystem");
+    expect(out).not.toContain("Anchor repos:");
+  });
+
+  it("renders the Quick wins section", () => {
+    const out = renderFeatures(
+      featuresOutput({ quickWins: [featureCandidate()] }),
+      {},
+    );
+    expect(out).toContain("── Quick wins");
+    expect(out).toContain("owner/repo#2 [70/100] Add a feature");
+    expect(out).toContain("     https://github.com/owner/repo/issues/2");
+  });
+
+  it("renders the Bigger bets section and a stalled tag", () => {
+    const out = renderFeatures(
+      featuresOutput({
+        biggerBets: [
+          featureCandidate({
+            horizon: "bigger-bet",
+            linkedPR: {
+              number: 4,
+              state: "open",
+              url: "https://github.com/owner/repo/pull/4",
+              isStalled: true,
+            },
+          }),
+        ],
+      }),
+      {},
+    );
+    expect(out).toContain("── Bigger bets");
+    expect(out).toContain("(stalled PR, revive opportunity)");
+  });
+});
+
+// ── renderResults ───────────────────────────────────────────────────
+
+function savedCandidate(
+  overrides: Partial<SavedCandidate> = {},
+): SavedCandidate {
+  return {
+    issueUrl: "https://github.com/owner/repo/issues/1",
+    repo: "owner/repo",
+    number: 1,
+    title: "Fix the bug",
+    labels: [],
+    recommendation: "approve",
+    viabilityScore: 75,
+    searchPriority: "normal",
+    firstSeenAt: "2026-03-01T00:00:00.000Z",
+    lastSeenAt: "2026-03-01T00:00:00.000Z",
+    lastScore: 75,
+    ...overrides,
+  };
+}
+
+describe("renderResults", () => {
+  it("exposes the empty-state message as a constant", () => {
+    expect(RESULTS_EMPTY_MESSAGE).toBe(
+      "\nNo saved results. Run `oss-scout search` to find issues.\n",
+    );
+  });
+
+  it("renders the header count, table header, and divider", () => {
+    const out = renderResults([savedCandidate()]);
+    expect(out).toContain("Saved results (1):");
+    expect(out).toContain(
+      "  Score  Repo                              Issue   Recommendation  Title",
+    );
+    expect(out).toContain(
+      "  ─────  ────────────────────────────────  ──────  ──────────────  ─────",
+    );
+  });
+
+  it("pads the score, repo, issue, and recommendation columns", () => {
+    const out = renderResults([
+      savedCandidate({ viabilityScore: 9, number: 3 }),
+    ]);
+    const row = out.split("\n").find((l) => l.includes("#3"))!;
+    // score padStart(3): "  9"; then four spaces.
+    expect(row).toContain("    9    ");
+    expect(row).toContain("#3   ");
+    // recommendation padEnd(14): "approve" + 7 spaces.
+    expect(row).toContain("approve       ");
+  });
+
+  it("truncates titles longer than 50 chars with an ellipsis", () => {
+    const longTitle = "x".repeat(60);
+    const out = renderResults([savedCandidate({ title: longTitle })]);
+    expect(out).toContain("x".repeat(47) + "...");
+    expect(out).not.toContain("x".repeat(51));
+  });
+});
+
+// ── renderVetList ───────────────────────────────────────────────────
+
+function vetListResult(overrides: Partial<VetListResult> = {}): VetListResult {
+  return {
+    results: [],
+    summary: {
+      total: 0,
+      stillAvailable: 0,
+      claimed: 0,
+      closed: 0,
+      hasPR: 0,
+      errors: 0,
+    },
+    transitions: [],
+    ...overrides,
+  };
+}
+
+describe("renderVetList", () => {
+  it("exposes the empty-state message as a constant", () => {
+    expect(VET_LIST_EMPTY_MESSAGE).toBe(
+      "\nNo saved results to vet. Run `oss-scout search` first.\n",
+    );
+  });
+
+  it("renders the header count and the summary line", () => {
+    const out = renderVetList(
+      vetListResult({
+        results: [
+          {
+            issueUrl: "https://github.com/owner/repo/issues/1",
+            repo: "owner/repo",
+            number: 1,
+            title: "Fix the bug",
+            status: "still_available",
+            ok: true,
+            recommendation: "approve",
+            viabilityScore: 88,
+          },
+        ],
+        summary: {
+          total: 1,
+          stillAvailable: 1,
+          claimed: 0,
+          closed: 0,
+          hasPR: 0,
+          errors: 0,
+        },
+      }),
+    );
+    expect(out).toContain("Vet-list results (1):");
+    expect(out).toContain("✅ owner/repo#1 — still_available [88/100]");
+    expect(out).toContain("     Fix the bug");
+    expect(out).toContain(
+      "Summary: 1 available, 0 claimed, 0 has PR, 0 closed, 0 errors",
+    );
+  });
+
+  it("renders each status icon", () => {
+    const base = {
+      issueUrl: "https://github.com/owner/repo/issues/1",
+      repo: "owner/repo",
+      number: 1,
+      title: "t",
+    };
+    const out = renderVetList(
+      vetListResult({
+        results: [
+          {
+            ...base,
+            number: 1,
+            status: "still_available",
+            ok: false,
+            errorMessage: "",
+          },
+          {
+            ...base,
+            number: 2,
+            status: "claimed",
+            ok: false,
+            errorMessage: "",
+          },
+          { ...base, number: 3, status: "has_pr", ok: false, errorMessage: "" },
+          { ...base, number: 4, status: "closed", ok: false, errorMessage: "" },
+          {
+            ...base,
+            number: 5,
+            status: "error",
+            ok: false,
+            errorMessage: "boom",
+          },
+        ],
+      }),
+    );
+    expect(out).toContain("✅ owner/repo#1");
+    expect(out).toContain("🔒 owner/repo#2");
+    expect(out).toContain("🔀 owner/repo#3");
+    expect(out).toContain("🚫 owner/repo#4");
+    expect(out).toContain("❌ owner/repo#5");
+  });
+
+  it("omits the score for an errored (ok: false) entry", () => {
+    const out = renderVetList(
+      vetListResult({
+        results: [
+          {
+            issueUrl: "https://github.com/owner/repo/issues/1",
+            repo: "owner/repo",
+            number: 1,
+            title: "t",
+            status: "error",
+            ok: false,
+            errorMessage: "boom",
+          },
+        ],
+      }),
+    );
+    expect(out).toContain("❌ owner/repo#1 — error");
+    expect(out).not.toContain("/100");
+  });
+
+  it("renders the transitions block when transitions exist", () => {
+    const out = renderVetList(
+      vetListResult({
+        transitions: [
+          {
+            issueUrl: "https://github.com/owner/repo/issues/1",
+            repo: "owner/repo",
+            number: 1,
+            from: "still_available",
+            to: "claimed",
+          },
+        ],
+      }),
+    );
+    expect(out).toContain("🔔 Changes since last check (1):");
+    expect(out).toContain("owner/repo#1: still_available → claimed");
+  });
+
+  it("omits the transitions block when there are none", () => {
+    const out = renderVetList(vetListResult());
+    expect(out).not.toContain("Changes since last check");
+  });
+
+  it("renders the pruned-count line when prunedCount is set", () => {
+    const out = renderVetList(vetListResult({ prunedCount: 2 }));
+    expect(out).toContain("Pruned 2 unavailable issues from saved results.");
+  });
+
+  it("omits the pruned-count line when prunedCount is absent", () => {
+    const out = renderVetList(vetListResult());
+    expect(out).not.toContain("Pruned");
+  });
+});
+
+// ── renderVet ───────────────────────────────────────────────────────
+
+function vetOutput(overrides: Partial<VetOutput> = {}): VetOutput {
+  return {
+    issue: {
+      repo: "owner/repo",
+      number: 1,
+      title: "Fix the bug",
+      url: "https://github.com/owner/repo/issues/1",
+      labels: [],
+    },
+    recommendation: "approve",
+    reasonsToApprove: [],
+    reasonsToSkip: [],
+    projectHealth: {
+      repo: "owner/repo",
+      lastCommitAt: "2026-06-01T00:00:00.000Z",
+      daysSinceLastCommit: 3,
+      openIssuesCount: 10,
+      avgIssueResponseDays: 2,
+      ciStatus: "passing",
+      isActive: true,
+    },
+    // vettingResult is part of VetOutput but unused by the renderer; cast a
+    // minimal stub to satisfy the type without importing the full schema.
+    vettingResult: {} as VetOutput["vettingResult"],
+    ...overrides,
+  };
+}
+
+describe("renderVet", () => {
+  it("renders the recommendation header in upper case with the icon", () => {
+    const out = renderVet(vetOutput());
+    expect(out).toContain("✅ owner/repo#1: APPROVE");
+    expect(out).toContain("   Fix the bug");
+    expect(out).toContain("   https://github.com/owner/repo/issues/1");
+  });
+
+  it("renders reasons to approve and skip", () => {
+    const out = renderVet(
+      vetOutput({
+        reasonsToApprove: ["responsive maintainers"],
+        reasonsToSkip: ["already claimed"],
+      }),
+    );
+    expect(out).toContain("Reasons to approve:");
+    expect(out).toContain("  + responsive maintainers");
+    expect(out).toContain("Reasons to skip:");
+    expect(out).toContain("  - already claimed");
+  });
+
+  it("renders the active project-health branch", () => {
+    const out = renderVet(vetOutput());
+    expect(out).toContain("Project health: Active");
+    expect(out).toContain("  Last commit: 3 days ago");
+    expect(out).toContain("  CI status: passing");
+  });
+
+  it("renders the inactive project-health branch", () => {
+    const out = renderVet(
+      vetOutput({
+        projectHealth: {
+          repo: "owner/repo",
+          lastCommitAt: "2025-01-01T00:00:00.000Z",
+          daysSinceLastCommit: 400,
+          openIssuesCount: 10,
+          avgIssueResponseDays: 2,
+          ciStatus: "unknown",
+          isActive: false,
+        },
+      }),
+    );
+    expect(out).toContain("Project health: Inactive");
+  });
+
+  it("renders the checkFailed project-health branch (#158)", () => {
+    const out = renderVet(
+      vetOutput({
+        projectHealth: {
+          repo: "owner/repo",
+          checkFailed: true,
+          failureReason: "GitHub API 502",
+        },
+      }),
+    );
+    expect(out).toContain(
+      "Project health: unknown (check failed: GitHub API 502)",
+    );
+    expect(out).not.toContain("Last commit:");
+  });
+});

--- a/packages/core/src/formatters/human.ts
+++ b/packages/core/src/formatters/human.ts
@@ -1,0 +1,242 @@
+/**
+ * Human-readable (non-JSON) output formatters for the oss-scout CLI.
+ *
+ * Each renderer is a pure function that returns the exact multi-line string the
+ * CLI used to emit via a sequence of `console.log` calls. The caller does a
+ * single `console.log(renderX(...))`, which appends the one trailing newline
+ * that the final `console.log` in the old inline block produced.
+ *
+ * To stay byte-identical: every old `console.log(line)` becomes one entry in a
+ * lines array, a bare `console.log()` (blank line) becomes an empty entry, and
+ * the array is joined with "\n". The caller's own `console.log` supplies the
+ * last newline. STDERR output (the search rate-limit warning) is deliberately
+ * NOT folded in here — it stays a `console.error` in the caller.
+ */
+
+import type { SearchOutput } from "../commands/search.js";
+import type { FeaturesOutput } from "../commands/features.js";
+import type { SavedCandidate } from "../core/schemas.js";
+import type { VetListResult } from "../core/types.js";
+import type { VetOutput } from "../commands/vet.js";
+
+/** Emoji for a vetting recommendation, shared by the search and vet renderers. */
+export function recommendationIcon(
+  recommendation: "approve" | "skip" | "needs_review",
+): string {
+  if (recommendation === "approve") return "✅";
+  if (recommendation === "skip") return "❌";
+  return "⚠️";
+}
+
+/**
+ * Render the human-readable `search` output: the "Found N issue candidates"
+ * block with per-candidate icon, personalization and stalled tags, and the
+ * optional repoScore line. The trailing rate-limit warning is NOT included
+ * here; it goes to stderr in the caller.
+ */
+export function renderSearch(results: SearchOutput): string {
+  const lines: string[] = [];
+  lines.push(`\nFound ${results.candidates.length} issue candidates:\n`);
+  for (const c of results.candidates) {
+    const icon = recommendationIcon(c.recommendation);
+    const stalledTag = c.linkedPR?.isStalled
+      ? " (stalled PR, revive opportunity)"
+      : "";
+    // Personalization tag (#1244). A candidate is either boosted (matched a
+    // preference) or a diversity slot (matched none and filled a reserved
+    // slot); never both.
+    let personalizationTag = "";
+    if (c.boostReasons && c.boostReasons.length > 0) {
+      // Net score can be negative when avoidRepos applied (#168).
+      const verb = (c.boostScore ?? 0) >= 0 ? "boosted" : "deprioritized";
+      personalizationTag = ` [${verb}: ${c.boostReasons.join("; ")}]`;
+    } else if (c.diversitySlot) {
+      personalizationTag = " [diversity slot]";
+    }
+    lines.push(
+      `  ${icon} ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100]${personalizationTag}${stalledTag}`,
+    );
+    lines.push(`     ${c.issue.title}`);
+    lines.push(`     ${c.issue.url}`);
+    if (c.repoScore) {
+      lines.push(
+        `     Repo: ${c.repoScore.score}/10, ${c.repoScore.mergedPRCount} merged PRs`,
+      );
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Render the human-readable `features` output: the optional message, the
+ * "Feature opportunities" header, the anchor repos line, and the Quick wins /
+ * Bigger bets sections. Returns "" when there is nothing to print beyond an
+ * absent message (caller guards against logging a blank line).
+ */
+export function renderFeatures(
+  result: FeaturesOutput,
+  options: { broad?: boolean },
+): string {
+  const lines: string[] = [];
+  const total = result.quickWins.length + result.biggerBets.length;
+  if (result.message) {
+    lines.push(`\n${result.message}\n`);
+  }
+  if (total === 0) return lines.join("\n");
+  const headerScope = options.broad
+    ? "across the ecosystem"
+    : "in your anchor repos";
+  lines.push(
+    `\n🎯 Feature opportunities ${headerScope} (${result.quickWins.length} quick wins + ${result.biggerBets.length} bigger bets)\n`,
+  );
+  if (!options.broad) {
+    lines.push(`Anchor repos: ${result.anchorRepos.join(", ")}\n`);
+  }
+  if (result.quickWins.length) {
+    lines.push("── Quick wins ─────────────────────────────────────────");
+    for (const c of result.quickWins) {
+      const stalledTag = c.linkedPR?.isStalled
+        ? " (stalled PR, revive opportunity)"
+        : "";
+      lines.push(
+        `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,
+      );
+      lines.push(`     ${c.issue.url}`);
+    }
+    lines.push("");
+  }
+  if (result.biggerBets.length) {
+    lines.push("── Bigger bets ────────────────────────────────────────");
+    for (const c of result.biggerBets) {
+      const stalledTag = c.linkedPR?.isStalled
+        ? " (stalled PR, revive opportunity)"
+        : "";
+      lines.push(
+        `  ${c.issue.repo}#${c.issue.number} [${c.viabilityScore}/100] ${c.issue.title}${stalledTag}`,
+      );
+      lines.push(`     ${c.issue.url}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/** The empty-state message printed by `results` when nothing is saved. */
+export const RESULTS_EMPTY_MESSAGE =
+  "\nNo saved results. Run `oss-scout search` to find issues.\n";
+
+/**
+ * Render the human-readable `results` table: the "Saved results" header and a
+ * Score / Repo / Issue / Recommendation / Title row per saved candidate.
+ * Callers handle the empty state (RESULTS_EMPTY_MESSAGE) separately.
+ */
+export function renderResults(results: SavedCandidate[]): string {
+  const lines: string[] = [];
+  lines.push(`\nSaved results (${results.length}):\n`);
+  lines.push(
+    "  Score  Repo                              Issue   Recommendation  Title",
+  );
+  lines.push(
+    "  ─────  ────────────────────────────────  ──────  ──────────────  ─────",
+  );
+  for (const r of results) {
+    const score = String(r.viabilityScore).padStart(3);
+    const repo = r.repo.padEnd(32).slice(0, 32);
+    const issue = `#${r.number}`.padEnd(6);
+    const rec = r.recommendation.padEnd(14);
+    const title = r.title.length > 50 ? r.title.slice(0, 47) + "..." : r.title;
+    lines.push(`  ${score}    ${repo}  ${issue}  ${rec}  ${title}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** The empty-state message printed by `vet-list` when there is nothing to vet. */
+export const VET_LIST_EMPTY_MESSAGE =
+  "\nNo saved results to vet. Run `oss-scout search` first.\n";
+
+/** Icon for a vet-list entry's availability status. */
+function vetListStatusIcon(
+  status: VetListResult["results"][number]["status"],
+): string {
+  return status === "still_available"
+    ? "✅"
+    : status === "claimed"
+      ? "🔒"
+      : status === "has_pr"
+        ? "🔀"
+        : status === "closed"
+          ? "🚫"
+          : "❌";
+}
+
+/**
+ * Render the human-readable `vet-list` output: the "Vet-list results (N)"
+ * block with a per-row status icon, the "Changes since last check"
+ * transitions block, the summary line, and the optional pruned-count line.
+ * Callers handle the empty state (VET_LIST_EMPTY_MESSAGE) separately.
+ */
+export function renderVetList(result: VetListResult): string {
+  const lines: string[] = [];
+  lines.push(`\nVet-list results (${result.summary.total}):\n`);
+  for (const r of result.results) {
+    const icon = vetListStatusIcon(r.status);
+    const score = r.ok ? ` [${r.viabilityScore}/100]` : "";
+    lines.push(`  ${icon} ${r.repo}#${r.number} — ${r.status}${score}`);
+    lines.push(`     ${r.title}`);
+  }
+  if (result.transitions.length > 0) {
+    lines.push(`\n🔔 Changes since last check (${result.transitions.length}):`);
+    for (const t of result.transitions) {
+      lines.push(`  ${t.repo}#${t.number}: ${t.from} → ${t.to}`);
+    }
+  }
+  lines.push(
+    `\nSummary: ${result.summary.stillAvailable} available, ${result.summary.claimed} claimed, ${result.summary.hasPR} has PR, ${result.summary.closed} closed, ${result.summary.errors} errors`,
+  );
+  if (result.prunedCount != null) {
+    lines.push(
+      `Pruned ${result.prunedCount} unavailable issues from saved results.`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Render the human-readable single-issue `vet` output: the recommendation
+ * header, the reasons to approve / skip, and the project-health block. The
+ * checkFailed branch (#158) is preserved exactly.
+ */
+export function renderVet(result: VetOutput): string {
+  const lines: string[] = [];
+  const icon = recommendationIcon(result.recommendation);
+  lines.push(
+    `\n${icon} ${result.issue.repo}#${result.issue.number}: ${result.recommendation.toUpperCase()}`,
+  );
+  lines.push(`   ${result.issue.title}`);
+  lines.push(`   ${result.issue.url}\n`);
+  if (result.reasonsToApprove.length > 0) {
+    lines.push("Reasons to approve:");
+    for (const r of result.reasonsToApprove) lines.push(`  + ${r}`);
+  }
+  if (result.reasonsToSkip.length > 0) {
+    lines.push("Reasons to skip:");
+    for (const r of result.reasonsToSkip) lines.push(`  - ${r}`);
+  }
+  if (result.projectHealth.checkFailed) {
+    lines.push(
+      `\nProject health: unknown (check failed: ${result.projectHealth.failureReason})`,
+    );
+  } else {
+    lines.push(
+      `\nProject health: ${result.projectHealth.isActive ? "Active" : "Inactive"}`,
+    );
+    lines.push(
+      `  Last commit: ${result.projectHealth.daysSinceLastCommit} days ago`,
+    );
+    lines.push(`  CI status: ${result.projectHealth.ciStatus}`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
Part of #157.

cli.ts carried ~150 lines of inline `console.log` human-output rendering inside its command actions — untestable (the child-process `cli.test.ts` only covers `--help`/`--version`/`--json`) and crowding the arg wiring next to a `formatters/` dir that held only a 32-line JSON file.

## What

Extracts the five non-JSON renderers into pure string-returning functions in a new `formatters/human.ts`:
- `renderSearch`, `renderFeatures`, `renderResults`, `renderVetList`, `renderVet`

The caller now does `console.log(renderX(...))`. `recommendationIcon` moved into `human.ts`. A new `human.test.ts` (34 tests) pins each renderer's output, including the branches that were previously impossible to test inline.

## Behavior-preserving

The CLI's stdout/stderr is byte-identical:
- Each renderer returns the exact multi-line string the inline `console.log`s produced (bare `console.log()` → empty line preserved via join semantics).
- The search **rate-limit warning stays on stderr** in the caller (`console.error`), not folded into the returned string.
- The `features`/`results`/`vet-list` empty-state and early-return cases are reproduced so no spurious blank line prints where the original printed nothing (`renderFeatures` returns `""` and the caller guards with `if (out) console.log(out)`; the empty-state messages are extracted as byte-identical constants).
- The `vet` project-health block preserves both the `checkFailed` (#158) and active branches.
- JSON and markdown output paths are untouched.

Reviewed specifically for output drift against the original `cli.ts` — none found.

## Remaining for #157

The `searchIssues` phase-runner table extraction (the other half of #157) is a separate follow-up; this PR is the cli-renderer half.

## Tests

Full gate green locally: lint, format:check, typecheck, 975 core (+34) + 32 mcp tests.