### PR TITLE
fix: cap Phase 0's budget share so starred/broad phases run again

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -435,6 +435,78 @@ describe("IssueDiscovery", () => {
       expect(phase0Call![2].slice(0, 8)).toEqual(merged);
     });
 
+    it("caps Phase 0's share of maxResults so starred (Phase 1) still runs", async () => {
+      // Regression: Phase 0 previously took the whole budget, so the
+      // `allCandidates < maxResults` gate skipped Phase 1 even when starred
+      // repos existed. Phase 0 is now capped at ceil(maxResults * 0.5).
+      // The Phase 0 mock returns AS MANY as requested, so without the cap it
+      // would fill maxResults and gate Phase 1 out — making this non-vacuous.
+      const maxResults = 10;
+      mockFetchIssuesFromKnownRepos.mockImplementation(
+        async (
+          _octokit: unknown,
+          _vetter: unknown,
+          _repos: unknown,
+          _labels: unknown,
+          reqMax: number,
+          priority: string,
+        ) => {
+          const candidates =
+            priority === "merged_pr"
+              ? Array.from({ length: reqMax }, (_, i) =>
+                  makeCandidate(`org/merged-${i}`, "merged_pr"),
+                )
+              : [makeCandidate("org/starred-repo", "starred")];
+          return { candidates, allReposFailed: false, rateLimitHit: false };
+        },
+      );
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged-repo"]),
+        getStarredRepos: vi.fn(() => ["org/starred-repo"]),
+      });
+
+      await discovery.searchIssues({ maxResults });
+
+      // Phase 0 (first call) was capped at ceil(10 * 0.5) = 5, not 10.
+      const phase0Call = mockFetchIssuesFromKnownRepos.mock.calls[0];
+      expect(phase0Call[5]).toBe("merged_pr");
+      expect(phase0Call[4]).toBe(5);
+      // Phase 0 returned its capped 5, leaving room, so Phase 1 (starred) ran.
+      // Without the cap Phase 0 would have returned 10 and gated Phase 1 out.
+      const phase1Call = mockFetchIssuesFromKnownRepos.mock.calls.find(
+        (call) => call[5] === "starred",
+      );
+      expect(phase1Call).toBeDefined();
+    });
+
+    it("does NOT cap Phase 0 when no other strategy can run (no under-fill)", async () => {
+      // A contributed-only user (no starred repos; broad/maintained disabled)
+      // must still get the full budget from Phase 0 — the cap only applies
+      // when a later phase can actually consume the reserved share.
+      const c = makeCandidate("org/merged-repo", "merged_pr");
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [c],
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery(
+        {
+          getReposWithMergedPRs: vi.fn(() => ["org/merged-repo"]),
+          getStarredRepos: vi.fn(() => []),
+        },
+        { defaultStrategy: ["merged"] },
+      );
+
+      await discovery.searchIssues({ maxResults: 10 });
+
+      // Phase 0 got the full budget (10), not the halved cap (5).
+      const phase0Call = mockFetchIssuesFromKnownRepos.mock.calls[0];
+      expect(phase0Call[5]).toBe("merged_pr");
+      expect(phase0Call[4]).toBe(10);
+    });
+
     it("Phase 1: excludes starred repos that are already searched as open-PR repos in Phase 0", async () => {
       const c = makeCandidate("org/shared", "merged_pr");
       mockFetchIssuesFromKnownRepos.mockResolvedValue({

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -84,6 +84,16 @@ const PHASE0_PER_PAGE = 30;
  */
 const CONTRIBUTED_REPO_MAX_AGE_DAYS = 365;
 
+/**
+ * Cap on Phase 0's share of `maxResults`. Phase 0 (contributed repos) fetches
+ * deeply (`PHASE0_PER_PAGE`) and can otherwise fill the entire result budget,
+ * which makes the `allCandidates.length < maxResults` gate false for every
+ * later phase so starred (Phase 1) and broad (Phases 2/3) never run. Reserving
+ * half the budget for the other strategies keeps each search round varied
+ * instead of returning only contributed-repo results.
+ */
+const PHASE0_MAX_SHARE = 0.5;
+
 // ── Extracted types and standalone functions ──────────────────────────
 
 /** Result from a single search phase. */
@@ -719,8 +729,21 @@ export class IssueDiscovery {
     }
     const phase0RepoSet = new Set(phase0Repos);
 
+    // Only cap Phase 0 when a later phase can actually consume the reserved
+    // budget — otherwise (no starred repos, broad/maintained disabled) the
+    // reservation would just shrink the result set with nothing to fill it.
+    const otherStrategiesCanRun =
+      (starredRepos.length > 0 && enabledStrategies.has("starred")) ||
+      enabledStrategies.has("broad") ||
+      enabledStrategies.has("maintained");
+
     if (phase0Repos.length > 0 && enabledStrategies.has("merged")) {
-      const remaining = maxResults - allCandidates.length;
+      // Cap Phase 0's share so it can't consume the whole budget and starve
+      // the starred/broad phases (which gate on allCandidates < maxResults).
+      const phase0Cap = otherStrategiesCanRun
+        ? Math.max(1, Math.ceil(maxResults * PHASE0_MAX_SHARE))
+        : maxResults;
+      const remaining = Math.min(maxResults - allCandidates.length, phase0Cap);
       if (remaining > 0) {
         const result = await runPhase0(
           this.octokit,


### PR DESCRIPTION
## Summary

The contributed-repo depth bump (#244) had a side effect: Phase 0 now returns up to the full `maxResults` budget, which makes the `allCandidates.length < maxResults` gate false for every later phase. Result: **Phase 1 (starred repos) and Phases 2/3 (broad/maintained) stopped running entirely** — searches only ever returned contributed-repo results, recycling the same set every round.

## Changes

- Cap Phase 0's share at `ceil(maxResults * PHASE0_MAX_SHARE)` (0.5), reserving half the budget for the other strategies.
- **Conditional**: the cap only applies when a later phase can actually consume the reserved budget (starred repos exist + `starred` enabled, OR `broad`/`maintained` enabled). A contributed-only user (no stars, broad/maintained off) still gets the full budget, so there's no under-fill regression.

## Scope / honest caveats

- This restores **Phase 1 (starred)**. Phase 2 (broad) remains gated by its separate `skipBroadWhenSufficientResults` threshold (default 8) — if Phase 0 + Phase 1 already produce enough, broad is still skipped by design. Full round-to-round strategy rotation (a persisted cursor) is a planned follow-up, not in this PR.
- Starred search also requires the user's `starredRepos` to be populated in state, which only happens in the gist-bootstrap path today (separate follow-up for local-mode users).

## Tests

- New: Phase 0 capped at `ceil(10 * 0.5) = 5` and Phase 1 runs (non-vacuous — the Phase 0 mock returns as many as requested, so without the cap it fills `maxResults` and gates Phase 1 out).
- New: contributed-only config (no stars, `defaultStrategy: ['merged']`) gives Phase 0 the full budget (10), not the cap — guards the under-fill regression.
- Full core suite: 989 pass. Typecheck + lint + format clean.
