### PR TITLE
feat(vetting): batch merged-PR repo checks via GraphQL search to free the Search API budget

### DIFF
--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -221,13 +221,25 @@ export async function checkNoExistingPR(
 }
 
 /** TTL for cached merged-PR counts per repo (15 minutes). */
-const MERGED_PR_CACHE_TTL_MS = 15 * 60 * 1000;
+export const MERGED_PR_CACHE_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * Cache key for a repo's merged-PR count. Exported so the batched GraphQL
+ * prefetch (issue-graphql.ts) writes to the exact same key this per-call path
+ * reads — the prefetch simply pre-populates the cache and every later
+ * per-repo call short-circuits on the cache hit below (#182).
+ */
+export function mergedPRsCacheKey(owner: string, repo: string): string {
+  return versionedCacheKey(`merged-prs:${owner}/${repo}`);
+}
 
 /**
  * Check how many merged PRs the authenticated user has in a repo.
  * Uses GitHub Search API. Returns 0 on error (non-fatal).
  * Results are cached per-repo for 15 minutes to avoid redundant Search API
- * calls when multiple issues from the same repo are vetted.
+ * calls when multiple issues from the same repo are vetted. The batched
+ * GraphQL prefetch populates this same cache, so a warmed repo never reaches
+ * the Search API here at all (#182).
  */
 export async function checkUserMergedPRsInRepo(
   octokit: Octokit,
@@ -239,7 +251,7 @@ export async function checkUserMergedPRsInRepo(
   tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<number | null> {
   const cache = getHttpCache();
-  const cacheKey = versionedCacheKey(`merged-prs:${owner}/${repo}`);
+  const cacheKey = mergedPRsCacheKey(owner, repo);
 
   // In-flight dedup: parallel vetting frequently hits several issues from
   // one repo at once, and each used to pay a separate Search API call

--- a/packages/core/src/core/issue-graphql.ts
+++ b/packages/core/src/core/issue-graphql.ts
@@ -20,6 +20,8 @@
 import type { Octokit } from "@octokit/rest";
 import { rethrowIfFatal, errorMessage } from "./errors.js";
 import { warn } from "./logger.js";
+import { getHttpCache } from "./http-cache.js";
+import { mergedPRsCacheKey } from "./issue-eligibility.js";
 
 const MODULE = "issue-graphql";
 
@@ -170,4 +172,190 @@ export async function prefetchIssueCores(
   });
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Batched merged-PR counts (#182)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strict validation for the owner/repo/username segments that go into a
+ * GraphQL `search` query string. GitHub allows `[A-Za-z0-9_.-]` in these
+ * segments. Even though the query strings are passed as GraphQL *variables*
+ * (never interpolated into the query document), a malformed segment would
+ * still corrupt the `is:pr is:merged author:… repo:…/…` filter, so anything
+ * failing this is dropped and left to the REST fallback (which validates via
+ * the GitHub API itself).
+ */
+const GH_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
+
+/** A repo whose merged-PR count should be prefetched. */
+export interface MergedPRRepoRef {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Repos per GraphQL merged-PR batch. A `search` connection with `first: 1`
+ * (we only read `issueCount`) is cheap — a handful of aliased searches
+ * empirically cost ~1 GraphQL point total — so this stays well under the
+ * GraphQL complexity limit while collapsing many REST Search calls into one.
+ */
+const MERGED_PR_BATCH_SIZE = 15;
+
+/**
+ * Shape of the aliased search response plus the `viewer` identity probe:
+ * `{ viewer: { login }, r0: { issueCount }, r1: … }`.
+ */
+interface MergedPRBatchResponse {
+  viewer?: { login: string } | null;
+  [alias: string]:
+    | { issueCount: number }
+    | { login: string }
+    | null
+    | undefined;
+}
+
+/**
+ * Batch-fetch how many merged PRs `username` has authored in each repo via
+ * aliased GraphQL `search` connections, writing each result into the HTTP
+ * cache under the SAME key `checkUserMergedPRsInRepo` reads (`mergedPRsCacheKey`).
+ *
+ * This replaces scout's dominant REST Search-API consumer: the per-repo
+ * `search.issuesAndPullRequests` call. A GraphQL `search` connection bills the
+ * GraphQL points bucket (5000/hr), NOT the REST Search bucket (30/min), so
+ * these calls are deliberately NOT recorded against the SearchBudgetTracker.
+ *
+ * Fallback semantics mirror {@link prefetchIssueCores}: fatal errors (401 /
+ * rate limit) propagate via `rethrowIfFatal`; a partial-data GraphQL error
+ * keeps the aliases that resolved; any repo not written to the cache simply
+ * falls back to the existing REST path in `checkUserMergedPRsInRepo`.
+ *
+ * No-ops when `username` is empty or invalid — the GraphQL `author:` filter
+ * needs a concrete login, and the REST path already handles that case with
+ * `author:@me`.
+ *
+ * Identity safety: the prefetch searches `author:${username}` while the REST
+ * fallback (`checkUserMergedPRsInRepo`) searches `author:@me` (the token's real
+ * identity). If `getGitHubUsername()` is stale or misconfigured, a successful
+ * `author:${username}` search would otherwise cache a count for the WRONG
+ * account and suppress the authoritative `@me` query for the cache TTL. To
+ * prevent that, each batch also selects `viewer { login }` in the same
+ * round-trip and only warms the cache when it equals `username`; on any
+ * mismatch the cache is left cold and the REST `@me` path answers.
+ */
+export async function prefetchMergedPRCounts(
+  octokit: Octokit,
+  username: string,
+  repos: MergedPRRepoRef[],
+): Promise<void> {
+  if (repos.length === 0) return;
+  if (!GH_NAME_PATTERN.test(username)) {
+    warn(
+      MODULE,
+      `Skipping merged-PR prefetch: username failed validation (falling back to REST)`,
+    );
+    return;
+  }
+
+  // Dedup by owner/repo and drop anything failing strict validation.
+  const seen = new Set<string>();
+  const valid: MergedPRRepoRef[] = [];
+  for (const r of repos) {
+    const full = `${r.owner}/${r.repo}`;
+    if (seen.has(full)) continue;
+    seen.add(full);
+    if (!GH_NAME_PATTERN.test(r.owner) || !GH_NAME_PATTERN.test(r.repo)) {
+      warn(
+        MODULE,
+        `Skipping merged-PR prefetch for "${full}": failed validation (falling back to REST)`,
+      );
+      continue;
+    }
+    valid.push(r);
+  }
+  if (valid.length === 0) return;
+
+  const cache = getHttpCache();
+  const batches: Promise<void>[] = [];
+  for (let i = 0; i < valid.length; i += MERGED_PR_BATCH_SIZE) {
+    batches.push(
+      fetchMergedPRBatch(
+        octokit,
+        username,
+        valid.slice(i, i + MERGED_PR_BATCH_SIZE),
+        cache,
+      ),
+    );
+  }
+  await Promise.all(batches);
+}
+
+/** Fetch one batch of merged-PR counts and write resolved ones to the cache. */
+async function fetchMergedPRBatch(
+  octokit: Octokit,
+  username: string,
+  repos: MergedPRRepoRef[],
+  cache: ReturnType<typeof getHttpCache>,
+): Promise<void> {
+  const varDefs: string[] = [];
+  // `viewer { login }` folds an identity check into the same round-trip (see
+  // the fn doc): we only trust prefetched counts when the authenticated login
+  // matches `username`.
+  const selections: string[] = ["viewer { login }"];
+  const variables: Record<string, string> = {};
+  repos.forEach((r, i) => {
+    varDefs.push(`$q${i}: String!`);
+    // The query text is a GraphQL variable — user data never touches the query
+    // document. Segments are already validated against GH_NAME_PATTERN.
+    variables[`q${i}`] =
+      `is:pr is:merged author:${username} repo:${r.owner}/${r.repo}`;
+    selections.push(
+      `r${i}: search(query: $q${i}, type: ISSUE, first: 1) { issueCount }`,
+    );
+  });
+  const query = `query batchMergedPRCounts(${varDefs.join(", ")}) {\n${selections.join("\n")}\n}`;
+
+  let data: MergedPRBatchResponse | undefined;
+  try {
+    data = await octokit.graphql<MergedPRBatchResponse>(query, variables);
+  } catch (err) {
+    rethrowIfFatal(err);
+    // octokit attaches resolved aliases to `.data` when only some searches
+    // errored; keep those and let the rest fall back to REST.
+    const partial = (err as { data?: MergedPRBatchResponse }).data;
+    if (partial) {
+      data = partial;
+    } else {
+      warn(
+        MODULE,
+        `Merged-PR prefetch batch failed, falling back to REST: ${errorMessage(err)}`,
+      );
+      return;
+    }
+  }
+
+  // Identity gate: only warm the cache when the authenticated user (whom the
+  // REST `@me` fallback would query) is the same login we searched. On a
+  // mismatch or an unreadable viewer, cache nothing so the authoritative REST
+  // path answers instead of serving a wrong-account count.
+  const viewerLogin = data?.viewer?.login;
+  if (!viewerLogin || viewerLogin.toLowerCase() !== username.toLowerCase()) {
+    if (viewerLogin) {
+      warn(
+        MODULE,
+        `Merged-PR prefetch identity mismatch (configured username != authenticated login); leaving cache cold so REST @me answers`,
+      );
+    }
+    return;
+  }
+
+  repos.forEach((r, i) => {
+    const alias = data?.[`r${i}`];
+    const count = alias && "issueCount" in alias ? alias.issueCount : undefined;
+    // A missing alias (partial error) leaves the cache cold so the per-call
+    // REST path fetches it. Only cache concrete numeric counts.
+    if (typeof count !== "number") return;
+    cache.set(mergedPRsCacheKey(r.owner, r.repo), "", count);
+  });
 }

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -65,6 +65,10 @@ vi.mock("./issue-eligibility.js", () => ({
   checkNotClaimed: vi.fn().mockResolvedValue({ passed: true }),
   checkUserMergedPRsInRepo: vi.fn().mockResolvedValue(0),
   analyzeRequirements: vi.fn(() => true),
+  // Imported by issue-graphql's merged-PR prefetch (#182) to build the cache
+  // key it writes; keep it consistent with the real implementation's shape.
+  mergedPRsCacheKey: (owner: string, repo: string) =>
+    `v1:merged-prs:${owner}/${repo}`,
 }));
 
 vi.mock("./repo-health.js", () => ({
@@ -841,6 +845,95 @@ describe("IssueVetter", () => {
       expect(getSpy).toHaveBeenCalledWith(
         expect.objectContaining({ issue_number: 2 }),
       );
+    });
+
+    it("prefetches merged-PR counts only for repos not already known (#182)", async () => {
+      // graphql serves both the issue-core batch and the merged-PR batch;
+      // the merged-PR query is the one containing a `search(` selection.
+      const graphql = vi.fn().mockImplementation((query: string) => {
+        if (query.includes("search(")) {
+          return Promise.resolve({ r0: { issueCount: 0 } });
+        }
+        // Empty core batch → both issues fall back to REST issues.get.
+        return Promise.resolve({});
+      });
+      const octokit = {
+        issues: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              id: 1,
+              html_url: "https://github.com/owner/repo1/issues/1",
+              title: "Issue",
+              body: "1. repro\n2. expected\n```code```",
+              comments: 0,
+              labels: [],
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-03-01T00:00:00Z",
+            },
+          }),
+        },
+        graphql,
+      } as unknown as Octokit;
+      const vetter = new IssueVetter(
+        octokit,
+        makeStubStateReader({
+          getGitHubUsername: vi.fn(() => "octocat"),
+          // repo1 is already known → must be excluded from the prefetch.
+          getReposWithMergedPRs: vi.fn(() => ["owner/repo1"]),
+        }),
+      );
+
+      await vetter.vetIssuesParallel(
+        [
+          "https://github.com/owner/repo1/issues/1",
+          "https://github.com/owner/repo2/issues/2",
+        ],
+        10,
+      );
+
+      const searchCall = graphql.mock.calls.find(([q]) =>
+        (q as string).includes("search("),
+      );
+      expect(searchCall).toBeTruthy();
+      const [, variables] = searchCall as [string, Record<string, string>];
+      const serialized = JSON.stringify(variables);
+      expect(serialized).toContain("repo:owner/repo2");
+      // The already-known repo is skipped — it never reaches the Search API.
+      expect(serialized).not.toContain("repo:owner/repo1");
+    });
+
+    it("does not prefetch merged-PR counts when the username is unknown (#182)", async () => {
+      const graphql = vi.fn().mockResolvedValue({});
+      const octokit = {
+        issues: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              id: 1,
+              html_url: "https://github.com/owner/repo/issues/1",
+              title: "Issue",
+              body: "1. repro\n2. expected\n```code```",
+              comments: 0,
+              labels: [],
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-03-01T00:00:00Z",
+            },
+          }),
+        },
+        graphql,
+      } as unknown as Octokit;
+      // makeStubStateReader has no getGitHubUsername → prefetch is skipped.
+      const vetter = new IssueVetter(octokit, makeStubStateReader());
+
+      await vetter.vetIssuesParallel(
+        ["https://github.com/owner/repo/issues/1"],
+        10,
+      );
+
+      // Only the issue-core batch runs; no merged-PR search query is issued.
+      const searchCall = graphql.mock.calls.find(([q]) =>
+        (q as string).includes("search("),
+      );
+      expect(searchCall).toBeUndefined();
     });
 
     it("propagates 401 auth errors instead of swallowing per-item", async () => {

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -46,8 +46,10 @@ import {
 import { fetchAndScanAntiLLMPolicy } from "./anti-llm-policy.js";
 import {
   prefetchIssueCores,
+  prefetchMergedPRCounts,
   issueCoreKey,
   type PrefetchedIssueCore,
+  type MergedPRRepoRef,
 } from "./issue-graphql.js";
 import { getHttpCache, versionedCacheKey } from "./http-cache.js";
 import {
@@ -688,6 +690,37 @@ export class IssueVetter {
   }
 
   /**
+   * Batch-prefetch merged-PR counts for the repos in a vetting batch (#182),
+   * warming the cache `checkUserMergedPRsInRepo` reads so each per-repo Search
+   * API call becomes a cache hit.
+   *
+   * Two repos are intentionally excluded:
+   * - Repos already known to have the user's merged PRs
+   *   (`getReposWithMergedPRs`): `vetIssue` short-circuits those to a merged
+   *   count of 1 and never calls the Search API, so prefetching them is waste.
+   * - Everything, when the GitHub username is unknown: the GraphQL `author:`
+   *   filter needs a concrete login and the REST path falls back to `@me`.
+   */
+  private async prefetchMergedPRCounts(
+    issueRefs: MergedPRRepoRef[],
+  ): Promise<void> {
+    const username = this.stateReader.getGitHubUsername?.() ?? "";
+    if (!username) return;
+
+    const alreadyKnown = new Set(this.stateReader.getReposWithMergedPRs());
+    const seen = new Set<string>();
+    const repos: MergedPRRepoRef[] = [];
+    for (const { owner, repo } of issueRefs) {
+      const full = `${owner}/${repo}`;
+      if (alreadyKnown.has(full) || seen.has(full)) continue;
+      seen.add(full);
+      repos.push({ owner, repo });
+    }
+    if (repos.length === 0) return;
+    await prefetchMergedPRCounts(this.octokit, username, repos);
+  }
+
+  /**
    * Vet multiple issues in parallel with concurrency limit
    */
   async vetIssuesParallel(
@@ -722,15 +755,21 @@ export class IssueVetter {
     // from the map and vetIssue falls back to REST for it. A fatal error (401 /
     // rate limit) propagates out of prefetchIssueCores and aborts the batch,
     // matching the per-issue auth-error handling below.
-    const prefetched = await prefetchIssueCores(
-      this.octokit,
-      uniqueUrls.flatMap((url) => {
-        const p = parseGitHubUrl(url);
-        return p && p.type === "issues"
-          ? [{ owner: p.owner, repo: p.repo, number: p.number }]
-          : [];
-      }),
-    );
+    const issueRefs = uniqueUrls.flatMap((url) => {
+      const p = parseGitHubUrl(url);
+      return p && p.type === "issues"
+        ? [{ owner: p.owner, repo: p.repo, number: p.number }]
+        : [];
+    });
+    // Two independent GraphQL prefetches run concurrently: issue cores (#169)
+    // and merged-PR counts (#182). The merged-PR prefetch pre-populates the
+    // same cache checkUserMergedPRsInRepo reads, replacing scout's dominant
+    // REST Search-API consumer with a single batched GraphQL query per ~15
+    // repos (which bills the GraphQL points bucket, not the Search bucket).
+    const [prefetched] = await Promise.all([
+      prefetchIssueCores(this.octokit, issueRefs),
+      this.prefetchMergedPRCounts(issueRefs),
+    ]);
     const prefetchFor = (url: string): PrefetchedIssueCore | undefined => {
       const p = parseGitHubUrl(url);
       return p && p.type === "issues"

--- a/packages/core/src/core/merged-pr-prefetch.test.ts
+++ b/packages/core/src/core/merged-pr-prefetch.test.ts
@@ -157,7 +157,9 @@ describe("prefetchMergedPRCounts", () => {
     const search = vi.fn();
     const octokit = makeOctokit(graphql, search);
 
-    await prefetchMergedPRCounts(octokit, "octocat", [{ owner: "o1", repo: "r1" }]);
+    await prefetchMergedPRCounts(octokit, "octocat", [
+      { owner: "o1", repo: "r1" },
+    ]);
     const count = await checkUserMergedPRsInRepo(octokit, "o1", "r1");
 
     expect(count).toBe(5);
@@ -243,7 +245,9 @@ describe("prefetchMergedPRCounts", () => {
     const search = vi.fn().mockResolvedValue({ data: { total_count: 4 } });
     const octokit = makeOctokit(graphql, search);
 
-    await prefetchMergedPRCounts(octokit, "octocat", [{ owner: "o1", repo: "r1" }]);
+    await prefetchMergedPRCounts(octokit, "octocat", [
+      { owner: "o1", repo: "r1" },
+    ]);
     expect(cacheStub.set).not.toHaveBeenCalled();
 
     // The per-call path falls through to the authoritative REST @me query.
@@ -253,9 +257,10 @@ describe("prefetchMergedPRCounts", () => {
   });
 
   it("matches the authenticated login case-insensitively", async () => {
-    const graphql = vi
-      .fn()
-      .mockResolvedValue({ viewer: { login: "OctoCat" }, r0: { issueCount: 6 } });
+    const graphql = vi.fn().mockResolvedValue({
+      viewer: { login: "OctoCat" },
+      r0: { issueCount: 6 },
+    });
     await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", [
       { owner: "o1", repo: "r1" },
     ]);

--- a/packages/core/src/core/merged-pr-prefetch.test.ts
+++ b/packages/core/src/core/merged-pr-prefetch.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Octokit } from "@octokit/rest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+//
+// A single stateful cache stub shared across both modules under test:
+// prefetchMergedPRCounts (issue-graphql) writes to it, and
+// checkUserMergedPRsInRepo (issue-eligibility) reads from it. This proves the
+// two paths agree on the cache key (via the shared mergedPRsCacheKey helper).
+
+const cacheStub = vi.hoisted(() => {
+  const store = new Map<string, { body: unknown; at: number }>();
+  return {
+    store,
+    getIfFresh: vi.fn((key: string, maxAgeMs: number) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      if (Date.now() - entry.at > maxAgeMs) return null;
+      return entry.body;
+    }),
+    set: vi.fn((key: string, _etag: string, body: unknown) => {
+      store.set(key, { body, at: Date.now() });
+    }),
+  };
+});
+
+vi.mock("./http-cache.js", () => ({
+  versionedCacheKey: (key: string) => `v1:${key}`,
+  getHttpCache: () => cacheStub,
+  // Passthrough — dedup itself is covered in http-cache.test.ts.
+  withInflightDedup: async (
+    _cache: unknown,
+    _key: string,
+    fn: () => Promise<unknown>,
+  ) => fn(),
+}));
+
+vi.mock("./logger.js", () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("./search-budget.js", () => ({
+  getSearchBudgetTracker: vi.fn(() => ({
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+    recordCall: vi.fn(),
+  })),
+}));
+
+vi.mock("./pagination.js", () => ({
+  paginateAll: vi.fn(),
+}));
+
+import {
+  prefetchMergedPRCounts,
+  type MergedPRRepoRef,
+} from "./issue-graphql.js";
+import {
+  checkUserMergedPRsInRepo,
+  mergedPRsCacheKey,
+} from "./issue-eligibility.js";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function makeOctokit(
+  graphql: ReturnType<typeof vi.fn>,
+  search?: ReturnType<typeof vi.fn>,
+): Octokit {
+  return {
+    graphql,
+    search: { issuesAndPullRequests: search ?? vi.fn() },
+  } as unknown as Octokit;
+}
+
+/** The authenticated-identity probe folded into every batch response. */
+const VIEWER = { login: "octocat" };
+
+const REPOS: MergedPRRepoRef[] = [
+  { owner: "o1", repo: "r1" },
+  { owner: "o2", repo: "r2" },
+];
+
+describe("prefetchMergedPRCounts", () => {
+  beforeEach(() => {
+    cacheStub.store.clear();
+    cacheStub.set.mockClear();
+    cacheStub.getIfFresh.mockClear();
+  });
+
+  it("no-ops without calling GraphQL when there are no repos", async () => {
+    const graphql = vi.fn();
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", []);
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it("builds one aliased search query, passing query strings as variables", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      viewer: VIEWER,
+      r0: { issueCount: 3 },
+      r1: { issueCount: 0 },
+    });
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", REPOS);
+
+    expect(graphql).toHaveBeenCalledTimes(1);
+    const [query, variables] = graphql.mock.calls[0];
+    expect(query).toContain(
+      "r0: search(query: $q0, type: ISSUE, first: 1) { issueCount }",
+    );
+    // Identity probe folded into the same round-trip.
+    expect(query).toContain("viewer { login }");
+    expect(query).toContain("$q0: String!");
+    expect(query).toContain("$q1: String!");
+    // User data lives in variables, never interpolated into the query document.
+    expect(variables).toEqual({
+      q0: "is:pr is:merged author:octocat repo:o1/r1",
+      q1: "is:pr is:merged author:octocat repo:o2/r2",
+    });
+  });
+
+  it("writes resolved counts to the cache under mergedPRsCacheKey", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      viewer: VIEWER,
+      r0: { issueCount: 3 },
+      r1: { issueCount: 7 },
+    });
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", REPOS);
+
+    expect(cacheStub.set).toHaveBeenCalledWith(
+      mergedPRsCacheKey("o1", "r1"),
+      "",
+      3,
+    );
+    expect(cacheStub.set).toHaveBeenCalledWith(
+      mergedPRsCacheKey("o2", "r2"),
+      "",
+      7,
+    );
+  });
+
+  it("caches a count of 0 (no merged PRs is a real answer, not an error)", async () => {
+    const graphql = vi
+      .fn()
+      .mockResolvedValue({ viewer: VIEWER, r0: { issueCount: 0 } });
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", [REPOS[0]]);
+    expect(cacheStub.set).toHaveBeenCalledWith(
+      mergedPRsCacheKey("o1", "r1"),
+      "",
+      0,
+    );
+  });
+
+  it("lets the per-call path hit the prefetched cache without a Search call", async () => {
+    const graphql = vi
+      .fn()
+      .mockResolvedValue({ viewer: VIEWER, r0: { issueCount: 5 } });
+    const search = vi.fn();
+    const octokit = makeOctokit(graphql, search);
+
+    await prefetchMergedPRCounts(octokit, "octocat", [{ owner: "o1", repo: "r1" }]);
+    const count = await checkUserMergedPRsInRepo(octokit, "o1", "r1");
+
+    expect(count).toBe(5);
+    // The whole point: the Search API is never touched for a warmed repo.
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it("dedups repeated repos into a single alias", async () => {
+    const graphql = vi
+      .fn()
+      .mockResolvedValue({ viewer: VIEWER, r0: { issueCount: 1 } });
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", [
+      { owner: "o1", repo: "r1" },
+      { owner: "o1", repo: "r1" },
+    ]);
+    const [, variables] = graphql.mock.calls[0];
+    expect(variables).not.toHaveProperty("q1");
+  });
+
+  it("splits repos beyond the batch size into multiple queries", async () => {
+    const graphql = vi.fn().mockResolvedValue({});
+    const many: MergedPRRepoRef[] = Array.from({ length: 16 }, (_, i) => ({
+      owner: "o",
+      repo: `r${i}`,
+    }));
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", many);
+    // 16 repos / batch size 15 → two queries (15 + 1).
+    expect(graphql).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops repos with hostile names but keeps the valid ones", async () => {
+    const graphql = vi
+      .fn()
+      .mockResolvedValue({ viewer: VIEWER, r0: { issueCount: 2 } });
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", [
+      { owner: "good", repo: "repo" },
+      { owner: "evil", repo: 'x") { viewer { login } } #' },
+    ]);
+    expect(graphql).toHaveBeenCalledTimes(1);
+    const [, variables] = graphql.mock.calls[0];
+    // Only the valid repo survives; the hostile one never enters the query.
+    expect(variables).toEqual({
+      q0: "is:pr is:merged author:octocat repo:good/repo",
+    });
+  });
+
+  it("never calls GraphQL when every repo fails validation", async () => {
+    const graphql = vi.fn();
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", [
+      { owner: "evil", repo: "a b c" },
+      { owner: "also/bad", repo: "r" },
+    ]);
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it("no-ops on an empty or invalid username (REST falls back to @me)", async () => {
+    const graphql = vi.fn();
+    await prefetchMergedPRCounts(makeOctokit(graphql), "", REPOS);
+    await prefetchMergedPRCounts(makeOctokit(graphql), "bad user!", REPOS);
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it("uses partial data on a GraphQL error: caches resolved, leaves errored cold", async () => {
+    const err = Object.assign(new Error("Could not resolve"), {
+      data: { viewer: VIEWER, r0: { issueCount: 2 }, r1: null },
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", REPOS);
+
+    expect(cacheStub.store.get(mergedPRsCacheKey("o1", "r1"))?.body).toBe(2);
+    // The errored alias stays cold so the per-call REST path fetches it.
+    expect(cacheStub.store.has(mergedPRsCacheKey("o2", "r2"))).toBe(false);
+  });
+
+  it("leaves the cache cold when the authenticated login differs from username", async () => {
+    // getGitHubUsername() is stale/misconfigured: the token authenticates as
+    // someone else. Trusting the author:${username} count would poison the
+    // cache and suppress the authoritative REST author:@me query.
+    const graphql = vi.fn().mockResolvedValue({
+      viewer: { login: "different-account" },
+      r0: { issueCount: 9 },
+    });
+    const search = vi.fn().mockResolvedValue({ data: { total_count: 4 } });
+    const octokit = makeOctokit(graphql, search);
+
+    await prefetchMergedPRCounts(octokit, "octocat", [{ owner: "o1", repo: "r1" }]);
+    expect(cacheStub.set).not.toHaveBeenCalled();
+
+    // The per-call path falls through to the authoritative REST @me query.
+    const count = await checkUserMergedPRsInRepo(octokit, "o1", "r1");
+    expect(count).toBe(4);
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches the authenticated login case-insensitively", async () => {
+    const graphql = vi
+      .fn()
+      .mockResolvedValue({ viewer: { login: "OctoCat" }, r0: { issueCount: 6 } });
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", [
+      { owner: "o1", repo: "r1" },
+    ]);
+    expect(cacheStub.set).toHaveBeenCalledWith(
+      mergedPRsCacheKey("o1", "r1"),
+      "",
+      6,
+    );
+  });
+
+  it("leaves the cache cold when viewer identity cannot be read", async () => {
+    // A response missing viewer (e.g. dropped in a partial error) must not be
+    // trusted — cache nothing and let REST answer.
+    const graphql = vi.fn().mockResolvedValue({ r0: { issueCount: 3 } });
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", [
+      { owner: "o1", repo: "r1" },
+    ]);
+    expect(cacheStub.set).not.toHaveBeenCalled();
+  });
+
+  it("caches nothing on a non-fatal error with no partial data", async () => {
+    const graphql = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    await prefetchMergedPRCounts(makeOctokit(graphql), "octocat", REPOS);
+    expect(cacheStub.set).not.toHaveBeenCalled();
+  });
+
+  it("propagates a 401 auth error (rethrowIfFatal)", async () => {
+    const err = Object.assign(new Error("Bad credentials"), { status: 401 });
+    const graphql = vi.fn().mockRejectedValue(err);
+    await expect(
+      prefetchMergedPRCounts(makeOctokit(graphql), "octocat", REPOS),
+    ).rejects.toThrow("Bad credentials");
+  });
+
+  it("propagates a rate-limit error (rethrowIfFatal)", async () => {
+    const err = Object.assign(new Error("API rate limit exceeded"), {
+      status: 429,
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    await expect(
+      prefetchMergedPRCounts(makeOctokit(graphql), "octocat", REPOS),
+    ).rejects.toThrow("rate limit");
+  });
+});


### PR DESCRIPTION
## Summary

`checkUserMergedPRsInRepo` runs one REST `search.issuesAndPullRequests` call per unique new repo during vetting. On a cold run over 20+ new repos that consumes most of the effective Search API budget (30 req/min minus a safety margin, so ~26 usable). The Search bucket is scout's tightest rate limit.

This replaces the per-repo REST Search call with a **batched, aliased GraphQL `search` prefetch**. A GraphQL `search` connection bills the **GraphQL points bucket (5000/hr)**, not the REST Search bucket (30/min), so the dominant Search-bucket consumer is eliminated.

### Budget: before / after (cold run over N new repos)

| | REST Search calls | GraphQL points |
|---|---|---|
| **Before** | ~15-25 (one per unique repo) | 0 |
| **After** | ~0 (all served from the warmed cache) | ~1-2 (one query per ~15 repos; `first:1` search connections are cheap) |

Empirically, a GraphQL query with several aliased `search` connections costs ~1 GraphQL point total and leaves the Search bucket at 0 used.

## How it works

- **`prefetchMergedPRCounts`** (`issue-graphql.ts`): builds one query per ~15 repos, each an aliased `search(query: $qN, type: ISSUE, first: 1) { issueCount }` where `$qN` is a GraphQL **variable** holding `is:pr is:merged author:USER repo:OWNER/NAME`. User data is passed as variables and never interpolated into the query document. `owner`/`repo`/`username` are validated against a strict `[A-Za-z0-9_.-]` pattern; anything failing is dropped and left to the REST fallback.
- **Same cache, no new plumbing**: resolved counts are written under the exact key `checkUserMergedPRsInRepo` reads (shared `mergedPRsCacheKey` helper), so a warmed repo short-circuits on the cache hit and never touches the Search API. The existing 15-min cache and in-flight dedup keep working unchanged.
- **Identity safety**: the prefetch searches `author:USERNAME` while the REST fallback searches `author:@me`. A `viewer { login }` probe is folded into the same round-trip; the cache is only warmed when the authenticated login matches the configured username, so a stale/misconfigured username can never poison the cache and suppress the authoritative REST query.
- **Fallbacks mirror `prefetchIssueCores`**: fatal errors (401 / rate limit) propagate via `rethrowIfFatal`; a partial GraphQL error keeps the aliases that resolved and leaves the rest cold for REST; only concrete numeric counts are cached (never an error-path `0`).
- **Skip-list preserved**: repos already known to have the user's merged PRs are excluded (vetIssue short-circuits those and never calls Search anyway), and the whole prefetch no-ops when the username is unknown.
- These GraphQL calls are intentionally **not** counted against the `SearchBudgetTracker` — they consume GraphQL points, not the Search bucket.

## Tests

Added `merged-pr-prefetch.test.ts` (query construction with variables not interpolation, hostile-name rejection, partial-error REST fallback, prefetch-populates-cache/per-call-path-hits-it, batch splitting, identity-mismatch leaves cache cold, fatal-error propagation) plus skip-list and unknown-username tests in `issue-vetting.test.ts`.

- `pnpm -r run typecheck`: clean
- `pnpm run lint`: clean
- `pnpm test`: core 1014 passed, mcp-server 32 passed
