### PR TITLE
fix(discovery): count only new-repo candidates toward the broad-phase skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ oss-scout config reset                               # reset to defaults
 | `defaultStrategy` | enum[] | all | Default search strategies: merged, starred, broad, maintained |
 | `interPhaseDelayMs` | number | 30000 | Delay between search phases (rate-limit pacing) |
 | `broadPhaseDelayMs` | number | 90000 | Extra delay before the broad phase |
-| `skipBroadWhenSufficientResults` | number | 8 | Skip the broad phase once this many candidates are found (0 disables) |
+| `skipBroadWhenSufficientResults` | number | 8 | Skip the broad phase once this many candidates from **new** repos are found (0 disables). Candidates from your affinity (Phase 0) and starred (Phase 1) repos do not count, so the broad phase still runs to surface repos you haven't contributed to. |
 | `persistence` | enum | local | State storage: local or gist |
 | `preferLanguages` | string[] | [] | Soft-boost ranking for these repo languages (the `--prefer-languages` flag overrides) |
 | `preferRepos` | string[] | [] | Soft-boost ranking for these `owner/repo` slugs (the `--prefer-repos` flag overrides) |

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -1018,20 +1018,23 @@ describe("IssueDiscovery", () => {
   });
 
   describe("searchIssues — broad phase delay/skip logic", () => {
-    it("skips Phase 2 when allCandidates >= skipBroadWhenSufficientResults", async () => {
-      // Phase 0 returns enough candidates to exceed the skip threshold
-      const candidates = Array.from({ length: 15 }, (_, i) =>
-        makeCandidate(`org/repo-${i}`, "merged_pr"),
+    it("runs Phase 2 when phases 0/1 found candidates only in affinity repos", async () => {
+      // Phase 0 returns 15 candidates, all from the user's own merged-PR repos.
+      // These must NOT gate off the broad phase — otherwise an affinity-heavy
+      // user never discovers new repos (broad is the only phase that does).
+      const affinityRepos = Array.from(
+        { length: 15 },
+        (_, i) => `org/affinity-${i}`,
       );
       mockFetchIssuesFromKnownRepos.mockResolvedValue({
-        candidates,
+        candidates: affinityRepos.map((r) => makeCandidate(r, "merged_pr")),
         allReposFailed: false,
         rateLimitHit: false,
       });
       vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
 
       const discovery = makeDiscovery(
-        { getReposWithMergedPRs: vi.fn(() => ["org/repo-0"]) },
+        { getReposWithMergedPRs: vi.fn(() => affinityRepos) },
         { skipBroadWhenSufficientResults: 15 },
       );
 
@@ -1039,8 +1042,34 @@ describe("IssueDiscovery", () => {
         maxResults: 20,
       });
 
-      // Phase 2 body short-circuited by the skip threshold: no broad query
-      // ran, so "broad" must NOT be reported as used (#130)
+      expect(strategiesUsed).toContain("broad");
+      expect(mockSearchAcrossLanguagesAndLabels).toHaveBeenCalled();
+    });
+
+    it("skips Phase 2 once enough candidates come from NEW repos", async () => {
+      // The skip gate still fires, but only on candidates from repos outside the
+      // user's affinity + starred sets. (Phase 0 searches "org/seed" here while
+      // the candidates come from fresh repos — a mock decoupling that exercises
+      // the gate; in normal flow new-repo candidates only appear via the broad
+      // phase itself.)
+      const freshRepos = Array.from({ length: 15 }, (_, i) => `org/fresh-${i}`);
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: freshRepos.map((r) => makeCandidate(r, "merged_pr")),
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+      vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
+
+      const discovery = makeDiscovery(
+        { getReposWithMergedPRs: vi.fn(() => ["org/seed"]) },
+        { skipBroadWhenSufficientResults: 15 },
+      );
+
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 20,
+      });
+
+      // No broad query ran, so "broad" must NOT be reported as used (#130)
       expect(strategiesUsed).not.toContain("broad");
       expect(mockSearchAcrossLanguagesAndLabels).not.toHaveBeenCalled();
     });
@@ -1155,9 +1184,10 @@ describe("IssueDiscovery", () => {
     });
 
     it("clamps an unsatisfiable threshold to maxResults - 1 (old persisted default 15 vs maxResults 10)", async () => {
-      // 9 candidates from Phase 0: under maxResults (10), so Phase 2's gate
-      // is open; threshold 15 would never fire unclamped, but clamped to 9
-      // it skips the broad phase.
+      // 9 new-repo candidates: under maxResults (10), so Phase 2's gate is open;
+      // threshold 15 would never fire unclamped, but clamped to 9 it skips the
+      // broad phase. Phase 0 seeds an unrelated affinity repo, so all 9
+      // candidates count as "new" toward the skip gate.
       const candidates = Array.from({ length: 9 }, (_, i) =>
         makeCandidate(`org/clamp-${i}`, "merged_pr"),
       );
@@ -1169,7 +1199,7 @@ describe("IssueDiscovery", () => {
       vi.mocked(applyPerRepoCap).mockImplementation((c) => c);
 
       const discovery = makeDiscovery(
-        { getReposWithMergedPRs: vi.fn(() => ["org/clamp-0"]) },
+        { getReposWithMergedPRs: vi.fn(() => ["org/seed"]) },
         { skipBroadWhenSufficientResults: 15 },
       );
 

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -802,11 +802,20 @@ export class IssueDiscovery {
       searchBudget >= LOW_BUDGET_THRESHOLD &&
       enabledStrategies.has("broad")
     ) {
-      // Skip broad search if we already have enough candidates
-      if (skipThreshold > 0 && allCandidates.length >= skipThreshold) {
+      // Skip broad search only if we already have enough candidates from NEW
+      // repos. Phases 0/1 only ever search the user's affinity + starred repos,
+      // so counting their candidates here would gate off the broad phase — the
+      // one phase that surfaces repos the user hasn't touched. Counting
+      // only new-repo candidates keeps "sufficient results" meaning "enough NEW
+      // work", not "we re-found issues in the same repos".
+      const newRepoCandidateCount = allCandidates.filter(
+        (c) =>
+          !phase0RepoSet.has(c.issue.repo) && !starredRepoSet.has(c.issue.repo),
+      ).length;
+      if (skipThreshold > 0 && newRepoCandidateCount >= skipThreshold) {
         info(
           MODULE,
-          `Skipping broad search: already found ${allCandidates.length} candidates (threshold: ${skipThreshold})`,
+          `Skipping broad search: already found ${newRepoCandidateCount} candidate(s) from new repos (threshold: ${skipThreshold})`,
         );
       } else {
         // Always apply baseline inter-phase delay


### PR DESCRIPTION
## Problem

Phase 2 (the broad search — the only phase that discovers repos you haven't contributed to or starred) was being skipped on **every** search for users with contribution history. The skip compared the *total* candidate count against `skipBroadWhenSufficientResults`, but Phases 0 (affinity) and 1 (starred) only search your existing repos, so they alone exceed the threshold and gate off broad discovery. Result: searches re-mine the same handful of repos and never surface new ones.

## Fix

Count only candidates from repos **outside** the affinity + starred sets toward the skip threshold (`issue-discovery.ts`). "Sufficient results" now means "enough *new* work," not "re-found issues in the same repos." `0` still disables the skip.

## Tests

- New: Phase 2 runs when phases 0/1 returned >= threshold candidates that are all from affinity repos (the bug — fails before this change, passes after).
- Updated the skip-gate + clamp tests to exercise new-repo candidates.
- Core suite: 990 tests pass; lint/format/typecheck clean. (README updated.)

Half of a two-repo fix — the oss-autopilot side (expose the config key, add a `--broad` flag, drop the hardcoded `15`) follows once this releases.
