### PR TITLE
refactor(core): consolidate repo-doc probing into probeRepoFile (#156)

### DIFF
--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -9,17 +9,10 @@
  */
 
 import { Octokit } from "@octokit/rest";
-import {
-  errorMessage,
-  getHttpStatusCode,
-  isRateLimitError,
-  rethrowIfFatal,
-} from "./errors.js";
-import { warn } from "./logger.js";
+import { getHttpStatusCode, isRateLimitError } from "./errors.js";
 import { getHttpCache, versionedCacheKey } from "./http-cache.js";
+import { probeRepoFile } from "./probe-repo-file.js";
 import type { AntiLLMPolicyResult, AntiLLMPolicySourceFile } from "./types.js";
-
-const MODULE = "anti-llm-policy";
 
 /** TTL for cached anti-LLM policy scan results (1 hour). Policy docs change rarely. */
 const POLICY_SCAN_CACHE_TTL_MS = 60 * 60 * 1000;
@@ -107,39 +100,6 @@ const SOURCE_FILE_FAMILIES: ReadonlyArray<{
 ];
 
 /**
- * Fetch one path's raw text content. The `transient` flag distinguishes a
- * clean miss (404 — file absent) from a degraded miss (5xx, network) so the
- * caller can decide whether to cache "no policy" or retry. Throws on
- * 401/auth and rate-limit per documented project error strategy.
- */
-async function fetchFileText(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  path: string,
-): Promise<{ text: string | null; transient: boolean }> {
-  try {
-    const { data } = await octokit.repos.getContent({ owner, repo, path });
-    if ("content" in data && typeof data.content === "string") {
-      return {
-        text: Buffer.from(data.content, "base64").toString("utf-8"),
-        transient: false,
-      };
-    }
-    return { text: null, transient: false };
-  } catch (error) {
-    const status = getHttpStatusCode(error);
-    if (status === 404) return { text: null, transient: false };
-    rethrowIfFatal(error);
-    warn(
-      MODULE,
-      `Unexpected error fetching ${path} from ${owner}/${repo}: ${errorMessage(error)}`,
-    );
-    return { text: null, transient: true };
-  }
-}
-
-/**
  * Result of probing one source-file family. `hadTransientFailure` lets the
  * caller decide whether to skip caching a "no match" result that may have
  * been incomplete due to a 5xx / network blip.
@@ -161,7 +121,7 @@ async function fetchFamilyText(
   paths: readonly string[],
 ): Promise<FamilyFetchResult> {
   const results = await Promise.allSettled(
-    paths.map((p) => fetchFileText(octokit, owner, repo, p)),
+    paths.map((p) => probeRepoFile(octokit, owner, repo, p)),
   );
   let hadTransientFailure = false;
   for (const result of results) {

--- a/packages/core/src/core/probe-repo-file.test.ts
+++ b/packages/core/src/core/probe-repo-file.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { warn } from "./logger.js";
+import { probeRepoFile } from "./probe-repo-file.js";
+import type { Octokit } from "@octokit/rest";
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+/** An HTTP-shaped error with a numeric status (Octokit RequestError shape). */
+function httpError(
+  status: number,
+  message: string,
+): Error & { status: number } {
+  const err = new Error(message) as Error & { status: number };
+  err.status = status;
+  return err;
+}
+
+/** Build an Octokit mock whose getContent runs the supplied implementation. */
+function makeOctokit(impl: (path: string) => Promise<unknown>): Octokit {
+  return {
+    repos: {
+      getContent: vi.fn(({ path }: { path: string }) => impl(path)),
+    },
+  } as unknown as Octokit;
+}
+
+describe("probeRepoFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns decoded content on a 200 file payload", async () => {
+    const octokit = makeOctokit(async () => ({
+      data: { content: Buffer.from("hello world", "utf-8").toString("base64") },
+    }));
+    const result = await probeRepoFile(octokit, "o", "r", "README.md");
+    expect(result).toEqual({ text: "hello world", transient: false });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns a clean null on 404 (file absent)", async () => {
+    const octokit = makeOctokit(async () => {
+      throw httpError(404, "Not Found");
+    });
+    const result = await probeRepoFile(octokit, "o", "r", "ROADMAP.md");
+    expect(result).toEqual({ text: null, transient: false });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns a clean null on a non-content payload (e.g. directory listing)", async () => {
+    const octokit = makeOctokit(async () => ({ data: [] }));
+    const result = await probeRepoFile(octokit, "o", "r", "docs");
+    expect(result).toEqual({ text: null, transient: false });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns a clean null when content is present but not a string", async () => {
+    const octokit = makeOctokit(async () => ({ data: { content: 123 } }));
+    const result = await probeRepoFile(octokit, "o", "r", "weird");
+    expect(result).toEqual({ text: null, transient: false });
+  });
+
+  it("rethrows 401 auth errors as fatal", async () => {
+    const octokit = makeOctokit(async () => {
+      throw httpError(401, "Unauthorized");
+    });
+    await expect(
+      probeRepoFile(octokit, "o", "r", "CONTRIBUTING.md"),
+    ).rejects.toThrow("Unauthorized");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("rethrows rate-limit errors as fatal", async () => {
+    const octokit = makeOctokit(async () => {
+      throw httpError(429, "API rate limit exceeded");
+    });
+    await expect(
+      probeRepoFile(octokit, "o", "r", "CONTRIBUTING.md"),
+    ).rejects.toThrow("rate limit");
+  });
+
+  it("returns a transient null and warns on a 5xx server error", async () => {
+    const octokit = makeOctokit(async () => {
+      throw httpError(503, "Service Unavailable");
+    });
+    const result = await probeRepoFile(octokit, "o", "r", "README.md");
+    expect(result).toEqual({ text: null, transient: true });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a transient null and warns on a network error (no status)", async () => {
+    const octokit = makeOctokit(async () => {
+      throw new Error("ENOTFOUND api.github.com");
+    });
+    const result = await probeRepoFile(octokit, "o", "r", "README.md");
+    expect(result).toEqual({ text: null, transient: true });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/core/probe-repo-file.ts
+++ b/packages/core/src/core/probe-repo-file.ts
@@ -1,0 +1,87 @@
+/**
+ * Single-path repo-file probe (#156).
+ *
+ * Three modules (repo-health, roadmap, anti-llm-policy) independently fetch a
+ * repo doc by trying a list of candidate paths and stopping at the first hit.
+ * The per-path fetch was copy-pasted three times, each re-deriving the same
+ * 404-continue / fatal-propagate / base64-decode logic. This is the one
+ * genuinely-shared primitive.
+ *
+ * The orchestration around it stays per-caller (parallel 4-path probe,
+ * sequential 5-path probe, sequential family probe) and so do the return shapes
+ * (parsed guidelines, issue-ref set, policy scan). Only the single GET is
+ * shared.
+ *
+ * The `transient` flag is load-bearing: it distinguishes a clean miss (404 —
+ * file absent) from a degraded miss (5xx, network) so callers can decide
+ * whether to cache a negative result or leave it open to retry. Collapsing the
+ * two would bypass anti-llm-policy's transient-failure cache safeguard, so the
+ * primitive must keep them separate.
+ */
+
+import type { Octokit } from "@octokit/rest";
+import { errorMessage, getHttpStatusCode, rethrowIfFatal } from "./errors.js";
+import { warn } from "./logger.js";
+
+const MODULE = "probe-repo-file";
+
+/**
+ * Result of probing one repo file path.
+ *
+ * - `text` — decoded UTF-8 content on a 200 with a file payload, else `null`
+ *   (404, a non-content payload such as a directory listing, or a soft error).
+ * - `transient` — `true` only when the miss was a degraded failure (5xx,
+ *   network) rather than a clean 404 / missing file. A `true` value means the
+ *   `null` may be incomplete and the caller should avoid caching it as a known
+ *   absence.
+ */
+export interface ProbeRepoFileResult {
+  text: string | null;
+  transient: boolean;
+}
+
+/**
+ * GET one repo file path. Returns decoded content on a 200 file payload, a
+ * clean `null` on 404 or a non-content payload, and a transient `null` on a
+ * soft error (5xx, network) after logging it. Rethrows fatal errors (401 auth,
+ * rate limit) so the caller's existing rate-limit handling sees them.
+ *
+ * Callers that need 401/rate-limit to surface across a *parallel* batch (where
+ * a faster path may have already resolved) must inspect the rejected reasons
+ * themselves; this primitive only rethrows for the single path it owns. See
+ * repo-health and anti-llm-policy for that pre-scan.
+ */
+export async function probeRepoFile(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<ProbeRepoFileResult> {
+  try {
+    const { data } = await octokit.repos.getContent({ owner, repo, path });
+    if (
+      data &&
+      typeof data === "object" &&
+      "content" in data &&
+      typeof (data as { content: unknown }).content === "string"
+    ) {
+      return {
+        text: Buffer.from(
+          (data as { content: string }).content,
+          "base64",
+        ).toString("utf-8"),
+        transient: false,
+      };
+    }
+    return { text: null, transient: false };
+  } catch (error) {
+    const status = getHttpStatusCode(error);
+    if (status === 404) return { text: null, transient: false };
+    rethrowIfFatal(error);
+    warn(
+      MODULE,
+      `Unexpected error fetching ${path} from ${owner}/${repo}: ${errorMessage(error)}`,
+    );
+    return { text: null, transient: true };
+  }
+}

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -16,6 +16,7 @@ import {
 } from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache, cachedRequest, cachedTimeBased } from "./http-cache.js";
+import { probeRepoFile } from "./probe-repo-file.js";
 
 const MODULE = "repo-health";
 
@@ -194,16 +195,12 @@ async function fetchContributionGuidelinesUncached(
     "contributing.md",
   ];
 
-  // Probe all paths in parallel — take the first success in priority order
+  // Probe all paths in parallel — take the first success in priority order.
+  // probeRepoFile rethrows 401/rate-limit, so those still surface here as
+  // rejected results for the pre-scan below; 404s and 5xx come back as a null
+  // text (the primitive warns on 5xx, so no extra warn is needed here).
   const results = await Promise.allSettled(
-    filesToCheck.map((file) =>
-      octokit.repos.getContent({ owner, repo, path: file }).then(({ data }) => {
-        if ("content" in data) {
-          return Buffer.from(data.content, "base64").toString("utf-8");
-        }
-        return null;
-      }),
-    ),
+    filesToCheck.map((file) => probeRepoFile(octokit, owner, repo, file)),
   );
 
   // Pre-scan: auth/rate-limit must propagate even if a faster probe succeeded —
@@ -219,22 +216,12 @@ async function fetchContributionGuidelinesUncached(
     }
   }
 
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i];
-    if (result.status === "fulfilled" && result.value) {
-      const guidelines = parseContributionGuidelines(result.value);
+  for (const result of results) {
+    if (result.status === "fulfilled" && result.value.text) {
+      const guidelines = parseContributionGuidelines(result.value.text);
       guidelinesCache.set(cacheKey, { guidelines, fetchedAt: Date.now() });
       pruneCache();
       return guidelines;
-    }
-    if (result.status === "rejected") {
-      const status = getHttpStatusCode(result.reason);
-      if (status !== 404) {
-        warn(
-          MODULE,
-          `Unexpected error fetching ${filesToCheck[i]} from ${owner}/${repo}: ${errorMessage(result.reason)}`,
-        );
-      }
     }
   }
 

--- a/packages/core/src/core/roadmap.ts
+++ b/packages/core/src/core/roadmap.ts
@@ -12,10 +12,7 @@
  */
 
 import type { Octokit } from "@octokit/rest";
-import { errorMessage, getHttpStatusCode, rethrowIfFatal } from "./errors.js";
-import { warn } from "./logger.js";
-
-const MODULE = "roadmap";
+import { probeRepoFile } from "./probe-repo-file.js";
 
 /** TTL for roadmap fetch results (1 hour). */
 const CACHE_TTL_MS = 60 * 60 * 1000;
@@ -144,24 +141,15 @@ async function fetchRoadmapIssueRefsUncached(
   cacheKey: string,
 ): Promise<Set<number>> {
   for (const path of ROADMAP_PATHS) {
-    try {
-      const { data } = await octokit.repos.getContent({ owner, repo, path });
-      if (!("content" in data)) continue;
-      const content = Buffer.from(data.content, "base64").toString("utf-8");
-      const refs = parseRoadmapIssueRefs(content, owner, repo);
-      roadmapCache.set(cacheKey, { refs, fetchedAt: Date.now() });
-      pruneCache();
-      return refs;
-    } catch (err: unknown) {
-      rethrowIfFatal(err);
-      const status = getHttpStatusCode(err);
-      if (status === 404) continue; // path missing — try next
-      warn(
-        MODULE,
-        `Unexpected error fetching ${path} from ${owner}/${repo}: ${errorMessage(err)}`,
-      );
-      // Fall through and try next path.
-    }
+    // probeRepoFile rethrows 401/rate-limit, treats 404 and non-content
+    // payloads as a null text, and warns on 5xx — all of which we degrade past
+    // by trying the next path.
+    const { text } = await probeRepoFile(octokit, owner, repo, path);
+    if (!text) continue;
+    const refs = parseRoadmapIssueRefs(text, owner, repo);
+    roadmapCache.set(cacheKey, { refs, fetchedAt: Date.now() });
+    pruneCache();
+    return refs;
   }
 
   // No roadmap found (or all probes errored softly). Cache the empty result


### PR DESCRIPTION
Closes #156. (Final sub-item; logger/ScoutStateWriter/bootstrapScout and the SearchBudgetTracker concurrency fix landed earlier.)

## What

`repo-health`, `roadmap`, and `anti-llm-policy` each re-implemented the same single-path GitHub file fetch: `getContent` → base64-decode on 200, `null` on 404, rethrow on fatal (401/rate-limit), warn on transient 5xx/network. Extracted into one shared primitive:

```ts
probeRepoFile(octokit, owner, repo, path): Promise<{ text: string | null; transient: boolean }>
```

Only the genuinely-shared single-path fetch is consolidated. Each call site keeps its own orchestration and return shape, unchanged:
- **repo-health** + **anti-llm-policy**: parallel probe (`Promise.allSettled`, first-truthy-in-priority-order wins)
- **roadmap**: sequential probe (first 200 wins)

## Behavior-preserving — the two subtleties

1. **404 vs 5xx is never collapsed.** The `transient` flag carries the distinction: 404 → `{null, transient:false}`, 5xx/network → `{null, transient:true}`, 401/rate-limit → rethrow. anti-llm-policy's "skip the no-policy cache write on a transient failure" gate still fires on `transient:true`, and repo-health's `fetchContributionGuidelines` still returns `undefined` (not a defined empty) for the no-win/transient case so the downstream transient-miss re-fetch keeps working.
2. **Fatal-across-a-parallel-batch is intact.** `probeRepoFile` throws synchronously on a fatal error, so `Promise.allSettled` records it `rejected` and each call site's unchanged pre-scan rethrows the 401/rate-limit before winner selection.

Caching keys, TTLs, in-flight dedup, negative-caching, and winner ordering are all unchanged.

## Notes

- Net -65 lines across the three call sites; dead `MODULE` consts and now-unused imports removed.
- One cosmetic change: the 5xx/network `warn` log prefix is now `probe-repo-file` instead of the per-caller module.
- The `http-cache` singleton is intentionally left as-is: unlike the budget tracker (fixed in the prior PR), it is a URL-hash-keyed content cache with no per-search `init()`/reset, so it carries no concurrency hazard and threading it through every standalone function would be churn with no behavior change.

## Tests

New `probe-repo-file.test.ts` (8 tests): 200/404/non-content/401/rate-limit/5xx/network. No existing test expectation changed. Full gate green locally: lint, format:check, typecheck, 985 core + 32 mcp.