### PR TITLE
perf(vetting): ETag-cache doc probes and health commits so revalidation is rate-limit-free

### DIFF
--- a/packages/core/src/core/anti-llm-policy.test.ts
+++ b/packages/core/src/core/anti-llm-policy.test.ts
@@ -51,6 +51,14 @@ vi.mock("./http-cache.js", () => ({
     getIfFresh: vi.fn(() => null),
     set: vi.fn(),
   })),
+  // Pass-through: probeRepoFile now routes its getContent through cachedRequest.
+  // Exercise the real fetcher here; ETag behavior is covered in http-cache and
+  // probe-repo-file.etag tests.
+  cachedRequest: async (
+    _cache: unknown,
+    _url: string,
+    fetcher: (headers: Record<string, string>) => Promise<{ data: unknown }>,
+  ) => (await fetcher({})).data,
 }));
 
 import {

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -23,6 +23,19 @@ vi.mock("./http-cache.js", () => ({
     getIfFresh: vi.fn(() => null),
     set: vi.fn(),
   })),
+  // Pass-through: probeRepoFile routes getContent through cachedRequest, so
+  // rate-limit/404 errors from the octokit mocks must still reach it unchanged.
+  cachedRequest: async (
+    _cache: unknown,
+    _url: string,
+    fetcher: (headers: Record<string, string>) => Promise<{ data: unknown }>,
+  ) => (await fetcher({})).data,
+  cachedTimeBased: async (
+    _cache: unknown,
+    _key: string,
+    _ttl: number,
+    fetcher: () => Promise<unknown>,
+  ) => fetcher(),
 }));
 vi.mock("./search-budget.js", () => ({
   getSearchBudgetTracker: vi.fn(() => ({

--- a/packages/core/src/core/probe-repo-file.etag.test.ts
+++ b/packages/core/src/core/probe-repo-file.etag.test.ts
@@ -22,7 +22,10 @@ vi.mock("./http-cache.js", async () => {
 });
 
 /** An HTTP-shaped error with a numeric status (Octokit RequestError shape). */
-function httpError(status: number, message: string): Error & { status: number } {
+function httpError(
+  status: number,
+  message: string,
+): Error & { status: number } {
   const err = new Error(message) as Error & { status: number };
   err.status = status;
   return err;
@@ -34,7 +37,10 @@ function base64(text: string): string {
 
 /** Octokit mock whose getContent runs the supplied per-call implementation. */
 function makeOctokit(
-  impl: (args: { path: string; headers?: Record<string, string> }) => Promise<unknown>,
+  impl: (args: {
+    path: string;
+    headers?: Record<string, string>;
+  }) => Promise<unknown>,
 ): { octokit: Octokit; getContent: ReturnType<typeof vi.fn> } {
   const getContent = vi.fn(impl);
   const octokit = { repos: { getContent } } as unknown as Octokit;

--- a/packages/core/src/core/probe-repo-file.etag.test.ts
+++ b/packages/core/src/core/probe-repo-file.etag.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { HttpCache } from "./http-cache.js";
+import { probeRepoFile } from "./probe-repo-file.js";
+import type { Octokit } from "@octokit/rest";
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+// Real cachedRequest/HttpCache, but point getHttpCache at a per-test temp dir so
+// the ETag path is exercised end-to-end without touching ~/.oss-scout/cache.
+let cache: HttpCache;
+vi.mock("./http-cache.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./http-cache.js")>("./http-cache.js");
+  return { ...actual, getHttpCache: () => cache };
+});
+
+/** An HTTP-shaped error with a numeric status (Octokit RequestError shape). */
+function httpError(status: number, message: string): Error & { status: number } {
+  const err = new Error(message) as Error & { status: number };
+  err.status = status;
+  return err;
+}
+
+function base64(text: string): string {
+  return Buffer.from(text, "utf-8").toString("base64");
+}
+
+/** Octokit mock whose getContent runs the supplied per-call implementation. */
+function makeOctokit(
+  impl: (args: { path: string; headers?: Record<string, string> }) => Promise<unknown>,
+): { octokit: Octokit; getContent: ReturnType<typeof vi.fn> } {
+  const getContent = vi.fn(impl);
+  const octokit = { repos: { getContent } } as unknown as Octokit;
+  return { octokit, getContent };
+}
+
+let tmpDir: string;
+
+describe("probeRepoFile ETag caching", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oss-scout-probe-etag-"));
+    cache = new HttpCache(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("caches a 200 body and returns identical content on a subsequent 304", async () => {
+    const { octokit, getContent } = makeOctokit(async ({ headers }) => {
+      // First call: no conditional header, serve the file + ETag.
+      if (!headers?.["if-none-match"]) {
+        return {
+          data: { content: base64("hello world") },
+          headers: { etag: "etag-1" },
+        };
+      }
+      // Second call: the stored ETag is replayed — respond 304.
+      expect(headers["if-none-match"]).toBe("etag-1");
+      throw httpError(304, "Not Modified");
+    });
+
+    const first = await probeRepoFile(octokit, "o", "r", "CONTRIBUTING.md");
+    const second = await probeRepoFile(octokit, "o", "r", "CONTRIBUTING.md");
+
+    expect(first).toEqual({ text: "hello world", transient: false });
+    expect(second).toEqual(first);
+    expect(getContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a 404: a known-absent path stays a miss (no phantom file)", async () => {
+    const { octokit, getContent } = makeOctokit(async () => {
+      throw httpError(404, "Not Found");
+    });
+
+    const first = await probeRepoFile(octokit, "o", "r", "CONTRIBUTING.md");
+    const second = await probeRepoFile(octokit, "o", "r", "CONTRIBUTING.md");
+
+    expect(first).toEqual({ text: null, transient: false });
+    expect(second).toEqual({ text: null, transient: false });
+    // Both probes hit the network (no phantom cache entry masking the absence),
+    // and nothing was written to the ETag cache for this path.
+    expect(getContent).toHaveBeenCalledTimes(2);
+    expect(cache.get("/repos/o/r/contents/CONTRIBUTING.md")).toBeNull();
+  });
+
+  it("still surfaces the decoded content when the 304 body was cached earlier", async () => {
+    // A repo whose doc later 304s must not degrade to a null text — the cached
+    // body has to flow back through the base64 decode path.
+    const { octokit } = makeOctokit(async ({ headers }) => {
+      if (!headers?.["if-none-match"]) {
+        return {
+          data: { content: base64("# Roadmap\n#42") },
+          headers: { etag: "rm-1" },
+        };
+      }
+      throw httpError(304, "Not Modified");
+    });
+
+    await probeRepoFile(octokit, "o", "r", "ROADMAP.md");
+    const revalidated = await probeRepoFile(octokit, "o", "r", "ROADMAP.md");
+    expect(revalidated).toEqual({ text: "# Roadmap\n#42", transient: false });
+  });
+});

--- a/packages/core/src/core/probe-repo-file.test.ts
+++ b/packages/core/src/core/probe-repo-file.test.ts
@@ -9,6 +9,21 @@ vi.mock("./logger.js", () => ({
   info: vi.fn(),
 }));
 
+// Pass-through http-cache so these unit tests exercise the real fetcher without
+// touching the on-disk ETag cache. ETag-specific behavior is covered separately
+// in probe-repo-file.etag.test.ts against a real HttpCache.
+vi.mock("./http-cache.js", () => ({
+  getHttpCache: () => ({}),
+  cachedRequest: async (
+    _cache: unknown,
+    _url: string,
+    fetcher: (headers: Record<string, string>) => Promise<{ data: unknown }>,
+  ) => {
+    const response = await fetcher({});
+    return response.data;
+  },
+}));
+
 /** An HTTP-shaped error with a numeric status (Octokit RequestError shape). */
 function httpError(
   status: number,

--- a/packages/core/src/core/probe-repo-file.ts
+++ b/packages/core/src/core/probe-repo-file.ts
@@ -22,6 +22,7 @@
 import type { Octokit } from "@octokit/rest";
 import { errorMessage, getHttpStatusCode, rethrowIfFatal } from "./errors.js";
 import { warn } from "./logger.js";
+import { getHttpCache, cachedRequest } from "./http-cache.js";
 
 const MODULE = "probe-repo-file";
 
@@ -50,6 +51,13 @@ export interface ProbeRepoFileResult {
  * a faster path may have already resolved) must inspect the rejected reasons
  * themselves; this primitive only rethrows for the single path it owns. See
  * repo-health and anti-llm-policy for that pre-scan.
+ *
+ * Successful (200) responses are ETag-cached: a later probe of the same path
+ * revalidates with `If-None-Match`, so an unchanged doc comes back as a 304
+ * that costs zero primary rate-limit quota. Only 200 bodies are cached here —
+ * 404s (file absent) still surface as rejections that this function's own catch
+ * maps to a clean `null`, exactly as before, and the per-caller negative caches
+ * (guidelines/roadmap Maps, anti-llm time cache) continue to handle absences.
  */
 export async function probeRepoFile(
   octokit: Octokit,
@@ -58,7 +66,18 @@ export async function probeRepoFile(
   path: string,
 ): Promise<ProbeRepoFileResult> {
   try {
-    const { data } = await octokit.repos.getContent({ owner, repo, path });
+    // ETag-revalidate the content GET. cachedRequest only intercepts 304
+    // (returning the cached body); a 404 or fatal error propagates untouched to
+    // the catch below, preserving the "file absent" semantics callers depend on.
+    const data = await cachedRequest<unknown>(
+      getHttpCache(),
+      `/repos/${owner}/${repo}/contents/${path}`,
+      (headers) =>
+        octokit.repos.getContent({ owner, repo, path, headers }) as Promise<{
+          data: unknown;
+          headers: Record<string, string>;
+        }>,
+    );
     if (
       data &&
       typeof data === "object" &&

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -98,12 +98,25 @@ export async function checkProjectHealth(
             }>,
         );
 
-        // Get recent commits
-        const { data: commits } = await octokit.repos.listCommits({
-          owner,
-          repo,
-          per_page: 1,
-        });
+        // Get recent commits (ETag-cached — an unchanged tip revalidates as a
+        // free 304 once the surrounding health TTL expires).
+        const commitsUrl = `/repos/${owner}/${repo}/commits?per_page=1`;
+        const commits = await cachedRequest(
+          cache,
+          commitsUrl,
+          (headers) =>
+            octokit.repos.listCommits({
+              owner,
+              repo,
+              per_page: 1,
+              headers,
+            }) as Promise<{
+              data: Array<{
+                commit?: { author?: { date?: string } | null } | null;
+              }>;
+              headers: Record<string, string>;
+            }>,
+        );
 
         const lastCommit = commits[0];
         const lastCommitAt =

--- a/packages/core/src/core/roadmap.test.ts
+++ b/packages/core/src/core/roadmap.test.ts
@@ -1,4 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Pass-through http-cache: probeRepoFile now routes its getContent through
+// cachedRequest. Exercise the real fetcher here without touching the on-disk
+// ETag cache; ETag behavior is covered in probe-repo-file.etag tests.
+vi.mock("./http-cache.js", () => ({
+  getHttpCache: () => ({}),
+  cachedRequest: async (
+    _cache: unknown,
+    _url: string,
+    fetcher: (headers: Record<string, string>) => Promise<{ data: unknown }>,
+  ) => (await fetcher({})).data,
+}));
+
 import {
   parseRoadmapIssueRefs,
   fetchRoadmapIssueRefs,


### PR DESCRIPTION
## What

Wires the existing ETag conditional-request layer (`cachedRequest` in `http-cache.ts`) underneath the per-candidate vetting doc probes and the project-health commit check.

Per-candidate vetting issues ~11 `getContent` probes cold (CONTRIBUTING family, CODE_OF_CONDUCT, README, ROADMAP for feature mode) plus a `listCommits(per_page:1)` tip check in `checkProjectHealth`. These sat behind time-based caches (guidelines 1h, anti-LLM 1h, health 4h). Within the TTL the HTTP request is skipped entirely, but once the TTL expires every probe paid full primary rate-limit cost again on the refetch.

This change routes the single shared `getContent` primitive (`probeRepoFile`, used by `repo-health.ts`, `anti-llm-policy.ts`, and `roadmap.ts`) and `checkProjectHealth`'s `listCommits` through `cachedRequest`. The ETag layer sits *underneath* the existing TTL caches: when a TTL expires, the refetch sends `If-None-Match` and an unchanged doc comes back as a `304 Not Modified`, which costs zero primary rate-limit quota. The 4-way parallel fan-out per doc family is unchanged; 304s make those bursts cheap.

## 404 handling: minimal option (only 200 bodies get ETag-cached)

404 semantics are load-bearing (a 404 means "this repo has no CONTRIBUTING at that path" and callers depend on it), so I took the minimal, obviously-correct option:

- `cachedRequest` only intercepts HTTP **304** (returning the cached body). Every other error, 404 included, propagates untouched to `probeRepoFile`'s existing catch, which maps 404 to a clean `null` exactly as before.
- Only successful 200 responses get an ETag entry. Known-absent paths keep whatever negative caching exists today (the guidelines/roadmap in-memory Maps, the anti-LLM time cache). No new negative ETag caching was invented.
- Rate-limit and 401 auth errors still propagate (rethrowIfFatal semantics unchanged), including through the parallel pre-scan in `repo-health.ts` / `anti-llm-policy.ts`.

The TTL layers are preserved — the ETag round-trip only happens after a TTL miss, so within-TTL access still short-circuits with no HTTP request.

## Tests

- `probe-repo-file.etag.test.ts` (new): 200-then-304 returns identical parsed content; a 404 stays a miss with no phantom cache entry; the cached 304 body flows back through the base64 decode path. Runs against a real `HttpCache` in a temp dir.
- Existing caller tests updated with pass-through `http-cache` mocks (matching the established `repo-health.test.ts` pattern) so `probeRepoFile`'s Octokit error paths keep being exercised.
- Full suite green: core 998 passed, mcp-server 32 passed. Lint + typecheck clean.