### PR TITLE
refactor(core): make SearchBudgetTracker injectable to fix concurrent-search budget reset (#156)

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -243,6 +243,17 @@ function makeDiscovery(
   );
 }
 
+/** Minimal SearchBudgetTracker stand-in for injection assertions. */
+function makeFakeTracker() {
+  return {
+    init: vi.fn(),
+    recordCall: vi.fn(),
+    getTotalCalls: vi.fn(() => 7),
+    canAfford: vi.fn(() => true),
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────
 
 describe("IssueDiscovery", () => {
@@ -1068,6 +1079,62 @@ describe("IssueDiscovery", () => {
 
       // Phase 2 should have run (searchWithChunkedLabels called)
       expect(mockSearchAcrossLanguagesAndLabels).toHaveBeenCalled();
+    });
+  });
+
+  describe("budget tracker injection (#156)", () => {
+    it("uses an injected tracker instead of the shared singleton", async () => {
+      const item: GitHubSearchItem = {
+        html_url: "https://github.com/broad/repo/issues/1",
+        repository_url: "https://api.github.com/repos/broad/repo",
+        updated_at: "2026-01-01T00:00:00Z",
+      };
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue([item]);
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [makeCandidate("broad/repo", "normal")],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      const tracker = makeFakeTracker();
+      const discovery = new IssueDiscovery(
+        "test-token",
+        makePreferences(),
+        makeStateReader(),
+        tracker,
+      );
+      await discovery.searchIssues({ maxResults: 5 });
+
+      // Pre-flight init() ran on the injected instance, not the singleton.
+      expect(tracker.init).toHaveBeenCalledOnce();
+
+      // The same instance is threaded into the search-phases helper as its
+      // trailing argument, so concurrent searches no longer share budget state.
+      const phaseCall = mockSearchAcrossLanguagesAndLabels.mock.calls.at(-1)!;
+      expect(phaseCall.at(-1)).toBe(tracker);
+    });
+
+    it("falls back to the shared singleton when no tracker is injected", async () => {
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue([
+        {
+          html_url: "https://github.com/broad/repo/issues/1",
+          repository_url: "https://api.github.com/repos/broad/repo",
+          updated_at: "2026-01-01T00:00:00Z",
+        } as GitHubSearchItem,
+      ]);
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [makeCandidate("broad/repo", "normal")],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery();
+      await discovery.searchIssues({ maxResults: 5 });
+
+      // Default path threads the mocked singleton (a defined tracker object),
+      // never undefined, into the search-phases helper.
+      const phaseCall = mockSearchAcrossLanguagesAndLabels.mock.calls.at(-1)!;
+      expect(phaseCall.at(-1)).toBeDefined();
     });
   });
 });

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -14,7 +14,10 @@
 
 import { Octokit } from "@octokit/rest";
 import { getOctokit, checkRateLimit } from "./github.js";
