### PR TITLE
fix(bootstrap): pace bootstrap searches through the search budget tracker

### DIFF
--- a/packages/core/src/core/bootstrap.test.ts
+++ b/packages/core/src/core/bootstrap.test.ts
@@ -25,6 +25,16 @@ vi.mock("./logger.js", () => ({
   warn: () => {},
 }));
 
+// Bootstrap paces its Search API calls through the shared budget tracker
+// singleton; stub it so tests don't wait on real sliding-window pacing.
+const mockTracker = {
+  waitForBudget: vi.fn().mockResolvedValue(undefined),
+  recordCall: vi.fn(),
+};
+vi.mock("./search-budget.js", () => ({
+  getSearchBudgetTracker: () => mockTracker,
+}));
+
 const { bootstrapScout } = await import("./bootstrap.js");
 
 let tokenCounter = 0;
@@ -73,6 +83,8 @@ describe("bootstrapScout", () => {
       search: { issuesAndPullRequests: vi.fn() },
       paginate: { iterator: vi.fn() },
     };
+    mockTracker.waitForBudget.mockClear();
+    mockTracker.recordCall.mockClear();
   });
 
   it("skips when rate limit is too low", async () => {
@@ -126,6 +138,31 @@ describe("bootstrapScout", () => {
     expect(state.closedPRs).toHaveLength(1);
     expect(state.openPRs).toHaveLength(1);
     expect(state.openPRs[0].url).toBe("https://github.com/org/repo-d/pull/4");
+  });
+
+  it("paces every Search API call through the budget tracker", async () => {
+    mockRateLimit(30);
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        yield { data: [] };
+      })(),
+    );
+    mockOctokitInstance.search.issuesAndPullRequests = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { items: [makePRItem(1, "org/repo-a")] },
+      })
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ data: { items: [] } });
+
+    const token = uniqueToken();
+    const scout = new OssScout(token, makeState());
+    await bootstrapScout(scout, token);
+
+    // One merged/closed/open Search call each; waitForBudget gates and
+    // recordCall accounts for every one of them.
+    expect(mockTracker.waitForBudget).toHaveBeenCalledTimes(3);
+    expect(mockTracker.recordCall).toHaveBeenCalledTimes(3);
   });
 
   it("handles empty results", async () => {

--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -8,6 +8,10 @@ import { debug, warn } from "./logger.js";
 import { ConfigurationError, errorMessage, rethrowIfFatal } from "./errors.js";
 import { extractRepoFromUrl } from "./utils.js";
 import type { ScoutStateWriter } from "./issue-vetting.js";
+import {
+  getSearchBudgetTracker,
+  type SearchBudgetTracker,
+} from "./search-budget.js";
 
 const MODULE = "bootstrap";
 
@@ -28,6 +32,11 @@ const PER_PAGE = 100;
 export async function bootstrapScout(
   scout: ScoutStateWriter,
   token: string,
+  // Optional injected budget tracker. Defaults to the shared singleton so
+  // bootstrap paces itself against the same 30/min Search API window as the
+  // rest of the app; a host running bootstrap+search in one process shares
+  // budget accounting across both.
+  tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<BootstrapResult> {
   const username = scout.getPreferences().githubUsername;
   if (!username) {
@@ -88,11 +97,20 @@ export async function bootstrapScout(
   let mergedPRCount = 0;
   try {
     for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
-      const { data } = await octokit.search.issuesAndPullRequests({
-        q: `is:pr is:merged author:${username}`,
-        per_page: PER_PAGE,
-        page,
-      });
+      await tracker.waitForBudget();
+      let data: Awaited<
+        ReturnType<typeof octokit.search.issuesAndPullRequests>
+      >["data"];
+      try {
+        const response = await octokit.search.issuesAndPullRequests({
+          q: `is:pr is:merged author:${username}`,
+          per_page: PER_PAGE,
+          page,
+        });
+        data = response.data;
+      } finally {
+        tracker.recordCall();
+      }
 
       for (const item of data.items) {
         const repo = extractRepoFromUrl(item.html_url);
@@ -120,11 +138,20 @@ export async function bootstrapScout(
   let closedPRCount = 0;
   try {
     for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
-      const { data } = await octokit.search.issuesAndPullRequests({
-        q: `is:pr is:closed is:unmerged author:${username}`,
-        per_page: PER_PAGE,
-        page,
-      });
+      await tracker.waitForBudget();
+      let data: Awaited<
+        ReturnType<typeof octokit.search.issuesAndPullRequests>
+      >["data"];
+      try {
+        const response = await octokit.search.issuesAndPullRequests({
+          q: `is:pr is:closed is:unmerged author:${username}`,
+          per_page: PER_PAGE,
+          page,
+        });
+        data = response.data;
+      } finally {
+        tracker.recordCall();
+      }
 
       for (const item of data.items) {
         const repo = extractRepoFromUrl(item.html_url);
@@ -152,11 +179,20 @@ export async function bootstrapScout(
   let openPRCount = 0;
   try {
     for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
-      const { data } = await octokit.search.issuesAndPullRequests({
-        q: `is:pr is:open author:${username}`,
-        per_page: PER_PAGE,
-        page,
-      });
+      await tracker.waitForBudget();
+      let data: Awaited<
+        ReturnType<typeof octokit.search.issuesAndPullRequests>
+      >["data"];
+      try {
+        const response = await octokit.search.issuesAndPullRequests({
+          q: `is:pr is:open author:${username}`,
+          per_page: PER_PAGE,
+          page,
+        });
+        data = response.data;
+      } finally {
+        tracker.recordCall();
+      }
 
       for (const item of data.items) {
         const repo = extractRepoFromUrl(item.html_url);


### PR DESCRIPTION
## Summary

`bootstrapScout` issues 3 paginated `octokit.search.issuesAndPullRequests` queries (up to 9 Search API calls) directly, bypassing `SearchBudgetTracker`. This routes every bootstrap Search call through the tracker (`waitForBudget()` before, `recordCall()` after via `try/finally`), matching the pattern already used in `cachedSearchIssues` / the discovery phases.

`SearchBudgetTracker` is injected as an optional parameter defaulting to the shared singleton, same pattern used elsewhere in the codebase (e.g. `cachedSearchIssues`).

Pacing-only change: what bootstrap fetches, stores, or returns is unchanged. Error handling is unchanged too (`tracker.recordCall()` runs in a `finally`, so a failed search call still surfaces its error to the existing per-section `try/catch`).

**Limitation to note:** bootstrap and `search` run as separate processes under `action.yml` (the GitHub Action runs bootstrap immediately before search), so the in-process tracker singleton can't carry state between them there. This fix still matters for (a) library/MCP usage where bootstrap and search run in the same process and share the tracker, and (b) keeping bootstrap's own 9 calls under the 30/min window on its own.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 996 core tests + 32 mcp-server tests pass
- [x] Added a test asserting `waitForBudget`/`recordCall` are invoked once per Search API call in bootstrap