### PR TITLE
fix(search): rotate results across consecutive searches (#249)

### DIFF
--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -347,6 +347,21 @@ export interface SearchOptions {
    * `interPhaseDelayMs` for the rationale (#143).
    */
   broadPhaseDelayMs?: number;
+  /**
+   * Exclude issues already surfaced by a recent search so consecutive
+   * searches rotate to fresh candidates instead of returning the same set
+   * (#249). A result counts as "recently surfaced" when its `lastSeenAt`
+   * (recorded by `saveResults`) is within `recentlySurfacedTtlDays`.
+   * Defaults to `true`. Pass `false` to force-resurface (e.g. an explicit
+   * "search the same pool again" request).
+   */
+  excludeRecentlySurfaced?: boolean;
+  /**
+   * TTL in days for the `excludeRecentlySurfaced` rotation window (#249).
+   * Results last surfaced more than this many days ago are eligible to
+   * resurface. Defaults to 7.
+   */
+  recentlySurfacedTtlDays?: number;
 }
 
 /** Result of a search operation. */

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -6,6 +6,7 @@ import { ScoutStateSchema } from "./core/schemas.js";
 import type { ScoutState } from "./core/schemas.js";
 import type { IssueCandidate } from "./core/types.js";
 import type { Octokit } from "@octokit/rest";
+import { IssueDiscovery } from "./core/issue-discovery.js";
 
 vi.mock("./core/feature-discovery.js", async (importOriginal) => {
   const actual =
@@ -880,5 +881,93 @@ describe("OssScout.vetList partial-results discard (#162)", () => {
     await expect(scout.vetList({ concurrency: 1 })).rejects.toThrow(
       "Bad credentials",
     );
+  });
+});
+
+describe("OssScout.search recently-surfaced rotation (#249)", () => {
+  function savedResult(url: string, lastSeenAt: string) {
+    return {
+      issueUrl: url,
+      repo: "o/r",
+      number: 1,
+      title: "t",
+      labels: [],
+      recommendation: "approve" as const,
+      viabilityScore: 80,
+      searchPriority: "normal" as const,
+      firstSeenAt: lastSeenAt,
+      lastSeenAt,
+      lastScore: 80,
+    };
+  }
+
+  const RECENT_URL = "https://github.com/o/recent/issues/1";
+  const STALE_URL = "https://github.com/o/stale/issues/2";
+  const SKIPPED_URL = "https://github.com/o/skip/issues/3";
+
+  function makeScout(now: number) {
+    const recent = new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const stale = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
+    return new OssScout(
+      "test-token",
+      ScoutStateSchema.parse({
+        version: 1,
+        savedResults: [
+          savedResult(RECENT_URL, recent),
+          savedResult(STALE_URL, stale),
+        ],
+        skippedIssues: [
+          {
+            url: SKIPPED_URL,
+            repo: "o/skip",
+            number: 3,
+            title: "t",
+            skippedAt: recent,
+          },
+        ],
+      }),
+    );
+  }
+
+  function captureSkippedUrls() {
+    let captured: Set<string> | undefined;
+    vi.spyOn(IssueDiscovery.prototype, "searchIssues").mockImplementation(
+      async (opts: { skippedUrls?: Set<string> }) => {
+        captured = opts.skippedUrls;
+        return { candidates: [], strategiesUsed: [] };
+      },
+    );
+    return () => captured;
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("excludes results surfaced within the TTL while still excluding the skip list", async () => {
+    const scout = makeScout(Date.now());
+    const getCaptured = captureSkippedUrls();
+
+    await scout.search();
+
+    const skipped = getCaptured();
+    expect(skipped).toBeDefined();
+    // Explicit skip-list exclusion is preserved.
+    expect(skipped!.has(SKIPPED_URL)).toBe(true);
+    // A result surfaced 1 day ago is excluded so "search again" rotates.
+    expect(skipped!.has(RECENT_URL)).toBe(true);
+    // A result last surfaced 30 days ago is past the TTL and may resurface.
+    expect(skipped!.has(STALE_URL)).toBe(false);
+  });
+
+  it("does not exclude recently-surfaced results when excludeRecentlySurfaced is false", async () => {
+    const scout = makeScout(Date.now());
+    const getCaptured = captureSkippedUrls();
+
+    await scout.search({ excludeRecentlySurfaced: false });
+
+    const skipped = getCaptured();
+    expect(skipped!.has(SKIPPED_URL)).toBe(true);
+    expect(skipped!.has(RECENT_URL)).toBe(false);
   });
 });

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -231,6 +231,19 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
     const skippedUrls = new Set(
       (this.state.skippedIssues ?? []).map((s) => s.url),
     );
+
+    // Rotation (#249): also exclude issues surfaced by a recent search so
+    // consecutive searches return fresh candidates instead of the same set.
+    // Folded into the same exclusion set the issue filter already honors.
+    if (options?.excludeRecentlySurfaced ?? true) {
+      const ttlDays = options?.recentlySurfacedTtlDays ?? 7;
+      const cutoff = Date.now() - ttlDays * 24 * 60 * 60 * 1000;
+      for (const r of this.state.savedResults ?? []) {
+        const seen = Date.parse(r.lastSeenAt);
+        if (!Number.isNaN(seen) && seen >= cutoff) skippedUrls.add(r.issueUrl);
+      }
+    }
+
     const discovery = new IssueDiscovery(
       this.githubToken,
       this.state.preferences,


### PR DESCRIPTION
## Problem

Running `search` twice back-to-back returned a bit-for-bit identical candidate set: the only exclusion was the explicit skip list, so previously-surfaced-but-not-skipped issues kept reappearing. "Search again" had no way to rotate to fresh candidates.

## Fix

`OssScout.search()` now also excludes issues surfaced within a TTL (default 7 days, read from `savedResults.lastSeenAt`), folded into the same exclusion set the issue filter already honors. Added `SearchOptions.excludeRecentlySurfaced` (default `true`) and `recentlySurfacedTtlDays` (default `7`) so a caller can force-resurface the same pool.

## Tests

New rotation tests in `scout.test.ts` (recent surfaced → excluded, stale beyond TTL → eligible, skip list still excluded, opt-out honored). Full suite: 991 pass, typecheck + lint clean.

Addresses the rotation half of #249. (Quality-gate half — dropping already-merged/closed-linked-PR issues and expanding spam filtering — is tracked separately.)