-import { getSearchBudgetTracker } from "./search-budget.js";
+import {
+  getSearchBudgetTracker,
+  type SearchBudgetTracker,
+} from "./search-budget.js";
 import { daysBetween, extractRepoFromUrl, sleep } from "./utils.js";
 import {
   type SearchPriority,
@@ -196,6 +199,7 @@ async function runPhase2(
   starredRepoSet: Set<string>,
   existingCandidates: IssueCandidate[],
   filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
+  tracker: SearchBudgetTracker,
 ): Promise<PhaseResult> {
   info(MODULE, "Phase 2: General issue search...");
   const seenRepos = new Set(existingCandidates.map((c) => c.issue.repo));
@@ -237,6 +241,7 @@ async function runPhase2(
         (langQ) =>
           `is:issue is:open ${langQ} no:assignee`.replace(/  +/g, " ").trim(),
         budgetPerTier * 3,
+        tracker,
       );
 
       info(MODULE, `Phase 2 [${tier}]: processing ${allItems.length} items...`);
@@ -307,6 +312,7 @@ async function runPhase3(
   starredRepos: string[],
   existingCandidates: IssueCandidate[],
   filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
+  tracker: SearchBudgetTracker,
 ): Promise<PhaseResult> {
   info(MODULE, "Phase 3: Searching actively maintained repos...");
 
@@ -382,12 +388,16 @@ async function runPhase3(
       .trim();
 
   try {
-    const data = await cachedSearchIssues(octokit, {
-      q: phase3Query,
-      sort: "updated",
-      order: "desc",
-      per_page: maxResults * 3,
-    });
+    const data = await cachedSearchIssues(
+      octokit,
+      {
+        q: phase3Query,
+        sort: "updated",
+        order: "desc",
+        per_page: maxResults * 3,
+      },
+      tracker,
+    );
 
     info(
       MODULE,
@@ -447,6 +457,7 @@ export class IssueDiscovery {
   private octokit: Octokit;
   private githubToken: string;
   private vetter: IssueVetter;
+  private budgetTracker: SearchBudgetTracker;
 
   /** Set after searchIssues() runs if rate limits affected the search (low pre-flight quota or mid-search rate limit hits). */
   rateLimitWarning: string | null = null;
@@ -455,15 +466,28 @@ export class IssueDiscovery {
    * @param githubToken  - GitHub personal access token or token from `gh auth token`
    * @param preferences  - User's search preferences (languages, labels, scopes, etc.)
    * @param stateReader  - Read-only interface for accessing scout state (merged PRs, starred repos, etc.)
+   * @param budgetTracker - Search budget tracker. Defaults to the shared
+   *   singleton so existing callers behave identically. A long-lived host
+   *   serving concurrent searches can inject a per-search instance so one
+   *   search's init() no longer resets the budget state of another (the
+   *   shared-singleton concurrency hazard, #156).
    */
   constructor(
     githubToken: string,
     private preferences: ScoutPreferences,
     private stateReader: ScoutStateReader,
+    budgetTracker: SearchBudgetTracker = getSearchBudgetTracker(),
   ) {
     this.githubToken = githubToken;
     this.octokit = getOctokit(githubToken);
-    this.vetter = new IssueVetter(this.octokit, this.stateReader);
+    this.budgetTracker = budgetTracker;
+    // Thread the same tracker into the vetter so the merged-PR Search API
+    // call (checkUserMergedPRsInRepo) pays the same budget as the search phases.
+    this.vetter = new IssueVetter(
+      this.octokit,
+      this.stateReader,
+      this.budgetTracker,
+    );
   }
 
   /**
@@ -572,7 +596,7 @@ export class IssueDiscovery {
 
     // Pre-flight rate limit check
     this.rateLimitWarning = null;
-    const tracker = getSearchBudgetTracker();
+    const tracker = this.budgetTracker;
     let searchBudget = LOW_BUDGET_THRESHOLD - 1;
     try {
       const rateLimit = await checkRateLimit(this.githubToken);
@@ -768,6 +792,7 @@ export class IssueDiscovery {
           starredRepoSet,
           allCandidates,
           filterIssues,
+          tracker,
         );
         recordPhaseResult("2", result);
         // Recorded only when the phase actually queried, not when the
@@ -796,6 +821,7 @@ export class IssueDiscovery {
         starredRepos,
         allCandidates,
         filterIssues,
+        tracker,
       );
       recordPhaseResult("3", result);
       strategiesUsed.push("maintained");

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -15,7 +15,10 @@ import {
   withInflightDedup,
   versionedCacheKey,
 } from "./http-cache.js";
-import { getSearchBudgetTracker } from "./search-budget.js";
+import {
+  getSearchBudgetTracker,
+  type SearchBudgetTracker,
+} from "./search-budget.js";
 import type { CheckResult, LinkedPR } from "./types.js";
 
 /**
@@ -230,6 +233,10 @@ export async function checkUserMergedPRsInRepo(
   octokit: Octokit,
   owner: string,
   repo: string,
+  // Optional injected budget tracker. Defaults to the shared singleton so
+  // existing callers keep the same global budget accounting; a host wanting
+  // per-search isolation threads its own tracker down from IssueVetter.
+  tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<number | null> {
   const cache = getHttpCache();
   const cacheKey = versionedCacheKey(`merged-prs:${owner}/${repo}`);
@@ -248,7 +255,6 @@ export async function checkUserMergedPRsInRepo(
     }
 
     try {
-      const tracker = getSearchBudgetTracker();
       await tracker.waitForBudget();
       try {
         // Use @me to search as the authenticated user

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -51,6 +51,10 @@ import {
 } from "./issue-graphql.js";
 import { getHttpCache, versionedCacheKey } from "./http-cache.js";
 import {
+  getSearchBudgetTracker,
+  type SearchBudgetTracker,
+} from "./search-budget.js";
+import {
   triageWithSLM,
   buildTriageInput,
   type SLMTriageOptions,
@@ -304,10 +308,23 @@ export function deriveRecommendation(
 export class IssueVetter {
   private octokit: Octokit;
   private stateReader: ScoutStateReader;
+  private budgetTracker: SearchBudgetTracker;
 
-  constructor(octokit: Octokit, stateReader: ScoutStateReader) {
+  /**
+   * @param octokit      - Authenticated Octokit instance
+   * @param stateReader  - Read-only scout state interface
+   * @param budgetTracker - Search budget tracker. Defaults to the shared
+   *   singleton so existing callers behave identically; inject a per-search
+   *   instance to isolate budget accounting in a long-lived concurrent host.
+   */
+  constructor(
+    octokit: Octokit,
+    stateReader: ScoutStateReader,
+    budgetTracker: SearchBudgetTracker = getSearchBudgetTracker(),
+  ) {
     this.octokit = octokit;
     this.stateReader = stateReader;
+    this.budgetTracker = budgetTracker;
   }
 
   /**
@@ -383,7 +400,12 @@ export class IssueVetter {
       fetchContributionGuidelines(this.octokit, owner, repo),
       hasMergedPRsInRepo
         ? Promise.resolve(0)
-        : checkUserMergedPRsInRepo(this.octokit, owner, repo),
+        : checkUserMergedPRsInRepo(
+            this.octokit,
+            owner,
+            repo,
+            this.budgetTracker,
+          ),
     ]);
 
     // Anti-LLM scan reuses the CONTRIBUTING text just fetched above —

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -21,7 +21,10 @@ import {
 } from "./issue-filtering.js";
 import { IssueVetter } from "./issue-vetting.js";
 import { extractRepoFromUrl, sleep } from "./utils.js";
-import { getSearchBudgetTracker } from "./search-budget.js";
+import {
+  getSearchBudgetTracker,
+  type SearchBudgetTracker,
+} from "./search-budget.js";
 
 const MODULE = "search-phases";
 
@@ -117,6 +120,10 @@ export async function cachedSearchIssues(
     order: "asc" | "desc";
     per_page: number;
   },
+  // Optional injected budget tracker. Defaults to the shared singleton so
+  // existing callers keep the exact same global budget accounting; a host
+  // serving concurrent searches can inject a per-search tracker for isolation.
+  tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<{ total_count: number; items: GitHubSearchItem[] }> {
   const cacheKey = versionedCacheKey(
     `search:${params.q}:${params.sort}:${params.order}:${params.per_page}`,
@@ -131,7 +138,6 @@ export async function cachedSearchIssues(
   }
 
   // Fetch from API
-  const tracker = getSearchBudgetTracker();
   await tracker.waitForBudget();
   let data: { total_count: number; items: GitHubSearchItem[] };
   try {
@@ -374,6 +380,7 @@ export async function searchWithChunkedLabels(
   reservedOps: number,
   buildQuery: (labelQuery: string) => string,
   perPage: number,
+  tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<GitHubSearchItem[]> {
   const labelChunks = chunkLabels(labels, reservedOps);
   const seenUrls = new Set<string>();
@@ -383,12 +390,16 @@ export async function searchWithChunkedLabels(
     if (i > 0) await sleep(INTER_QUERY_DELAY_MS);
 
     const query = buildQuery(buildLabelQuery(labelChunks[i]));
-    const data = await cachedSearchIssues(octokit, {
-      q: query,
-      sort: "created",
-      order: "desc",
-      per_page: perPage,
-    });
+    const data = await cachedSearchIssues(
+      octokit,
+      {
+        q: query,
+        sort: "created",
+        order: "desc",
+        per_page: perPage,
+      },
+      tracker,
+    );
 
     for (const item of data.items) {
       if (!seenUrls.has(item.html_url)) {
@@ -441,6 +452,7 @@ export async function searchAcrossLanguagesAndLabels(
   labels: string[],
   buildBaseQuery: (langQuery: string) => string,
   perPage: number,
+  tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<GitHubSearchItem[]> {
   const langVariants = buildLanguageVariants(
     languages,
@@ -461,6 +473,7 @@ export async function searchAcrossLanguagesAndLabels(
           .replace(/  +/g, " ")
           .trim(),
       perPage,
+      tracker,
     );
     for (const item of items) {
       if (!seenUrls.has(item.html_url)) {


### PR DESCRIPTION
Part of #156 (the "thread cache/budget singletons through constructors" item; logger/ScoutStateWriter/bootstrapScout landed earlier).

## The bug

`getSearchBudgetTracker()` returns a module-level singleton, and `IssueDiscovery.searchIssues` calls its `init()` at pre-flight — which **resets shared budget state across concurrent searches** in one long-lived process (e.g. an MCP server serving parallel search requests). Two searches running at once clobber each other's budget accounting.

## Fix: injectable with singleton default

`IssueDiscovery` and `IssueVetter` gain a `budgetTracker` constructor param defaulting to `getSearchBudgetTracker()`. `searchIssues` uses `this.budgetTracker` and threads **that same instance** into:
- the phase functions (`runPhase2`/`runPhase3` → `search-phases.ts` `cachedSearchIssues`/`searchWithChunkedLabels`/`searchAcrossLanguagesAndLabels`)
- the `IssueVetter` it constructs (→ `checkUserMergedPRsInRepo`)

So one injected tracker covers the whole search **including vetting**, with no accounting split. A host that wants isolation passes a fresh tracker per search; everyone else keeps the shared singleton.

## Non-breaking + behavior-preserving

Every new parameter is optional/defaulted. With nothing injected, `this.budgetTracker` **is** the singleton, so `init()` / `waitForBudget` / `recordCall` / `getTotalCalls` hit the exact same instance as before — byte-for-byte identical accounting. `init()` resets only instance fields (no module globals), still called exactly once per run. Phases 0/1 use the REST `listForRepo` endpoint (not the Search API), so they correctly take no tracker. No existing test changed its expectations (the test diff is purely additive).

## Scoped out: http-cache

`getHttpCache()` is also a singleton but is a URL-hash-keyed content cache with no per-search `init()`/reset — it carries no concurrency hazard, and threading it through every standalone function (`checkProjectHealth`, `fetchContributionGuidelines`, `vetIssue`'s cache, etc.) would be large churn for no bug fix. Left as a clean additive follow-up. The remaining #156 item, the `probeRepoFiles` 3-way consolidation, is a separate follow-up too.

## Tests

New `budget tracker injection (#156)` tests assert the injected instance flows through `searchIssues` → phase functions. Full gate green locally: lint, format:check, typecheck, 977 core (+2) + 32 mcp.