### PR TITLE
fix(github): retry transient 5xx/network errors via @octokit/plugin-retry

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "@octokit/plugin-retry": "^8.1.0",
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
     "commander": "^14.0.3",

--- a/packages/core/src/core/github.test.ts
+++ b/packages/core/src/core/github.test.ts
@@ -6,14 +6,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let mockOctokitInstance: any;
 
+const pluginSpy = vi.fn(() => {
+  return class MockOctokit {
+    constructor() {
+      return mockOctokitInstance;
+    }
+  };
+});
+
 vi.mock("@octokit/rest", () => ({
   Octokit: {
-    plugin: () =>
-      class MockOctokit {
-        constructor() {
-          return mockOctokitInstance;
-        }
-      },
+    plugin: (...plugins: unknown[]) => pluginSpy(...plugins),
   },
 }));
 
@@ -21,9 +24,21 @@ vi.mock("@octokit/plugin-throttling", () => ({
   throttling: {},
 }));
 
+vi.mock("@octokit/plugin-retry", () => ({
+  retry: {},
+}));
+
 // Must import after mocks are set up
 const { checkRateLimit, getOctokit, getRateLimitCallbacks } =
   await import("./github.js");
+const { throttling } = await import("@octokit/plugin-throttling");
+const { retry } = await import("@octokit/plugin-retry");
+
+describe("Octokit plugin composition", () => {
+  it("should compose throttling and retry plugins", () => {
+    expect(pluginSpy).toHaveBeenCalledWith(throttling, retry);
+  });
+});
 
 describe("checkRateLimit", () => {
   beforeEach(() => {

--- a/packages/core/src/core/github.ts
+++ b/packages/core/src/core/github.ts
@@ -4,11 +4,12 @@
 
 import { Octokit } from "@octokit/rest";
 import { throttling } from "@octokit/plugin-throttling";
+import { retry } from "@octokit/plugin-retry";
 import { warn } from "./logger.js";
 
 const MODULE = "github";
 
-const ThrottledOctokit = Octokit.plugin(throttling);
+const ThrottledOctokit = Octokit.plugin(throttling, retry);
 
 interface RateLimitInfo {
   remaining: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@octokit/plugin-retry':
+        specifier: ^8.1.0
+        version: 8.1.0(@octokit/core@7.0.6)
       '@octokit/plugin-throttling':
         specifier: ^11.0.3
         version: 11.0.3(@octokit/core@7.0.6)
@@ -412,6 +415,12 @@ packages:
     engines: {node: '>= 20'}
     peerDependencies:
       '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.1.0':
+    resolution: {integrity: sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
 
   '@octokit/plugin-throttling@11.0.3':
     resolution: {integrity: sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==}
@@ -1792,6 +1801,13 @@ snapshots:
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/types': 16.0.0
+
+  '@octokit/plugin-retry@8.1.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      bottleneck: 2.19.5
 
   '@octokit/plugin-throttling@11.0.3(@octokit/core@7.0.6)':
     dependencies:


### PR DESCRIPTION
## Summary
- The shared Octokit client (`packages/core/src/core/github.ts`) only handled primary/secondary rate limiting via `@octokit/plugin-throttling`. Transient 5xx responses and network errors weren't retried at all.
- Added `@octokit/plugin-retry@^8.1.0` and composed it via `Octokit.plugin(throttling, retry)`, leaving the existing `onRateLimit`/`onSecondaryRateLimit` config untouched.
- Version choice: installed `@octokit/core` resolves to `7.0.6`. `plugin-retry` 7.2.1/8.0.0 only require `@octokit/core >=6`; 8.1.0 is the first to require `>=7`, so it's the version whose peer range is actually scoped to the installed core major.
- `plugin-retry`'s default `doNotRetry` list already excludes 403 (GitHub's rate-limit status), so there's no double-handling with `plugin-throttling` — no `doNotRetry` override needed.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean for `packages/core`
- [x] `pnpm run test` — 996 tests passed (core), 32 passed (mcp-server)
- [x] `pnpm --filter @oss-scout/core run bundle` — succeeds; confirmed `doNotRetry` marker present in `dist/cli.bundle.cjs`
- [x] Extended `github.test.ts` with a spy asserting `Octokit.plugin` is composed with `(throttling, retry)`