### PR TITLE
Add vet eval suite: score the current vetter against 30 historical outcomes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:watch": "pnpm -r run test:watch",
     "test:coverage": "pnpm -r run test:coverage",
     "typecheck": "pnpm -r run typecheck",
+    "eval:vet": "pnpm --filter @oss-scout/core run eval:vet",
+    "eval:vet:quick": "pnpm --filter @oss-scout/core run eval:vet:quick",
     "lint": "eslint packages/",
     "lint:fix": "eslint packages/ --fix",
     "format": "prettier --write packages/",

--- a/packages/core/eval/fixtures/vet/README.md
+++ b/packages/core/eval/fixtures/vet/README.md
@@ -1,0 +1,45 @@
+# Vet eval fixtures
+
+30 historical GitHub issues from John's OSS-pipeline notes
+(`~/dev/obsidian-vault/open-source/potential-issue-list.md` and
+`skipped-issues.md`), each with a realized outcome recorded later:
+`merged`, `lost_race`, `maintainer_fixed`, or `skip_correct`.
+
+## How these were built
+
+1. **Ground truth** (`../../src/eval/ground-truth.ts`): for each issue, the
+   `vetTimeFacts` (existing-PR / claimed / project-active / merged-PR-count
+   / etc.) are hand-derived from the vault's own vetting-time notes — the
+   vault records these checks in prose at the time each issue was actually
+   vetted. This can't be re-derived from a live API call because GitHub's
+   search and timeline APIs cannot be queried as of a past date.
+2. **Objective facts** (`../../src/eval/build-fixtures.ts`): issue
+   title/body/labels/state/timestamps and repo star/fork counts are fetched
+   live via the `gh` CLI (read-only, no writes, no posting). These reflect
+   state as of the fixture-build date (2026-07-05), which can differ
+   slightly from vet-time state if an issue was edited or a repo grew.
+3. **Outcome verification**: every merge/close status cited in `outcome`
+   was independently re-verified against the live GitHub API on 2026-07-05
+   (`gh api repos/<owner>/<repo>/pulls/<n>` for `merged`/`merged_at`,
+   `gh api repos/<owner>/<repo>/issues/<n>` for `state`/`state_reason`) —
+   not just trusted from vault prose.
+
+Each fixture's `fidelityNote` documents the specific provenance and any
+known reconstruction gaps for that case. `measurable: false` fixtures are
+run and reported but excluded from the headline verdict-accuracy score —
+see `docs/plans/fleet-evals-design.md` and the PR description for why
+(their outcomes hinge on race timing / maintainer behavior / feasibility
+judgment that oss-scout's current deterministic checks don't attempt to
+predict).
+
+## Regenerating
+
+```
+pnpm --filter @oss-scout/core run eval:vet:build-fixtures
+```
+
+This re-fetches the objective (title/body/labels/repo metadata) fields
+live but leaves `vetTimeFacts`/`outcome`/`measurable`/`expectedVerdict`
+untouched (those come from `ground-truth.ts`, edited by hand). Re-run
+only if you want to refresh drift in issue bodies/repo stats, or after
+editing `ground-truth.ts` to add/change a fixture.

--- a/packages/core/eval/fixtures/vet/activist-2084.json
+++ b/packages/core/eval/fixtures/vet/activist-2084.json
@@ -1,0 +1,39 @@
+{
+  "id": "activist-2084",
+  "url": "https://github.com/activist-org/activist/issues/2084",
+  "owner": "activist-org",
+  "repo": "activist",
+  "issueNumber": 2084,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "Add a workflow to audit `npm` and `pypi` packages in the project",
+    "body": "### Terms\n\n- [x] I have searched [open and closed feature requests](https://github.com/activist-org/activist/issues?q=is%3Aissue+label%3Afeature)\n- [x] I agree to follow activist's [Code of Conduct](.github/CODE_OF_CONDUCT.md)\n\n### Description\n\nWith the recent incidents within some of the open source communities, its safer for us to start auditing the packages/dependencies that we are integrating into our projects. Using [`pip-audit`](https://github.com/pypa/pip-audit) package for the backend and [`npm audit`](https://yarnpkg.com/cli/npm/audit) command for the frontend within out workflows would a good way to start checking if any of the dependencies are compromised.\n\ncc @andrewtavis @nicki182 @to-sta \n\n### Contribution\n\n_No response_",
+    "labels": ["-priority-", "dependencies", "backend", "frontend"],
+    "state": "closed",
+    "createdAt": "2026-04-04T17:53:46Z",
+    "updatedAtObserved": "2026-05-17T18:15:32Z"
+  },
+  "repoMeta": {
+    "stars": 702,
+    "forks": 579
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": true,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-12",
+    "detail": "Skipped: issue assigned to @sh-ran at vet time (verified live: assignee still on the closed issue)."
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "isClaimed=true matches checkNotClaimed's assignee check.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/backstage-8216.json
+++ b/packages/core/eval/fixtures/vet/backstage-8216.json
@@ -1,0 +1,40 @@
+{
+  "id": "backstage-8216",
+  "url": "https://github.com/backstage/community-plugins/issues/8216",
+  "owner": "backstage",
+  "repo": "community-plugins",
+  "issueNumber": 8216,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "🐛 entity-validation: Errors out with `kind` or `metadata` key value missing, instead of properly reporting the issue",
+    "body": "### Workspace\n\nentity-validation\n\n### 📜 Description\n\nWhen an entity with either missing `kind` or an empty `metadata` field is validated, the plugin errors out, instead of reporting proper errors.\n\n### 👍 Expected behavior\n\nThe plugin should properly flag missing `kind` and `metadata` to be a proper object type.\n\n### 👎 Actual Behavior with Screenshots\n\nIt errors out instead of reporting the missing field.\n\nWhen `kind` is missing ->\n<img width=\"1919\" height=\"1059\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/28af3979-d3cb-439f-9c63-251c14bf7149\" />\n\nWhen `metadata` property is present without any content ->\n<img width=\"1919\" height=\"1059\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/2c5cac2d-8076-4a21-97e7-97f7127d2f3a\" />\n\n### 👟 Reproduction steps\n\n1. Go to entity validation plugin screen.\n2. Try to validate an entity with `kind` or `metadata` key value missing.\n\n### 📃 Provide the context for the Bug.\n\nThis bug doesn't flag an incorrect entity properly. This happens because the `humaizeEntityRef` from `@backstage/plugin-catalog-react` package expects `entitiyRef.kind` & `entityRef.metadata.namespace` to be available, even with the defaults provided.\n\n### 👀 Have you spent some time to check if this bug has been raised before?\n\n- [x] I checked and didn't find similar issue\n\n### 🏢 Have you read the Code of Conduct?\n\n- [x] I have read the [Code of Conduct](https://github.com/backstage/community-plugins/blob/main/CODE_OF_CONDUCT.md)\n\n### Are you willing to submit PR?\n\nYes I am willing to submit a PR!",
+    "labels": ["bug", "workspace/entity-validation"],
+    "state": "closed",
+    "createdAt": "2026-03-24T11:38:41Z",
+    "updatedAtObserved": "2026-07-03T17:43:55Z"
+  },
+  "repoMeta": {
+    "stars": 396,
+    "forks": 649
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-07-03",
+    "detail": "PR #8547 merged 2026-07-03 — an unusually long ~3 month review cycle (verified live: merged=true)",
+    "prUrl": "https://github.com/backstage/community-plugins/pull/8547"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Longest merge latency in this fixture set; included deliberately so the report's calibration section isn't only fast-merge success stories.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/casa-6836.json
+++ b/packages/core/eval/fixtures/vet/casa-6836.json
@@ -1,0 +1,39 @@
+{
+  "id": "casa-6836",
+  "url": "https://github.com/rubyforgood/casa/issues/6836",
+  "owner": "rubyforgood",
+  "repo": "casa",
+  "issueNumber": 6836,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "Bug: N+1 queries on new case contacts datatable endpoint",
+    "body": "## Impacted User Types\n\nAll users who visit `/case_contacts/new_design` — volunteers, supervisors, and admins.\n\n## Environment\n\nAny environment where the `new_case_contact_table` Flipper flag is enabled.\n\n## Current Behavior\n\nWhen the new case contacts table loads at `/case_contacts/new_design`, the datatable endpoint (`POST /case_contacts/new_design/datatable`) fires two N+1 query sets — one per row for `casa_cases` and one per row for `followups`. The queries scale linearly with the number of rows returned per page (default 10, configurable up to 100).\n\n<details>\n\n<summary>Rails log showing the N+1 warnings</summary>\n\n```shell\n18:09:23 web.1  | N+1 queries detected:\n18:09:23 web.1  |   SELECT \"casa_cases\".\"id\", \"casa_cases\".\"case_number\", ... FROM \"casa_cases\" WHERE \"casa_cases\".\"id\" = $1 LIMIT $2\n18:09:23 web.1  |   SELECT \"casa_cases\".\"id\", \"casa_cases\".\"case_number\", ... FROM \"casa_cases\" WHERE \"casa_cases\".\"id\" = $1 LIMIT $2\n18:09:23 web.1  |   SELECT \"casa_cases\".\"id\", \"casa_cases\".\"case_number\", ... FROM \"casa_cases\" WHERE \"casa_cases\".\"id\" = $1 LIMIT $2\n18:09:23 web.1  |   SELECT \"casa_cases\".\"id\", \"casa_cases\".\"case_number\", ... FROM \"casa_cases\" WHERE \"casa_cases\".\"id\" = $1 LIMIT $2\n18:09:23 web.1  |   SELECT \"casa_cases\".\"id\", \"casa_cases\".\"case_number\", ... FROM \"casa_cases\" WHERE \"casa_cases\".\"id\" = $1 LIMIT $2\n18:09:23 web.1  |   SELECT \"casa_cases\".\"id\", \"casa_cases\".\"case_number\", ... FROM \"casa_cases\" WHERE \"casa_cases\".\"id\" = $1 LIMIT $2\n18:09:23 web.1  |   SELECT \"casa_cases\".\"id\", \"casa_cases\".\"case_number\", ... FROM \"casa_cases\" WHERE \"casa_cases\".\"id\" = $1 LIMIT $2\n18:09:23 web.1  | Call stack:\n18:09:23 web.1  |   app/datatables/case_contact_datatable.rb:20:in 'block in CaseContactDatatable#data'\n18:09:23 web.1  |   app/datatables/case_contact_datatable.rb:14:in 'Enumerable#map'\n18:09:23 web.1  |   app/datatables/case_contact_datatable.rb:14:in 'CaseContactDatatable#data'\n18:09:23 web.1  |   app/datatables/application_datatable.rb:15:in 'ApplicationDatatable#as_json'\n18:09:23 web.1  |   app/controllers/case_contacts/case_contacts_new_design_controller.rb:15:in 'CaseContacts::CaseContactsNewDesignController#datatable'\n\n18:09:23 web.1  | N+1 queries detected:\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  |   SELECT 1 AS one FROM \"followups\" WHERE \"followups\".\"case_contact_id\" = $1 AND \"followups\".\"status\" = $2 LIMIT $3\n18:09:23 web.1  | Call stack:\n18:09:23 web.1  |   app/datatables/case_contact_datatable.rb:38:in 'block in CaseContactDatatable#data'\n18:09:23 web.1  |   app/datatables/case_contact_datatable.rb:14:in 'Enumerable#map'\n18:09:23 web.1  |   app/datatables/case_contact_datatable.rb:14:in 'CaseContactDatatable#data'\n18:09:23 web.1  |   app/datatables/application_datatable.rb:15:in 'ApplicationDatatable#as_json'\n18:09:23 web.1  |   app/controllers/case_contacts/case_contacts_new_design_controller.rb:15:in 'CaseContacts::CaseContactsNewDesignController#datatable'\n```\n\n</details>\n\n## Expected Behavior\n\nThe datatable endpoint should load all needed associations in a fixed number of queries regardless of page size.\n\n## Root Causes\n\n**N+1 #1 — `casa_cases` (datatable line 20)**\n\n`case_contact.casa_case&.case_number` triggers a query per row. The existing `.left_joins(:casa_case)` in `raw_records` joins for SQL filtering but does not eager load the association into memory.\n\nFix: add `:casa_case` to the `includes` chain in `raw_records`.\n\n**N+1 #2 — `followups.requested.exists?` (datatable line 38)**\n\n`:followups` is already in the `includes`, so the association records are loaded in memory. However, `.requested.exists?` fires a new SQL query regardless because `exists?` always hits the database.\n\nFix: replace with `case_contact.followups.any?(&:requested?)` — this operates on the already-loaded association without an additional query.\n\n## How to Replicate\n\n1. Enable the `new_case_contact_table` Flipper flag\n2. Log in as any user at the QA site\n3. Visit `/case_contacts/new_design`\n4. Observe the Rails log for `N+1 queries detected` warnings\n\n## How to access the QA site\n\n_Login Details:_\n[Link to QA site](https://casa-qa.herokuapp.com/)\n\nLogin Emails:\n\n- volunteer1@example.com — view site as a volunteer\n- supervisor1@example.com — view site as a supervisor\n- casa_admin1@example.com — view site as an admin\n- all_casa_admin1@example.com — view site as an all casa admin\n  - go to `/all_casa_admins/sign_in`\n\nPassword for all users: 12345678\n\n### Questions? Join Slack!\n\nWe highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.\n",
+    "labels": ["Type: Bug"],
+    "state": "closed",
+    "createdAt": "2026-04-09T20:52:15Z",
+    "updatedAtObserved": "2026-04-14T01:16:05Z"
+  },
+  "repoMeta": {
+    "stars": 373,
+    "forks": 533
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": true,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-12",
+    "detail": "Skipped: issue assigned to @cliftonmcintosh at vet time (verified live: assignee still on the closed issue)."
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "isClaimed=true matches checkNotClaimed's assignee check.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/casa-6839.json
+++ b/packages/core/eval/fixtures/vet/casa-6839.json
@@ -1,0 +1,40 @@
+{
+  "id": "casa-6839",
+  "url": "https://github.com/rubyforgood/casa/issues/6839",
+  "owner": "rubyforgood",
+  "repo": "casa",
+  "issueNumber": 6839,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "Bug(?): Supervisors cannot edit case contacts — CaseContactPolicy#show? excludes supervisors",
+    "body": "**Note:** It is unclear whether this is a bug or an intentional restriction. This issue is filed to ask for clarification. If supervisors are not meant to edit case contacts through this path, the Edit button should be hidden from them in the UI.\n\n## Impacted User Types\n\nSupervisors.\n\n## Environment\n\nAny environment. This is a policy configuration issue in the Rails authorization layer, not specific to a browser or deployment.\n\n## Current Behavior\n\nWhen a supervisor clicks **Edit** on a case contact (in either the old or new case contacts table), they are silently redirected away instead of reaching the edit form. The redirect chain is:\n\n1. `GET /case_contacts/:id/edit` → 302 → `/case_contacts/:id/form/details` ✓\n2. `GET /case_contacts/:id/form/details` → 302 → `/` ✗ (Pundit authorization failure)\n3. `GET /` → 302 → `/volunteers` (supervisor default page)\n\nThe failure in step 2 occurs because `CaseContacts::FormController#show` calls `authorize @case_contact`, which Pundit resolves to `CaseContactPolicy#show?`. That policy only permits the creator or an admin — supervisors are excluded.\n\nRelevant code in `app/policies/case_contact_policy.rb`:\n\n```ruby\ndef show?\n  creator_or_admin?          # supervisors are NOT included\nend\n\ndef update?\n  creator_or_supervisor_or_admin?   # supervisors ARE included\nend\n\nalias_method :edit?, :update?\n```\n\n## Expected Behavior\n\nEither:\n\n- **If supervisors should be able to edit:** `show?` should include supervisors so the edit form is accessible, consistent with `edit?` / `update?`.\n- **If supervisors should not be able to edit:** The Edit button should not be shown to supervisors in the UI.\n\n## How to Replicate\n\n1. Log in as a supervisor (e.g. `supervisor1@example.com`)\n2. Navigate to `/case_contacts` or `/case_contacts/new_design`\n3. Click **Edit** on any case contact\n4. Observe that the browser redirects to `/volunteers` instead of the edit form\n\n## How to access the QA site\n\n_Login Details:_\n[Link to QA site](https://casa-qa.herokuapp.com/)\n\nLogin Emails:\n\n- `volunteer1@example.com` — view site as a volunteer\n- `supervisor1@example.com` — view site as a supervisor\n- `casa_admin1@example.com` — view site as an admin\n- `all_casa_admin1@example.com` — view site as an all casa admin\n  - go to `/all_casa_admins/sign_in`\n\nPassword for all users: 12345678\n\n### Questions? Join Slack\n\nWe highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.",
+    "labels": ["Type: Bug", "Help Wanted"],
+    "state": "closed",
+    "createdAt": "2026-04-09T21:13:30Z",
+    "updatedAtObserved": "2026-04-14T01:16:39Z"
+  },
+  "repoMeta": {
+    "stars": 373,
+    "forks": 533
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": true,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-12",
+    "detail": "Skipped: competing PR #6844 was already open at vet time (verified live: #6844 merged=true, so the skip was also right in hindsight).",
+    "prUrl": "https://github.com/rubyforgood/casa/pull/6844"
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "hasExistingPR=true directly matches the vault note ('Taken: competing PR #6844 open') — exactly the checkNoExistingPR signal oss-scout's vetter runs today.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/casa-6923.json
+++ b/packages/core/eval/fixtures/vet/casa-6923.json
@@ -1,0 +1,40 @@
+{
+  "id": "casa-6923",
+  "url": "https://github.com/rubyforgood/casa/issues/6923",
+  "owner": "rubyforgood",
+  "repo": "casa",
+  "issueNumber": 6923,
+  "vetDate": "2026-06-09",
+  "issue": {
+    "title": "Fix broken Heroku Scheduler rake tasks",
+    "body": "## Context\n\nRunning each project rake task in this repo (`bundle exec rake <name>`) surfaces a cluster of bugs in the tasks driven by Heroku Scheduler. **Three tasks crash on every invocation; two more crash latently when production data shape triggers them.**\n\nThis issue covers the \"broken in production\" bugs only. Maintainability cleanup (auto_annotate noise, `factory_bot:lint` debt, `deployment/` pruning, in-task schedule-guard anti-pattern) and moving controller specs to request specs are tracked separately.\n\n## Bugs that crash on every run\n\n### 1. `send_case_contact_types_reminder` — `NoMethodError: undefined method 'every' for main`\n\n`lib/tasks/send_case_contact_types_reminder.rake:4` and `lib/tasks/send_no_contact_made_reminder.rake:4` both wrap their work in:\n\n```ruby\nevery 1.weeks do\n  CaseContactTypesReminder.new.send!\nend\n```\n\n`every` is from the `whenever` gem (intended for `config/schedule.rb`), not a Rake primitive. The block raises immediately when the task runs — meaning the case-contact-types SMS reminder has not actually executed since that block was added.\n\n### 2. `send_no_contact_made_reminder` — task name doesn't exist\n\n`lib/tasks/send_no_contact_made_reminder.rake` declares `task send_case_contact_types_reminder: :environment do …` — the same task name used by the other file. `rake -T` confirms only one task is registered, with both descriptions concatenated:\n\n```\nrake send_case_contact_types_reminder    # Send an SMS … past 60 or more days / Send an SMS … two weeks have passed …\n```\n\nSo Heroku Scheduler invocations of `send_no_contact_made_reminder` fail with \"Don't know how to build task\", and the no-contact-made SMS reminder has never run. The file also `require_relative`s the wrong service file and instantiates `CaseContactTypesReminder` instead of `NoContactMadeReminder`.\n\n### 3. `recurring:init` — `NameError: uninitialized constant ExampleRecurringTask`\n\n`lib/tasks/recurring_jobs.rake:3` calls `ExampleRecurringTask.schedule!`, but `ExampleRecurringTask` is defined in `lib/tasks/example_recurring_task.rb` which Rails does not autoload. The class is also dead example code:\n\n```ruby\ndef perform\n  Bugsnag.notify(\"This is just ExampleRecurringTask saying hi in #{Rails.env}\")\nend\n```\n\n— likely safe to delete entirely.\n\n## Latent bugs that crash when data triggers them\n\n### 4. `youth_birthday_reminder` — `NoMethodError: undefined method 'volunteer_id' for nil`\n\n`lib/tasks/youth_birthday_reminder.rake:6`:\n\n```ruby\n.deliver(Volunteer.find_by(id: casa_case.case_assignments.first.volunteer_id))\n```\n\nWhen a `CasaCase.birthday_next_month` case has no `case_assignments`, `.first` is `nil`. Confirmed via isolated repro against dev DB:\n\n```\n$ rails runner 'cc = CasaCase.birthday_next_month.first; cc.case_assignments.destroy_all; cc.case_assignments.first.volunteer_id'\nRAISED: NoMethodError: undefined method 'volunteer_id' for nil\n```\n\nSeed data happens to have ≥1 assignment per case, so the bug never fires in test/dev — but it will fire in production whenever a case is briefly without an active assignment.\n\n`.first` also ignores active vs. inactive — should be `case_assignments.active`.\n\n### 5. `emancipation_checklist_reminder_notifier` (in `development/notifications.rake`) — same bug as #4\n\n`lib/tasks/development/notifications.rake:6` has the identical `casa_case.case_assignments.first.volunteer_id` shape and will crash the same way. The whole `development/notifications.rake` file is also missing an `if Rails.env.development?` guard — so the dev tasks `followup_notifier` (`Followup.all.first`) and `reimbursement_complete_notifier` (`CaseContact.all.first`) could be triggered against prod data.\n\n## Proposed PR scope\n\nSingle PR titled \"Fix broken Heroku Scheduler rake tasks\":\n\n- [ ] Drop the `every 1.weeks do … end` and `every 1.days do … end` blocks in both reminder rake files (#1)\n- [ ] Rename the task in `send_no_contact_made_reminder.rake` to `send_no_contact_made_reminder` and wire it to `NoContactMadeReminder` (#2)\n- [ ] Move `lib/tasks/case_contact_types_reminder.rb`, `no_contact_made_reminder.rb`, `supervisor_weekly_digest.rb` to `app/services/`; drop the `require_relative` lines from their rake files and specs so Rails autoload picks them up (cleanup tied to #1 / #2)\n- [ ] Delete `lib/tasks/recurring_jobs.rake` and `lib/tasks/example_recurring_task.rb` (or move the class to `app/jobs/` and gut the Bugsnag noise) (#3)\n- [ ] Add nil-safety + switch to `case_assignments.active.find_each` in `youth_birthday_reminder.rake` (#4)\n- [ ] Wrap `lib/tasks/development/notifications.rake` in `if Rails.env.development?` and apply the same nil-safety to the emancipation notifier (#5)\n\n## How verified\n\nRan every project-defined rake task against current dev DB (35 cases, 7 volunteers, 2 birthday-next-month cases, 0 followups; today is Saturday May 2 so `monday?` / `day == 1` guards short-circuit the digest tasks):\n\n| Task | Result |\n|---|---|\n| `send_case_contact_types_reminder` | exit 1 — `NoMethodError: undefined method 'every'` |\n| `recurring:init` | exit 1 — `NameError: uninitialized constant ExampleRecurringTask` |\n| `youth_birthday_reminder` (with `case_assignments` empty) | confirmed `NoMethodError` via isolated repro |\n| `send_no_contact_made_reminder` | task name not registered (collides with `send_case_contact_types_reminder`) |\n| `clear_passed_dates`, `court_report_due_reminder`, `volunteer_birthday_reminder`, `send_learning_hour_reports`, `factory_bot:lint`, `test_checker` | exit 0, no crash |\n\n`post_gc_stat_to_discord` was skipped during verification because it HTTP-fetches the production URL — that's a separate concern (P3).",
+    "labels": ["Type: Bug", "ruby"],
+    "state": "closed",
+    "createdAt": "2026-05-03T05:59:24Z",
+    "updatedAtObserved": "2026-06-10T06:04:23Z"
+  },
+  "repoMeta": {
+    "stars": 373,
+    "forks": 533
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-06-10",
+    "detail": "PR #6990 merged 2026-06-10 (verified live: merged=true)",
+    "prUrl": "https://github.com/rubyforgood/casa/pull/6990"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "vetTimeFacts from potential-issue-list.md: 'Score 8/10 — PR OPEN', fully available/unclaimed at vet time, first PR John opened in this repo (mergedPRCount=0).",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/casa-6948.json
+++ b/packages/core/eval/fixtures/vet/casa-6948.json
@@ -1,0 +1,40 @@
+{
+  "id": "casa-6948",
+  "url": "https://github.com/rubyforgood/casa/issues/6948",
+  "owner": "rubyforgood",
+  "repo": "casa",
+  "issueNumber": 6948,
+  "vetDate": "2026-06-09",
+  "issue": {
+    "title": "DRY spec/requests/casa_cases.rb",
+    "body": "## Description\nSome blocks of code in this test file are copied and pasted especially between the supervisor and admin. Over time despite the page behaving the same for both types of users, the test blocks have diverged.\nGroup reused code in an [Rspec shared example](https://rspec.info/features/3-12/rspec-core/example-groups/shared-examples/). Shared examples can take parameters like functions.\nMake sure the tests are working.\n\n### Divergent Tests  \nGET index/\n - `it \"renders a successful response\"` use `build_stubbed` for both tests\n - `it \"shows all my organization's cases\" do` test relevant to admin and supervisor but only in admin section\n - `it \"doesn't show other organizations' cases\" do` test relevant to admin and supervisor but only in admin section\n\nOpportunities for shared examples between volunteers and supervisors for tests that check for unauthorized access\nAdmin test blocks have missing tests for suprvisors\n\n## How to access the QA site\n_Login Details:_  \n[Link to QA site](https://casa-qa.herokuapp.com/)  \n\nLogin Emails: \n- volunteer1@example.com  view site as a volunteer\n- supervisor1@example.com view site as a supervisor\n- casa_admin1@example.com view site as an admin\n- all_casa_admin1@example.com view site as an all casa admin\n  - go to `/all_casa_admins/sign_in`  \n\npassword for all users: 12345678  \n\n### Questions? Join Slack!\n\nWe highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.\n",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-05-13T00:43:42Z",
+    "updatedAtObserved": "2026-06-10T05:47:18Z"
+  },
+  "repoMeta": {
+    "stars": 373,
+    "forks": 533
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-06-10",
+    "detail": "PR #6991 merged 2026-06-10 (verified live: merged=true)",
+    "prUrl": "https://github.com/rubyforgood/casa/pull/6991"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "vault notes: prior claimant (andoq) auto-unassigned 15d before this vet for inactivity, so isClaimed=false at vet time. Same-day vet as #6923 (mergedPRCount=0 for both).",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/dioxus-5477.json
+++ b/packages/core/eval/fixtures/vet/dioxus-5477.json
@@ -1,0 +1,40 @@
+{
+  "id": "dioxus-5477",
+  "url": "https://github.com/DioxusLabs/dioxus/issues/5477",
+  "owner": "DioxusLabs",
+  "repo": "dioxus",
+  "issueNumber": 5477,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "dx serve --addr 0.0.0.0 should report http://0.0.0.0:8080 as the address",
+    "body": "## Feature Request\n\nI'm accustomed to tools where you can set 0.0.0.0 showing THAT address when you start the dev server. Mine is still showing\n\n> Serving at: http://127.0.0.1:8080\n\nIt also seems to redirect to 127 if I manually visit the all 0s version.\n\nI think it would be more intuitive to switch the address to all 0s both in the `dx serve` printout and to NOT redirect when you're making that the address in the browser. Obviously, you can run something like `sudo ss -tunlp` to verify but it's an extra step and I am fundamentally lazy.",
+    "labels": ["enhancement"],
+    "state": "closed",
+    "createdAt": "2026-04-10T08:45:12Z",
+    "updatedAtObserved": "2026-04-14T23:52:45Z"
+  },
+  "repoMeta": {
+    "stars": 36640,
+    "forks": 1709
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": false,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-04-14",
+    "detail": "PR #5481 merged 2026-04-14 (verified live: merged=true)",
+    "prUrl": "https://github.com/DioxusLabs/dioxus/pull/5481"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "No CONTRIBUTING.md found at any of the 4 probed paths (checked live 2026-07-05) — contributionGuidelinesFound=false is a real repo characteristic, not a fixture gap.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/directus-27091.json
+++ b/packages/core/eval/fixtures/vet/directus-27091.json
@@ -1,0 +1,47 @@
+{
+  "id": "directus-27091",
+  "url": "https://github.com/directus/directus/issues/27091",
+  "owner": "directus",
+  "repo": "directus",
+  "issueNumber": 27091,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "Save as copy throws error",
+    "body": "### Describe the Bug\n\nWhen selecting \"Save as copy\" on an edited file in the file library, a `403 Forbidden` error is thrown, even when admin\n\n### To Reproduce\n\n- Upload an image\n- Make an edit to the image, eg: change the title\n- Select save as copy\n- Observe error\n\n### Directus Version\n\n11.17+\n\n### Hosting Strategy\n\nSelf-Hosted (Docker Image)\n\n### Database\n\n_No response_",
+    "labels": [
+      "Bug",
+      "Regression",
+      "Studio",
+      "Assets / Files",
+      "High Impact",
+      "Med Reach"
+    ],
+    "state": "closed",
+    "createdAt": "2026-04-10T15:17:40Z",
+    "updatedAtObserved": "2026-06-28T03:46:06Z"
+  },
+  "repoMeta": {
+    "stars": 36409,
+    "forks": 4825
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": true,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-12",
+    "detail": "Skipped: competing PR #27099 already open at vet time (verified live: #27099 state=closed, merged=false — it didn't land either, but the skip decision was correct given what was visible then).",
+    "prUrl": "https://github.com/directus/directus/pull/27099"
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "hasExistingPR=true matches checkNoExistingPR. Included even though the competing PR itself never merged, to test that the vetter correctly treats 'has a competing PR' as a skip signal regardless of that PR's eventual fate.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/eslint-plugin-unicorn-3091.json
+++ b/packages/core/eval/fixtures/vet/eslint-plugin-unicorn-3091.json
@@ -1,0 +1,40 @@
+{
+  "id": "eslint-plugin-unicorn-3091",
+  "url": "https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3091",
+  "owner": "sindresorhus",
+  "repo": "eslint-plugin-unicorn",
+  "issueNumber": 3091,
+  "vetDate": "2026-06-11",
+  "issue": {
+    "title": "`consistent-compound-words` is overzealous",
+    "body": "Most of the phrases `consistent-compound-words` bans, like _down load_ are clearly misspellings. However, a few advocate for joining together two-word phrases that are perfectly fine, or even preferred, to keep apart.\n\nLooking through the list, the following stood out. I've checked them with a couple of dictionaries.\n* **Call back** is the verb; callback (or call back) is the noun.\n* **Feed back** is generally the verb; feedback is the noun.\n* **Key frame** is [how Wikipedia spells it](https://en.wikipedia.org/wiki/Key_frame), though it lists keyframe as an alternative. Keyframe is not in Chambers, and is a mere new word suggestion in Collins.\n* **New line** is not the name of `\\n`, but is correct in contexts like `shouldStartNewLine`.\n* **Time out** is the verb; the noun is time out, time-out or timeout.\n* **Touch screen** how Chambers spells this word, and Wikipedia lists it as an alternative spelling. Collins lists touchscreen, touch-screen and touch screen.\n* **Wild card** is how Chambers spells this, and Collins prefers to.",
+    "labels": ["bug"],
+    "state": "closed",
+    "createdAt": "2026-06-11T12:51:03Z",
+    "updatedAtObserved": "2026-06-11T22:00:48Z"
+  },
+  "repoMeta": {
+    "stars": 5173,
+    "forks": 486
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": false,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "maintainer_fixed",
+    "date": "2026-06-11",
+    "detail": "Maintainer (Sindre) merged his own PR #3117 same day, ~9h after sketching the fix in a comment (verified live: merged=true).",
+    "prUrl": "https://github.com/sindresorhus/eslint-plugin-unicorn/pull/3117"
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "The maintainer had already posted the exact fix in a thread comment before this vet — a 'maintainer recently commented with a concrete fix sketch' heuristic could plausibly catch this class, but oss-scout's vetter does not read/analyze comment bodies for that signal today. Flagged as a future-feature candidate in the report, not scored as a miss.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/graphite-4011.json
+++ b/packages/core/eval/fixtures/vet/graphite-4011.json
@@ -1,0 +1,40 @@
+{
+  "id": "graphite-4011",
+  "url": "https://github.com/GraphiteEditor/Graphite/issues/4011",
+  "owner": "GraphiteEditor",
+  "repo": "Graphite",
+  "issueNumber": 4011,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "Text alignment should work without an explicit max-width",
+    "body": "Currently, the Text node's \"Align\" parameter (Left/Center/Right/Justify) has no effect, and left alignment occurs regardless of the setting, when the \"Max Width\" setting is not active. It should use its own bounding box across all rows of text as the basis for centered and right-aligned justification.",
+    "labels": ["Good First Issue"],
+    "state": "open",
+    "createdAt": "2026-04-06T10:42:10Z",
+    "updatedAtObserved": "2026-04-11T16:47:20Z"
+  },
+  "repoMeta": {
+    "stars": 26467,
+    "forks": 1211
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": true,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": false,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-12",
+    "detail": "Skipped: competing PR #4025 open at vet time (verified live: issue and PR both still open as of 2026-07-05).",
+    "prUrl": "https://github.com/GraphiteEditor/Graphite/pull/4025"
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "hasExistingPR=true matches checkNoExistingPR.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/homebrew-21892.json
+++ b/packages/core/eval/fixtures/vet/homebrew-21892.json
@@ -1,0 +1,39 @@
+{
+  "id": "homebrew-21892",
+  "url": "https://github.com/Homebrew/brew/issues/21892",
+  "owner": "Homebrew",
+  "repo": "brew",
+  "issueNumber": 21892,
+  "vetDate": "2026-04-04",
+  "issue": {
+    "title": "`HOMEBREW_ARTIFACT_DOMAIN` does not fallback to ghcr.io URLs",
+    "body": "### `brew doctor` output\n\n```shell\nPlease note that these warnings are just used to help the Homebrew maintainers\nwith debugging if you file an issue. If everything you use Homebrew for is\nworking fine: please don't worry or file an issue; just ignore this. Thanks!\n\nWarning: /usr/bin occurs before /opt/homebrew/bin in your PATH.\nThis means that system-provided programs will be used instead of those\nprovided by Homebrew. Consider setting your PATH so that\n/opt/homebrew/bin occurs before /usr/bin. Here is a one-liner:\n  echo 'export PATH=\"/opt/homebrew/bin:$PATH\"' >> ~/.zshrc\n\nThe following tools exist at both paths:\n  openssl\n  pip3\n  python3\n```\n\n### Verification\n\n- [x] I ran `brew update` twice and am still able to reproduce my issue.\n- [x] My \"`brew doctor` output\" above says `Your system is ready to brew` or a definitely unrelated `Tier` message.\n- [x] This issue's title and/or description do not reference a single formula e.g. `brew install wget`. If they do, open an issue at https://github.com/Homebrew/homebrew-core/issues/new/choose instead.\n\n### `brew config` output\n\n```shell\nHOMEBREW_VERSION: 5.1.3-12-gf31f20a\nORIGIN: https://github.com/Homebrew/brew\nHEAD: f31f20a49747a14897a3eb3cd1773cbad6d70c72\nLast commit: 4 hours ago\nBranch: main\nCore tap JSON: 02 Apr 20:52 UTC\nCore cask tap JSON: 02 Apr 20:52 UTC\nHOMEBREW_PREFIX: /opt/homebrew\nHOMEBREW_REPOSITORY: /opt/homebrew/Homebrew\nHOMEBREW_ARTIFACT_DOMAIN: https://<internal_nexus>/repository/githubcr-proxy/\nHOMEBREW_CASK_OPTS: []\nHOMEBREW_DOWNLOAD_CONCURRENCY: 16\nHOMEBREW_FORBID_PACKAGES_FROM_PATHS: set\nHOMEBREW_MAKE_JOBS: 8\nHOMEBREW_SORBET_RUNTIME: set\nHomebrew Ruby: 4.0.2 => /opt/homebrew/Homebrew/Library/Homebrew/vendor/portable-ruby/4.0.2_1/bin/ruby\nCPU: octa-core 64-bit arm_firestorm_icestorm\nClang: 17.0.0 build 1700\nGit: 2.50.1 => /Library/Developer/CommandLineTools/usr/bin/git\nCurl: 8.7.1 => /usr/bin/curl\nmacOS: 26.3-arm64\nCLT: 26.2.0.0.1.1764812424\nXcode: N/A\nRosetta 2: false\n```\n\n### What were you trying to do (and why)?\n\nWhen connected to certain networks I do not have access to ghcr.io, so I have `HOMEBREW_ARTIFACT_DOMAIN` set to use an internal mirror. However, when `HOMEBREW_ARTIFACT_DOMAIN` is not reachable, Homebrew does not fallback to using ghcr.io. I do not have `HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK` set, so I expected Homebrew would be able to fallback.\n\n> : When `$HOMEBREW_ARTIFACT_DOMAIN` and `$HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK`\n  are both set, if the request to `$HOMEBREW_ARTIFACT_DOMAIN` fails then\n  Homebrew will error rather than trying any other/default URLs.\n\n### What happened (include all command output)?\n\n```\n==> Fetching downloads for: xz\n✘ Bottle xz (5.8.3)\nError: Failed to download resource \"xz\"\nDownload failed: https://<nexus_internal>/repository/githubcr-proxy/v2/homebrew/core/xz/blobs/sha256:55c891f5d47142fe923c87df0e3343d7ef2bc7d368c67892b4ad2c80e53069d5\ncurl: (6) Could not resolve host: <nexus_internal>\nWarning: Problem : timeout. Will retry in 1 seconds. 3 retries left.\ncurl: (6) Could not resolve host: <nexus_internal>\nWarning: Problem : timeout. Will retry in 2 seconds. 2 retries left.\ncurl: (6) Could not resolve host: <nexus_internal>\nWarning: Problem : timeout. Will retry in 4 seconds. 1 retries left.\ncurl: (6) Could not resolve host: <nexus_internal>\n```\n\n### What did you expect to happen?\n\nWhen `HOMEBREW_ARTIFACT_DOMAIN` is set, Homebrew will attempt to use the value set, if the artifact domain is not reachable, Homebrew will fallback to using the default ghcr.io domain.\n\n### Step-by-step reproduction instructions (by running `brew` commands)\n\n```shell\nHOMEBREW_ARTIFACT_DOMAIN=https://<internal_nexus>/repository/githubcr-proxy/ brew install xz\n```",
+    "labels": ["help wanted"],
+    "state": "closed",
+    "createdAt": "2026-04-02T22:55:15Z",
+    "updatedAtObserved": "2026-04-28T07:59:18Z"
+  },
+  "repoMeta": {
+    "stars": 48733,
+    "forks": 11203
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-04",
+    "detail": "Skipped: could not be reproduced or verified end-to-end without a private artifact host (verified live: state_reason=completed — someone else eventually resolved it upstream)."
+  },
+  "measurable": false,
+  "expectedVerdict": "skip",
+  "fidelityNote": "The skip reason is 'can't verify a fix works without infra John doesn't have' — a feasibility judgment, not something hasExistingPR/isClaimed/projectActive/clearRequirements models. Reported, not scored.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/homebrew-22206.json
+++ b/packages/core/eval/fixtures/vet/homebrew-22206.json
@@ -1,0 +1,40 @@
+{
+  "id": "homebrew-22206",
+  "url": "https://github.com/Homebrew/brew/issues/22206",
+  "owner": "Homebrew",
+  "repo": "brew",
+  "issueNumber": 22206,
+  "vetDate": "2026-05-10",
+  "issue": {
+    "title": "Error: Tab file for (cask) does not exist",
+    "body": "### Verification\n\n- [x] I understand that [if I ignore these instructions, my issue may be closed without review](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/faq/closing_issues_without_review.md).\n- [x] I have retried my command with `--force`.\n- [x] I ran `brew update-reset && brew update` and retried my command.\n- [x] I ran `brew doctor`, fixed as many issues as possible and retried my command.\n- [x] I have checked the instructions for [reporting bugs](https://github.com/Homebrew/homebrew-cask#reporting-bugs).\n- [x] I made doubly sure this is not a [checksum does not match / SHA256 mismatch](https://docs.brew.sh/Common-Issues#cask---checksum-does-not-match) error (do not open an issue before trying to open a PR to fix first).\n\n### Description of issue\n\nRunning `brew info --cask discord` reveals that the cask is \"Installed (as dependency)\".\n\nAttempting to change its installation to on-request, using the below command, fails with the below output.\n\nThe same behavior occurs with other casks that report being installed as dependency.\n\nChanging the installations of formulae and on-request casks with `brew tab` works as expected.\n\n### Command that failed\n\nbrew tab --installed-on-request --cask discord\n\n### Output of command with `--verbose --debug`\n\n```shell\n/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromAPILoader): loading discord\nError: Tab file for discord does not exist.\n/opt/homebrew/Library/Homebrew/cmd/tab.rb:70:in 'Homebrew::Cmd::TabCmd#update_tab'\n/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13184/lib/types/private/methods/call_validation.rb:286:in 'UnboundMethod#bind_call'\n/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13184/lib/types/private/methods/call_validation.rb:286:in 'T::Private::Methods::CallValidation.validate_call'\n/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13184/lib/types/private/methods/_methods.rb:259:in 'block in Homebrew::Cmd::TabCmd#_on_method_added'\n/opt/homebrew/Library/Homebrew/cmd/tab.rb:54:in 'block in Homebrew::Cmd::TabCmd#run'\n/opt/homebrew/Library/Homebrew/cmd/tab.rb:53:in 'Array#each'\n/opt/homebrew/Library/Homebrew/cmd/tab.rb:53:in 'Homebrew::Cmd::TabCmd#run'\n/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13184/lib/types/private/methods/call_validation.rb:286:in 'UnboundMethod#bind_call'\n/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13184/lib/types/private/methods/call_validation.rb:286:in 'T::Private::Methods::CallValidation.validate_call'\n/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13184/lib/types/private/methods/_methods.rb:259:in 'block in Homebrew::Cmd::TabCmd#_on_method_added'\n/opt/homebrew/Library/Homebrew/brew.rb:114:in '<main>'\nPlease report this issue:\n  https://docs.brew.sh/Troubleshooting\n```\n\n### Output of `brew doctor` and `brew config`\n\n```shell\nPlease note that these warnings are just used to help the Homebrew maintainers\nwith debugging if you file an issue. If everything you use Homebrew for is\nworking fine: please don't worry or file an issue; just ignore this. Thanks!\n\nWarning: Some installed casks are deprecated or disabled.\nYou should find replacements for the following casks:\n  dosbox-x-app\n  gstreamer-runtime\n  vmware-fusion\n  wine-stable\n\nHOMEBREW_VERSION: 5.1.10-52-g1c3a79e\nORIGIN: https://github.com/Homebrew/brew\nHEAD: 1c3a79e898a18b906531af25acf255461448d32d\nLast commit: 2 hours ago\nBranch: main\nCore tap JSON: 09 May 20:20 UTC\nCore cask tap JSON: 09 May 20:20 UTC\nHOMEBREW_PREFIX: /opt/homebrew\nHOMEBREW_CASK_OPTS: []\nHOMEBREW_DISPLAY: /var/run/com.apple.launchd.bd6musbP09/org.xquartz:0\nHOMEBREW_DOWNLOAD_CONCURRENCY: 20\nHOMEBREW_FORBID_PACKAGES_FROM_PATHS: set\nHOMEBREW_MAKE_JOBS: 10\nHOMEBREW_SORBET_RUNTIME: set\nHomebrew Ruby: 4.0.3 => /opt/homebrew/Library/Homebrew/vendor/portable-ruby/4.0.3/bin/ruby\nCPU: deca-core 64-bit arm_firestorm_icestorm\nClang: 21.0.0 build 2100\nGit: 2.50.1 => /Applications/Xcode.app/Contents/Developer/usr/bin/git\nCurl: 8.7.1 => /usr/bin/curl\nmacOS: 26.4.1-arm64\nCLT: 26.4.1.0.1775747724\nXcode: 26.4.1\nMetal Toolchain: N/A\nRosetta 2: false\n```\n\n### Output of `brew tap`\n\n```shell\ndcmfx/tap\nhomebrew/autoupdate\n```",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-05-09T21:32:23Z",
+    "updatedAtObserved": "2026-05-10T08:54:56Z"
+  },
+  "repoMeta": {
+    "stars": 48733,
+    "forks": 11203
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "lost_race",
+    "date": "2026-05-10",
+    "detail": "John's PR #22225 (opened 2026-05-10) was closed by the maintainer as a duplicate: PR #22211 by another contributor had merged ~9h earlier (verified live: #22211 merged=true, #22225 merged=false). The 'no other open PRs' check passed vacuously because #22211 was no longer open by the time John's PR was opened.",
+    "prUrl": "https://github.com/Homebrew/brew/pull/22225"
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "hasExistingPR=false is the CORRECT vet-time snapshot (no PR existed yet when John vetted/started); the competing PR was opened and merged entirely within John's build window. This is exactly the class of miss a snapshot-based existing-PR check structurally cannot catch — a fresh recheck immediately before push (which the vault's CLAUDE.md now mandates) is the real fix, not a vetting change.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/homebrew-22672.json
+++ b/packages/core/eval/fixtures/vet/homebrew-22672.json
@@ -1,0 +1,39 @@
+{
+  "id": "homebrew-22672",
+  "url": "https://github.com/Homebrew/brew/issues/22672",
+  "owner": "Homebrew",
+  "repo": "brew",
+  "issueNumber": 22672,
+  "vetDate": "2026-06-11",
+  "issue": {
+    "title": "brew bundle install with tap & root-level formula in that tap reports failure but succeeds",
+    "body": "### `brew doctor` output\n\n```shell\nPlease note that these warnings are just used to help the Homebrew maintainers\nwith debugging if you file an issue. If everything you use Homebrew for is\nworking fine: please don't worry or file an issue; just ignore this. Thanks!\n\nWarning: Your Xcode (26.1.1) is outdated.\nPlease update to Xcode 26.3 (or delete it).\nXcode can be updated from the App Store.\n\n\nThis is a Tier 2 configuration:\n  https://docs.brew.sh/Support-Tiers#tier-2\nYou can report issues with Tier 2 configurations to Homebrew/* repositories!\nRead the above document before opening any issues or PRs.\n```\n\nI have also reproduced this on a machine with no warnings from `brew doctor`, this is just the output I have the easiest access to copy-paste\n\n### Verification\n\n- [x] I ran `brew update` twice and am still able to reproduce my issue.\n- [x] My \"`brew doctor` output\" above says `Your system is ready to brew` or a definitely unrelated `Tier` message.\n- [x] This issue's title and/or description do not reference a single formula e.g. `brew install wget`. If they do, open an issue at https://github.com/Homebrew/homebrew-core/issues/new/choose instead.\n\n### `brew config` output\n\n```shell\nHOMEBREW_VERSION: 6.0.0\nORIGIN: https://github.com/Homebrew/brew\nHEAD: 3d9e344622974a7f96da927fd0407e08581eb437\nLast commit: 8 hours ago\nBranch: stable\nCore tap: N/A\nCore cask tap: N/A\nHOMEBREW_PREFIX: /opt/homebrew\nHOMEBREW_CASK_OPTS: []\nHOMEBREW_DOWNLOAD_CONCURRENCY: 24\nHOMEBREW_FORBID_PACKAGES_FROM_PATHS: set\nHOMEBREW_MAKE_JOBS: 12\nHOMEBREW_REQUIRE_TAP_TRUST: set\nHomebrew Ruby: 4.0.5 => /opt/homebrew/Library/Homebrew/vendor/portable-ruby/4.0.5_1/bin/ruby\nCPU: dodeca-core 64-bit arm_brava\nClang: 17.0.0 build 1700\nGit: 2.50.1 => /Applications/Xcode.app/Contents/Developer/usr/bin/git\nCurl: 8.7.1 => /usr/bin/curl\nmacOS: 26.5-arm64\nCLT: 26.5.0.0.1777544298\nXcode: 26.1.1\nMetal Toolchain: N/A\nRosetta 2: false\n```\n\n### What were you trying to do (and why)?\n\nI'm attempting to set up a `Brewfile` for reproducible installation of development environments, and I need to be able to install packages from third-party taps. One of the taps in question has its formulas at the root directory of the repo. Attempting to do so as of Homebrew 6 now experiences an error.\n\n### What happened (include all command output)?\n\n`brew bundle install` reports 3 warnings, a failure, and exits with a non-zero status code. However, the installation is actually successful and on a re-run there is nothing to be done\n\n```\n❯ brew bundle install\nWarning: 'metalbear-co/mirrord/mirrord' formula is unreadable: No available formula with the name \"metalbear-co/mirrord/mirrord\".\nThis command requires the tap metalbear-co/mirrord.\nIf you trust this tap, tap it explicitly and then try again:\n  brew tap metalbear-co/mirrord\nWarning: 'metalbear-co/mirrord/mirrord' formula is unreadable: No available formula with the name \"metalbear-co/mirrord/mirrord\".\nThis command requires the tap metalbear-co/mirrord.\nIf you trust this tap, tap it explicitly and then try again:\n  brew tap metalbear-co/mirrord\nTapping metalbear-co/mirrord\nInstalling metalbear-co/mirrord/mirrord\nWarning: 'metalbear-co/mirrord/mirrord' formula is unreadable: No available formula with the name \"metalbear-co/mirrord/mirrord\".\nInstalling metalbear-co/mirrord/mirrord has failed!\n`brew bundle` failed! 1 Brewfile dependency failed to install\n\n~/Desktop\n❯ brew list | grep mirrord\nmirrord\n\n~/Desktop\n❯ brew bundle install\nUsing metalbear-co/mirrord\nUsing metalbear-co/mirrord/mirrord\n`brew bundle` complete! 2 Brewfile dependencies now installed.\n```\n\n### What did you expect to happen?\n\nI'd expect:\n- No errors to be logged, as the Brewfile is tapping & trusting the tap\n- The command to exit with no error and a 0 status code, as it actually installed successfully\n\nAlternatively, if root-level formulas are not supported I'd expect it to error out entirely, rather than installing successfully\n\n### Step-by-step reproduction instructions (by running `brew` commands)\n\nWrite the following to a Brewfile (origin provided because of #22668):\n\n```ruby\ntap \"metalbear-co/mirrord\", \"https://github.com/metalbear-co/homebrew-mirrord\", trusted: true\nbrew \"metalbear-co/mirrord/mirrord\", trusted: true\n```\n\nInstall the brewfile with `brew bundle install`\n\nIt will report 3 warning, a failure, and exit with a non-zero status, but will have successfully installed the tap and the formula\n",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-06-11T19:55:11Z",
+    "updatedAtObserved": "2026-06-12T01:14:17Z"
+  },
+  "repoMeta": {
+    "stars": 48733,
+    "forks": 11203
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 1
+  },
+  "outcome": {
+    "label": "maintainer_fixed",
+    "date": "2026-06-12",
+    "detail": "Maintainer swept/closed the issue as completed within the 24-48h window flagged at vet time (verified live: state=closed, state_reason=completed)."
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "closedWithoutMergeCount=1 reflects the real prior history: John's #22225 (see homebrew-22206 fixture) had closed without merging a month earlier in this same repo, so calculateViabilityScore's -15 closed-without-merge penalty legitimately applies here even though mergedPRCount=0.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/nautilus-trader-4096.json
+++ b/packages/core/eval/fixtures/vet/nautilus-trader-4096.json
@@ -1,0 +1,39 @@
+{
+  "id": "nautilus-trader-4096",
+  "url": "https://github.com/nautechsystems/nautilus_trader/issues/4096",
+  "owner": "nautechsystems",
+  "repo": "nautilus_trader",
+  "issueNumber": 4096,
+  "vetDate": "2026-05-19",
+  "issue": {
+    "title": "Bybit XRP option symbols with decimal strikes incorrectly parsed as composite",
+    "body": "# Bug Report\n\n## Confirmation\n\n  - [x] I've re-read the relevant sections of the documentation.\n  - [x] I've searched existing issues and discussions to avoid duplicates.\n  - [x] I've reviewed or skimmed the source code (or examples) to confirm the behavior is not by design.\n  - [x] I've tested this issue using a recent *development* wheel (`dev` develop or `a` nightly) and can still reproduce it.\n\n  ---\n\n  ### Expected Behavior\n\n  Subscribing to order book deltas for a Bybit option whose strike price contains a decimal point\n  (e.g. `XRP-22MAY26-0.8-C-USDT-OPTION.BYBIT`) should behave identically to subscribing to any\n  other single-instrument option. `DataEngine._setup_order_book` should create a book for the\n  specified instrument and return without error.\n\n  ### Actual Behavior\n\n  The `DataEngine` crashes with an unhandled `TypeError` during `DataCommand` queue processing,\n  bringing down the entire trading node:\n\n  [ERROR] DataEngine: Unexpected exception in DataCommand queue processing:\n  TypeError(\"Argument 'other' has incorrect type (expected nautilus_trader.model.objects.Currency, got str)\")\n\n  This is caused by a two-step failure:\n\n  1. **`Symbol.is_composite()` misfires on decimal strikes.**\n     Nautilus uses `.` as the composite-symbol separator (e.g. `ES.CME`). Any option whose\n     strike price contains a decimal point — common on low-priced underlyings like XRP, DOGE, SHIB —\n     causes `is_composite()` to return `True` for what is a fully-qualified single-instrument ID:\n\n     ```python\n     InstrumentId.from_str(\"XRP-22MAY26-0.8-C-USDT-OPTION.BYBIT\").symbol.is_composite()\n     # True  ← incorrect; the '.' belongs to the strike, not a composite separator\n     InstrumentId.from_str(\"BTC-29MAY26-90000-C-USDT-OPTION.BYBIT\").symbol.is_composite()\n     # False ← correct; integer strike, no dot\n\n  2. Cache.instruments(underlying=…) compares a str to a Currency object.\n  Because is_composite() returned True, DataEngine._setup_order_book calls:\n\n  root = command.instrument_id.symbol.root()        # e.g. \"XRP-22MAY26-0\"  (str)\n  instruments = self._cache.instruments(venue=..., underlying=root)\n\n  2. Inside Cache.instruments the filter is:\n\n  underlying == x.underlying   # str == Currency\n\n  2. str.__eq__(Currency) returns NotImplemented; Python then tries Currency.__eq__(str),\n  which raises TypeError because the Cython Currency.__eq__ enforces strict typing.\n\n  The combined effect is a hard crash on the first SubscribeOrderBook command for any option\n  with a non-integer strike, despite the instrument having loaded and been cached correctly.\n\n  Steps to Reproduce the Problem\n\n  1. Connect a BybitDataClient for the OPTION product type with base_coin = \"XRP\".\n  2. Call strategy.subscribe_order_book_deltas(instrument_id, ...) for any XRP option whose\n  strike is a decimal (e.g. XRP-22MAY26-0.8-C-USDT-OPTION.BYBIT).\n  3. Observe the TypeError in the DataEngine command queue and node shutdown.\n\n  Code Snippets or Logs\n\n  Minimal reproduction of the misfire (no exchange connection needed):\n\n  from nautilus_trader.model.identifiers import InstrumentId\n\n  float_strike  = InstrumentId.from_str(\"XRP-22MAY26-0.8-C-USDT-OPTION.BYBIT\")\n  int_strike    = InstrumentId.from_str(\"BTC-29MAY26-90000-C-USDT-OPTION.BYBIT\")\n\n  print(float_strike.symbol.is_composite())   # True  — unexpected\n  print(float_strike.symbol.root())           # 'XRP-22MAY26-0' — meaningless root\n  print(int_strike.symbol.is_composite())     # False — correct\n\n  Full stack trace from a live node:\n\n  File \".../nautilus_trader/live/data_engine.py\", line 412, in _run_cmd_queue\n      self._execute_command(command)\n  File \"nautilus_trader/data/engine.pyx\", line 855,  in DataEngine._execute_command\n  File \"nautilus_trader/data/engine.pyx\", line 893,  in DataEngine._execute_command\n  File \"nautilus_trader/data/engine.pyx\", line 905,  in DataEngine._handle_subscribe\n  File \"nautilus_trader/data/engine.pyx\", line 1025, in DataEngine._handle_subscribe_order_book\n  File \"nautilus_trader/data/engine.pyx\", line 1035, in DataEngine._setup_order_book\n  File \"nautilus_trader/cache/cache.pyx\", line 3747, in Cache.instruments\n  TypeError: Argument 'other' has incorrect type (expected nautilus_trader.model.objects.Currency, got str)\n\n  Relevant source locations:\n\n  - engine.pyx ~1033: if command.instrument_id.symbol.is_composite():\n  - engine.pyx ~1035: instruments = self._cache.instruments(venue=..., underlying=root) — root is str\n  - cache.pyx  ~3747: underlying == x.underlying — x.underlying is Currency\n\n  Specifications\n\n  - OS platform: Linux (Debian 12 bookworm, x86-64)\n  - Python version: 3.12\n  - nautilus_trader version: 1.224.0\n",
+    "labels": ["bug", "wontfix"],
+    "state": "closed",
+    "createdAt": "2026-05-19T10:25:11Z",
+    "updatedAtObserved": "2026-05-20T00:54:31Z"
+  },
+  "repoMeta": {
+    "stars": 24464,
+    "forks": 3116
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "maintainer_fixed",
+    "date": "2026-05-19",
+    "detail": "Maintainer closed the issue NOT_PLANNED same day, having fixed the underlying problem differently on the Rust data-engine path (verified live: state=closed, state_reason=not_planned)."
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Not a self-fix in the same sense as the super-productivity cases — maintainer solved a related-but-different root cause and declined the Cython-path fix as legacy. Bucketed as maintainer_fixed because the practical effect (John's ready fix was never pushed) is the same.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/near-cli-rs-581.json
+++ b/packages/core/eval/fixtures/vet/near-cli-rs-581.json
@@ -1,0 +1,40 @@
+{
+  "id": "near-cli-rs-581",
+  "url": "https://github.com/near/near-cli-rs/issues/581",
+  "owner": "near",
+  "repo": "near-cli-rs",
+  "issueNumber": 581,
+  "vetDate": "2026-04-04",
+  "issue": {
+    "title": "[Task] Check that recipient is valid before sending transaction",
+    "body": "### Background\n\nIt would be nice to add a check that recipient is valid before sending transaction. It could be done in two ways:\n1) Making an rpc call to check that recipient exists on-chain and ask something like \"The provided recipient `<account-id>` does not exist on `<network>`, are you sure that you want to proceed? (y/n)\"\n\nThis option can be more robust, but it'll make life a bit harder for those who want to send tokens to new account that wasn't activated yet\n\n2) By raw parent account check and making sure that \"testnet\" is not parent if mainnet network is selected and vice versa for testnet network\n\nI think one this is simpler and doesn't require extra rpc call\n\n### User Story\n\nAs a user I want to have minimal chances of submitting a transaction to a recipient on different network or non-existent recipient at all, but I still want to be able to do it after explicit confirmation, I shouldn't be blocked by this\n\n### Acceptance Criteria\n\nI think this can be added only for `tokens` subcommand for now, since contract should be safe (call will immediately fail if recipient is invalid)\n\n### Resources & Additional Notes\n\nThis is needed to prevent such issues https://nearblocks.io/txns/4SeBJbjHxkEmtbwB1T7FLxBHzkgGCg3HmqCcbQoatL2Q",
+    "labels": ["enhancement", "good first issue"],
+    "state": "closed",
+    "createdAt": "2026-04-01T19:48:08Z",
+    "updatedAtObserved": "2026-05-08T00:09:06Z"
+  },
+  "repoMeta": {
+    "stars": 144,
+    "forks": 77
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": true,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": false,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-04",
+    "detail": "Skipped: competing PR #582 already under review at vet time (verified live: #582 merged=true).",
+    "prUrl": "https://github.com/near/near-cli-rs/pull/582"
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "hasExistingPR=true matches checkNoExistingPR.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/open-design-5081.json
+++ b/packages/core/eval/fixtures/vet/open-design-5081.json
@@ -1,0 +1,39 @@
+{
+  "id": "open-design-5081",
+  "url": "https://github.com/nexu-io/open-design/issues/5081",
+  "owner": "nexu-io",
+  "repo": "open-design",
+  "issueNumber": 5081,
+  "vetDate": "2026-07-02",
+  "issue": {
+    "title": "[Bug]: Kiro missing from agentLabels.ts (no display label / alias)",
+    "body": "## Before you submit\n- [x] I searched existing issues and confirmed this is not a duplicate.\n- [x] I replaced the example text with the real behavior, reproduction steps, expected result, and version.\n\n## What happened?\n`apps/web/src/utils/agentLabels.ts` has no entry for **Kiro**, so Kiro is not treated as a first-class agent in the web UI the way Claude, Codex, and Devin are.\n\nConcretely, in `AGENT_LABELS`:\n- there is **no** `kiro: 'Kiro'` (or `'Kiro CLI'`) label, and\n- in `AGENT_ALIASES` there is **no** `'kiro cli': 'kiro'` alias.\n\nBecause of this, `exactAgentDisplayName('kiro')` returns `null`, and `agentDisplayName('kiro', …)` falls through to `safeFallbackLabel`, rendering a raw/normalized string instead of the canonical brand name. Every consumer of these helpers is affected — e.g. `agentModelDisplayName` (used to show \"Agent · model\") and any UI that resolves an agent's display name (handoff/agent chips, run headers).\n\nNote the brand icon already exists at `apps/web/public/agent-icons/kiro.svg`, so this is purely a missing label/alias mapping, not a missing asset. Kiro is otherwise a fully supported runtime (`apps/daemon/src/runtimes/defs/kiro.ts`, registered in `runtimes/registry.ts`, metadata → `https://kiro.dev`).\n\nFor comparison, `AGENT_LABELS` currently contains `claude: 'Claude'`, `codex: 'Codex'`, `devin: 'Devin'`, `antigravity: 'Antigravity'`, etc., but not `kiro`.\n\n## Steps to reproduce\n1. Run an Open Design session using the **Kiro CLI** agent (agent id `kiro`).\n2. Look at any UI surface that shows the agent's display name (agent chip / run header / \"Agent · model\" label).\n3. Observe the label is a raw fallback (e.g. `kiro` / `Kiro CLI` passed through) rather than a canonical, alias-normalized brand label like the other agents get.\n\nAlternatively, in code: `exactAgentDisplayName('kiro')` returns `null`, whereas `exactAgentDisplayName('codex')` returns `'Codex'`.\n\n## Expected behavior\n`agentLabels.ts` maps Kiro like the other first-class agents:\n- `AGENT_LABELS`: add `kiro: 'Kiro'` (label consistent with the other short brand names).\n- `AGENT_ALIASES`: add `'kiro cli': 'kiro'` (and `'kiro-cli': 'kiro'`) so the daemon's `name: 'Kiro CLI'` / `bin: 'kiro-cli'` resolve to the canonical id.\n\nAfter the fix, `exactAgentDisplayName('kiro')` / `agentDisplayName('kiro', 'Kiro CLI')` return `'Kiro'`, and `agentIconId('kiro')` resolves to the existing `kiro.svg` brand asset. No regression to existing agents.\n\n## Open Design version\n0.12.1\n\n## Platform\nOther — UI label mapping, not OS-specific.\n\n## Logs (optional)\n```shell\n# Not applicable — no runtime error; incorrect/generic display label only.\n```\n\n## Screenshots (optional)\nAttach a screenshot of a Kiro run's agent chip / header showing the non-canonical label.\n\n## Additional context\n- The same file is also missing labels for other newer ACP agents (hermes, kilo, kimi, vibe, pi, grok/grok-build, trae/trae-cli, reasonix). This issue is scoped to **Kiro**; the others can be a follow-up.\n- Part of a broader effort to make Kiro a true first-class equivalent of Claude Code and Codex across the product (see also the MCP dropdown bug and the `od mcp install kiro` request).\n",
+    "labels": ["bug"],
+    "state": "open",
+    "createdAt": "2026-07-02T16:01:49Z",
+    "updatedAtObserved": "2026-07-06T00:12:07Z"
+  },
+  "repoMeta": {
+    "stars": 75275,
+    "forks": 8611
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "lost_race",
+    "date": "2026-07-02",
+    "detail": "Another contributor claimed + opened an identical-fix PR (#5085) while John's clone was still downloading; John's finished, review-gated fix was never pushed (zero external footprint)."
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Race timing is not observable from a point-in-time vet snapshot — oss-scout has no signal for 'a competing contributor is about to claim this in the next N minutes'. Excluded from headline accuracy; reported in the lost-race appendix.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/pg-clickhouse-167.json
+++ b/packages/core/eval/fixtures/vet/pg-clickhouse-167.json
@@ -1,0 +1,39 @@
+{
+  "id": "pg-clickhouse-167",
+  "url": "https://github.com/ClickHouse/pg_clickhouse/issues/167",
+  "owner": "ClickHouse",
+  "repo": "pg_clickhouse",
+  "issueNumber": 167,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "Convert all errors to ereport",
+    "body": "Replace all instances of `elog()` with `ereport()` with an appropriate error code and always prefixed with `pg_clickhouse: `. For generic FDW errors, for example:\n\n\n```c\nereport(ERROR,\n\t\terrcode(ERRCODE_FDW_ERROR),\n\t\terrmsg(\"pg_clickhouse: failed to push down %s\", text_to_cstring(name))\n\t);\n```\n\nConsult `include/server/utils/errcodes.h` for the relevant error codes.",
+    "labels": ["good first issue", "quality"],
+    "state": "closed",
+    "createdAt": "2026-04-01T16:26:29Z",
+    "updatedAtObserved": "2026-07-01T02:38:08Z"
+  },
+  "repoMeta": {
+    "stars": 251,
+    "forks": 14
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": true,
+    "projectActive": true,
+    "contributionGuidelinesFound": false,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-12",
+    "detail": "Skipped: issue assigned to @serprex at vet time (verified live: assignee still on the closed issue)."
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "isClaimed=true matches checkNotClaimed's assignee check.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/react-spectrum-9916.json
+++ b/packages/core/eval/fixtures/vet/react-spectrum-9916.json
@@ -1,0 +1,40 @@
+{
+  "id": "react-spectrum-9916",
+  "url": "https://github.com/adobe/react-spectrum/issues/9916",
+  "owner": "adobe",
+  "repo": "react-spectrum",
+  "issueNumber": 9916,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "`AlertDialog` renders without `aria-describedby`",
+    "body": "### Provide a general summary of the issue here\n\nWhen using `AlertDialog` (with `role=\"alertdialog\"`), the component renders without `aria-describedby`.\n\nAccording to the W3C specification, authors SHOULD use `aria-describedby` on an `alertdialog` to reference the alert message element in the dialog.\nhttps://www.w3.org/TR/wai-aria-1.2/#alertdialog\n\n### 🤔 Expected Behavior?\n\nI think one of the following behaviors should be expected:\n- `AlertDialog` automatically assigns an ID to the content element and sets `aria-describedby` on the dialog to reference it.\n- A development warning is shown when a rendered alertdialog lacks `aria-describedby`\n\n### 😯 Current Behavior\n\n`AlertDialog` renders without `aria-describedby` by default. \n\n### 💁 Possible Solution\n\n_No response_\n\n### 🔦 Context\n\n_No response_\n\n### 🖥️ Steps to Reproduce\n\nhttps://codesandbox.io/p/sandbox/happy-saha-jtm36v?file=%2Fsrc%2FApp.js%3A26%2C1\n\n### Version\n\n3.31.0\n\n### What browsers are you seeing the problem on?\n\nChrome\n\n### If other, please specify.\n\n_No response_\n\n### What operating system are you using?\n\nmacOS\n\n### 🧢 Your Company/Team\n\n_No response_\n\n### 🕷 Tracking Issue\n\n_No response_",
+    "labels": ["accessibility"],
+    "state": "closed",
+    "createdAt": "2026-04-12T13:30:33Z",
+    "updatedAtObserved": "2026-06-25T23:20:58Z"
+  },
+  "repoMeta": {
+    "stars": 15629,
+    "forks": 1496
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-06-25",
+    "detail": "PR #9924 merged 2026-06-25, a much longer review cycle than most (verified live: merged=true)",
+    "prUrl": "https://github.com/adobe/react-spectrum/pull/9924"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Merge landed >2 months after vet/PR-open — long enterprise-repo review latency, unrelated to vet quality.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-7188.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-7188.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-7188",
+  "url": "https://github.com/super-productivity/super-productivity/issues/7188",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 7188,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "🚨 Time estimate is reset when clicking on the title input field after setting the estimate",
+    "body": "### Version Used\n\n17.2.4 (Linux Mint desktop app, Windows 10 desktop app)\n\n### Expected Behavior\n\nWhen creating a new task, setting a time estimate first and then clicking on the title field to type the task name should preserve the estimate value.\n\n### Current Behavior\n\nIf a time estimate is selected from the dropdown *before* the task title is entered, clicking on the title input field immediately resets the estimate to zero.\n\n### Steps to Reproduce\n\n1. Open the add task input area\n2. Set a time estimate by selecting a value from the estimate dropdown (e.g. 30m)\n3. Click on the title input field to start typing the task name\n4. The time estimate is immediately cleared/reset to zero\n\n**Environment**\n- Version: 17.2.4\n- OS: Linux Mint (desktop app) / Windows 10 (desktop app)\n- Sync: Dropbox (3 devices)\n\n### Can you reproduce this reliably?\n\nYes, I can reproduce it reliably.\n\n### Console Output\n\n```shell\n\n```\n\n### documentation gap\n\n- [ ] The documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) is unclear or incorrect for this case.\n- [ ] There should be a note added to the documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) for this case.\n- [ ] I can help improve the documentation.",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-04-10T18:33:44Z",
+    "updatedAtObserved": "2026-04-13T14:44:59Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-04-13",
+    "detail": "PR #7211 merged 2026-04-13 (verified live: merged=true)",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/7211"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Cold-start in this repo, same as #7219/#7191.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-7191.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-7191.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-7191",
+  "url": "https://github.com/super-productivity/super-productivity/issues/7191",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 7191,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "🚨 \"Database Error - Cannot Load Data\" (indexedDB) when session is closed and reopened with autostart enabled",
+    "body": "**Version Used**\n17.2.4 (Linux Mint Cinnamon, Flatpak)\n\n**Expected Behavior**\nWhen logging out of a Linux Mint session and logging back in, with Super Productivity set to autostart, the app should open normally and load data without errors.\n\n**Current Behavior**\nAfter logging out of the Linux Mint (Cinnamon) session and logging back in, the app (launched automatically at session start) displays the following error:\n\n\"Database Error - Cannot Load Data\nSuper Productivity cannot open its database. This may be caused by:\n- Low disk space\n- Temporary file lock (try closing other tabs)\n- Storage corruption\nTechnical details: Internal error opening backing store for indexedDB.open.\"\n\nThe error occurs consistently on every logout/login cycle. Workaround: manually closing the app, waiting a few minutes, then relaunching it starts correctly.\n\n**Steps to Reproduce**\n1. Install SP via Flatpak on Linux Mint Cinnamon\n2. Set Super Productivity to autostart at session login\n3. Open a session with SP running\n4. Log out of the session (Menu → Log out)\n5. Log back in\n6. SP launches automatically and immediately shows the indexedDB error\n\nTested multiple times — behavior is consistent.\n\nNote: Similar errors have been reported in older issues (#375, #419, #955) but none identified this specific trigger (logout/login cycle with autostart). Closing SP manually before logging out prevents the error.\n\n**Your Environment**\n- Version: 17.2.4\n- OS: Linux Mint Cinnamon\n- Install method: Flatpak (com.super_productivity.SuperProductivity)\n- Sync: Dropbox (3 devices)\n\n### Can you reproduce this reliably?\n\nYes, I can reproduce it reliably.\n\n### Console Output\n\n```shell\n\n```\n\n### documentation gap\n\n- [ ] The documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) is unclear or incorrect for this case.\n- [ ] There should be a note added to the documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) for this case.\n- [ ] I can help improve the documentation.",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-04-10T18:44:03Z",
+    "updatedAtObserved": "2026-04-15T16:19:54Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-04-19",
+    "detail": "PR #7220 merged 2026-04-19 (verified live: merged=true)",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/7220"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Cold-start in this repo, same as #7219/#7188.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-7219.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-7219.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-7219",
+  "url": "https://github.com/super-productivity/super-productivity/issues/7219",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 7219,
+  "vetDate": "2026-04-13",
+  "issue": {
+    "title": "💥 Failed to execute 'querySelector' on 'Document': '#t-{private-dropbox-id} is not a valid selector.",
+    "body": "### Steps to Reproduce\n\nUncertain, as there were several actions here and I only recall the last  couple\n\n1. Swipe left to open context menu\n2. Delete task\n\n### Additional Console Output\nOn Android\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n### Url\nhttps://localhost/#/tag/TODAY/tasks\n\n\n\n### Meta Info\nMETA: SP18.1.3_L2A __ Browser – en-US – Linux armv8l – en-US – UA:Mozilla/5.0 (Linux; Android 13; Lenovo TB125FU Build/TP1A.220624.014; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/146.0.7680.177 Safari/537.36\n\n\n### Stacktrace\n```\nn._highlightSourceTask (https://localhost/chunk-6SR4OEIZ.js:13:21449)\nn.open (https://localhost/chunk-6SR4OEIZ.js:13:15681)\nn.open (https://localhost/chunk-6SR4OEIZ.js:14:834)\nn.openContextMenu (https://localhost/chunk-GTIGPKPG.js:3:20112)\nhttps://localhost/chunk-GTIGPKPG.js:3:25450\nGh (https://localhost/chunk-GENRFGET.js:4:63169)\nr (https://localhost/chunk-GENRFGET.js:4:63005)\nCo.emit (https://localhost/chunk-GENRFGET.js:4:140025)\nhttps://localhost/chunk-GXRACEOH.js:4:7927\n```\n\n\n### Actions Before Error\n```\n1776104698893: [Task] SetSelectedTask \n1776104700776: [SP_ALL] Load(import) all data \n1776104700813: [AppState] Set Today String \n1776104700829: [SP_ALL] All Data was loaded \n1776104700848: [Idle] Reset \n1776104771820: [Task] SetSelectedTask (2) \n1776104771832: [Layout] Hide Non-Task Side Panel \n1776104778257: [Task Shared] updateTask (2) \n1776104784729: [Task] SetSelectedTask \n1776104784736: [Layout] Hide Non-Task Side Panel \n1776104786170: [Task] SetSelectedTask (2) \n1776104786175: [Layout] Hide Non-Task Side Panel \n1776104794601: [Task Shared] updateTask (2) \n1776104795425: [Task] SetSelectedTask \n1776104795429: [Layout] Hide Non-Task Side Panel \n1776104796596: [Task] SetSelectedTask (2) \n1776104796600: [Layout] Hide Non-Task Side Panel \n1776104800201: [Task Shared] updateTask \n1776104802556: [Task] SetSelectedTask \n1776104802563: [Layout] Hide Non-Task Side Panel \n1776104804174: [Task] SetSelectedTask (2) \n1776104804179: [Layout] Hide Non-Task Side Panel \n1776104808698: [Task Shared] updateTask (2) \n1776104814261: [Task] SetSelectedTask \n1776104814268: [Layout] Hide Non-Task Side Panel \n1776104815412: [Task] SetSelectedTask (2) \n1776104815415: [Layout] Hide Non-Task Side Panel \n1776104819137: [Task Shared] updateTask (2) \n1776104824138: [Task] SetSelectedTask \n1776104824149: [Layout] Hide Non-Task Side Panel\n```",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-04-13T19:03:06Z",
+    "updatedAtObserved": "2026-04-16T16:03:47Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-04-16",
+    "detail": "PR #7222 merged 2026-04-16 (verified live: merged=true)",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/7222"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "One of John's earliest contributions to this repo — no prior merged/closed PR history yet (mergedPRCount=0), unlike the June entries above.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-7674.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-7674.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-7674",
+  "url": "https://github.com/super-productivity/super-productivity/issues/7674",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 7674,
+  "vetDate": "2026-06-09",
+  "issue": {
+    "title": "💡 Azure DevOps: Allow filtering by iteration (\"Iteration Path\") and teams/subteams (\"Area Path\"), issue type and more (WIQL support?)",
+    "body": "### Problem Statement\n\nAs a followup from https://github.com/super-productivity/super-productivity/pull/6446#discussion_r2798480446 even when testing manually I have the problem to find the actual task/issues to work on.\n\nSpecifically these filters seem to be useful:\n* by type ([bug/task/Product backlog items etc.](https://learn.microsoft.com/en-us/azure/devops/boards/work-items/guidance/scrum-process?view=azure-devops))\n* by iteration (\"sprint\" aka in agile developments you usually work in iterations that are natively supported by ADS)\n* by area (aka \"projects\", these may be useful, note ADS has a tree-hierarchy here aka allows for subareas separated by `/`)\n\n### Possible Solution\n\nADS has a \"key-value\" schema for many properties, as it is very customizable it can have different names, but usually \"Iteration Path\" is the iteration and \"area path\" is the \"team\":\n\n<img width=\"711\" height=\"132\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/13e4cca6-c56e-44d5-9368-96d41db4f71a\" />\n\nMaybe just allow passing a custom filter or so?\n\nActually best supports a custom query langauge: [WIQL reference](https://learn.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax?view=azure-devops)\nIt is AFAIK the same and can also [be defined from the GUI](https://learn.microsoft.com/en-us/azure/devops/boards/queries/using-queries?view=azure-devops&tabs=browser).\n\n### Describe alternatives you've considered\n\n* As shown above, even in the GUI you can define queries. Maybe allow selecting just \"a query\" from that list?\n* Or maybe a simpler implementation by just hardcoding the filter? As the current selection \"only assigned to me\" etc. allows?\n\n### Additional context\n\nIIRC your Jira integration has similar support/also supports their query language, so that may be useful.",
+    "labels": ["help wanted"],
+    "state": "closed",
+    "createdAt": "2026-05-19T10:43:02Z",
+    "updatedAtObserved": "2026-06-22T15:38:51Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-06-22",
+    "detail": "PR #8516 merged 2026-06-22 after a comment-first scoping round (verified live: merged=true)",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/8516"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Interesting calibration case: the issue body floats 3 mutually-exclusive designs (unclear scope at face value), so analyzeRequirements(body) may legitimately score clearRequirements=false. The eventual merge only happened because John scoped it with a comment before writing code, not from the raw issue alone — a good illustration that 'needs_review' can be the MORE honest verdict than a clean approve/skip binary for this one.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-7785.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-7785.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-7785",
+  "url": "https://github.com/super-productivity/super-productivity/issues/7785",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 7785,
+  "vetDate": "2026-05-25",
+  "issue": {
+    "title": "🚨 Mobile swipe action always shows \"Mark as done\" even for completed tasks",
+    "body": "### Version Used\n\n18.4.4_L2A (Android, Fairphone 5)\n\n### Current Behavior\n\nThe swipe action always displays \"Mark as done\" (MARK_DONE key) regardless \nof the task's current state. The action itself works correctly (it does \nre-activate the task), but the label is misleading.\n\n### Expected Behavior\n\nWhen swiping left on a completed task, the action label should reflect \nthe actual action: \"Mark as undone\" (or equivalent), since the task is \nalready done.\n\n### Steps to Reproduce\n\n1. Mark a task as done on Android\n2. Swipe left on that completed task\n3. The action label reads \"Mark as done\" instead of \"Mark as undone\"\n\n**Suggestion**\nAdd a separate i18n key (e.g. MARK_UNDONE) and use it conditionally \nbased on the task's current done state.\n\n**Note**\nThis action (re-activating a completed task) is not available on desktop \n(PC), where unchecking the task checkbox achieves the same result.\n\n### Can you reproduce this reliably?\n\nYes, I can reproduce it reliably.\n\n### Console Output\n\n```shell\n\n```\n\n### Documentation\n\n- [ ] The documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) is unclear or incorrect for this case.\n- [ ] There should be a note added to the documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) for this case.",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-05-25T14:56:16Z",
+    "updatedAtObserved": "2026-05-26T11:36:29Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-05-26",
+    "detail": "PR #7792 merged 2026-05-26 (verified live: merged=true)",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/7792"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "By this vet date John had several earlier merged PRs in this repo (#7211/#7220/#7222 all landed in April), so mergedPRCount treated as established (>0).",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-7786.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-7786.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-7786",
+  "url": "https://github.com/super-productivity/super-productivity/issues/7786",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 7786,
+  "vetDate": "2026-05-25",
+  "issue": {
+    "title": "🚨 Content of the task deleted when a checkbox was created",
+    "body": "### Version Used\n\nv18.7.0W Windows11\n\n### Current Behavior\n\nIf you create a new task in the board view and then try to add a checkbox, the entire content (note) of the task is deleted and a single checkbox is inserted instead (see video).\n\n<img width=\"300\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/bcd0b9fe-4251-4240-a898-5619d6ec256d\" />\n\nThe text in the ‘note’ in the video was pre-set (Settings -> Tasks). However, I've also had it happen before that the entire text was deleted when I'd already written something by myself.\n\nOtherwise, I’m happy with the checkbox feature and grateful that it’s available.\n\n### Expected Behavior\n\nWhen I create a checkbox, it should be inserted at the last cursor position. Alternatively, it can simply be inserted at the end of the text. Under no circumstances, however, should the existing text be deleted.\n\n### Steps to Reproduce\n\nsee video\n\n### Can you reproduce this reliably?\n\nYes, I can reproduce it reliably.\n\n### Console Output\n\n```shell\n\n```\n\n### Documentation\n\n- [ ] The documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) is unclear or incorrect for this case.\n- [ ] There should be a note added to the documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) for this case.",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-05-25T16:02:22Z",
+    "updatedAtObserved": "2026-05-26T11:22:41Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-05-26",
+    "detail": "PR #7793 merged 2026-05-26 (verified live: merged=true)",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/7793"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Same vet round as #7785, same repo/history facts.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-8220.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-8220.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-8220",
+  "url": "https://github.com/super-productivity/super-productivity/issues/8220",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 8220,
+  "vetDate": "2026-06-09",
+  "issue": {
+    "title": "🚨 Estimate remaining time in \"Today\" and \"Planner\" calculated differently for recurrent tasks",
+    "body": "### Version Used\n\n18.9.1WB (firefox desktop) and 18.8.0_L2AF (f-droid)\n\n### Current Behavior\n\nWhen I have a recurrent task and mark it as done without adding time for it (e.g. because the meeting didn't take place) its estimated time is still added to the remaining time in the \"Planner\" tab, but substracted in the \"Today\" tab.\n\nToday tab:\n\n<img width=\"874\" height=\"450\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/0f88bbb6-3682-4539-97a2-72dc92791d9f\" />\n\nPlanner tab:\n\n<img width=\"267\" height=\"650\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/e4397d07-2611-49d3-a370-44398b96fe94\" />\n\n### Expected Behavior\n\nWhen a task is marked as done, the time should not be used to calculate the total remaining time in the \"Planner\" tab.\n\n### Steps to Reproduce\n\nAdd a recurring task to today with a fixed time (e.g. 1h) and mark it as done without tracking time for it. The remaining time in \"today\" and \"planner\" is different.\n\n### Can you reproduce this reliably?\n\nYes, I can reproduce it reliably.\n\n### Console Output\n\n```shell\n\n```\n\n### Documentation\n\n- [ ] The documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) is unclear or incorrect for this case.\n- [ ] There should be a note added to the documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) for this case.",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-06-09T14:58:05Z",
+    "updatedAtObserved": "2026-06-09T20:43:50Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "merged",
+    "date": "2026-06-09",
+    "detail": "PR #8229 merged same day, 2026-06-09 (verified live: merged=true)",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/8229"
+  },
+  "measurable": true,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Fast same-day merge; established repo history by now.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-8232.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-8232.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-8232",
+  "url": "https://github.com/super-productivity/super-productivity/issues/8232",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 8232,
+  "vetDate": "2026-06-09",
+  "issue": {
+    "title": "fix(planner): timed recurring tasks (`dueWithTime`) still double-counted after #8229",
+    "body": "### Context\n\nFollow-up to #8220 / #8229.\n\n#8229 fixes the Planner's double-count for recurring tasks marked done without time tracked, by deduping repeat projections against `normalTasks` in `getPlannerDay` (`src/app/features/planner/store/planner.selectors.ts`). It correctly covers recurring tasks with no `startTime` (untimed) and recurring tasks on non-today columns.\n\nThere is still a gap for **timed** recurring tasks (`TaskRepeatCfg.startTime` set) on the **Today** column.\n\n### The gap\n\nIn `getPlannerDay`:\n\n- For today, `tIds = unplannedTaskIdsToday`, which is `todayListTaskIds.filter(id => !allPlannedIdSet.has(id))`. Tasks with `dueWithTime` are in `allPlannedTasks`, so they're excluded from `normalTasks`.\n- A recurring task with `startTime` gets created with `dueWithTime` (see `task-repeat-cfg.effects.ts:107-109`). So a timed recurring instance for today lives in `allPlannedTasks` → `scheduledTaskItems`, never in `normalTasks`.\n- `coveredRepeatCfgIds` is built from `normalTasks.map(t => t.repeatCfgId)`. The dedup added in #8229 therefore never sees this task's `repeatCfgId`, so the projection for the same cfg is **not** filtered from `repeatProjectionsForDay`.\n\nOn top of that, `getScheduledTaskItems` (`planner.selectors.ts:339-355`) computes `end = start + Math.max(task.timeEstimate - task.timeSpent, 0)` with no `isDone` check. So a done recurring meeting with `dueWithTime` and zero `timeSpent` still contributes its full estimate via `scheduledTaskItems`, **and** the projection adds another full estimate — the original #8220 symptom returns for timed recurring tasks.\n\n### Reproducer\n\n1. Create a recurring task with a fixed start time (e.g. 09:00, 1h estimate) scheduled for today.\n2. Mark the instance done without tracking time.\n3. Compare remaining time in Today vs Planner. Planner is `0` higher than Today by ~`2 × estimate` (one from `scheduledTaskItems`, one from the un-deduped projection).\n\n### Suggested fix\n\nTwo independent changes; either alone closes part of the gap, both together close it fully.\n\n1. **Extend the dedup in `getPlannerDay`** to also include `repeatCfgId`s from `scheduledTaskItems` (or, equivalently, from `allPlannedTasks` filtered to this day) before filtering `repeatProjectionsForDay` / `noStartTimeRepeatProjections`.\n2. **Make `getScheduledTaskItems` done-aware**, mirroring `normalTasks` (`isDone ? 0 : getTimeLeftForTask(t)`), so done timed tasks stop contributing to `timeEstimate`.\n\nA regression spec analogous to #8229's, but with `dueWithTime` set on the instance, would guard this.\n\n### Notes\n\n- The schedule view's existing dedup in `create-schedule-days.ts:162-169` keys by bare `repeatCfgId` similarly; the same approach extended over `scheduledTaskItems` should fit here too.\n- Not blocking on #8229 — that PR fixes the larger class of cases. This is a narrow follow-up for timed recurring instances on today's column.",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-06-09T20:37:52Z",
+    "updatedAtObserved": "2026-06-09T21:54:05Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "maintainer_fixed",
+    "date": "2026-06-09",
+    "detail": "Maintainer johannesjo merged his own PR #8236 same day, an identical fix to the one John had already built locally (verified live: merged=true).",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/8236"
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Same pattern as #8233, same vet round.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-8233.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-8233.json
@@ -1,0 +1,40 @@
+{
+  "id": "super-productivity-8233",
+  "url": "https://github.com/super-productivity/super-productivity/issues/8233",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 8233,
+  "vetDate": "2026-06-09",
+  "issue": {
+    "title": "refactor(sync): single source of truth for local-only sync settings + round-trip tests",
+    "body": "## Background\n\nPer-device sync settings live inside `globalConfig.sync` — synced state — and must be carefully (a) scrubbed at every remote-upload boundary and (b) preserved with local values at every hydration/replay boundary. The current implementation works, but the definition of \"which keys are local-only\" is duplicated across three places that can silently drift, and the two-tier model behind the stripping/applying is implicit.\n\nThis came up while reviewing #8077 (which fixes #7661). The PR is correct as-is; this issue tracks follow-up hardening that's out of scope for that fix.\n\n## Problem 1 — \"local-only\" defined in 3 places\n\nThe same conceptual set (\"keys that must stay on this device\") is encoded three times:\n\n1. `LocalOnlySyncSettings` type at `src/app/features/config/local-only-sync-settings.util.ts:3-10` — `Pick` of 5 keys\n2. `LOCAL_ONLY_SYNC_SCHEDULE_KEYS` array at `src/app/features/config/local-only-sync-settings.util.ts:12-15` — value array of 2 keys (the strip-at-wire subset)\n3. `withLocalOnlySyncSettings` helper at `src/app/features/config/store/global-config.reducer.ts:129-139` — hand-rolled list of all 5 keys, no link back to (1)\n\nAdding a 6th local-only field requires remembering to update (1) and (3), and sometimes (2). Nothing forces consistency.\n\n## Problem 2 — two-tier semantics are implicit\n\nThe util conflates two distinct concepts without naming them:\n\n- **Schedule keys** (`syncInterval`, `isManualSyncOnly`) — must never leave the device. `stripLocalOnlySyncScheduleSettings` removes them entirely.\n- **Device-identity keys** (`syncProvider`, `isEnabled`, `isEncryptionEnabled`) — exist on every device but the local value must win on hydration. `stripLocalOnlySyncSettingsFromAppData` nulls `syncProvider` on upload; the receiving side restores it.\n\n`stripLocalOnlySyncSettingsFromAppData` does *both* (strip schedule + null `syncProvider`) and the asymmetry is invisible to callers. A first-time reader has to mentally reconstruct the model.\n\n## Problem 3 — no round-trip integration test\n\nThe invariant (\"for these 5 keys, local always wins after a remote interaction\") is re-established at **5 strip sites**:\n\n- `src/app/imex/sync/snapshot-upload.service.ts:122`\n- `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts:410`\n- `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts:789`\n- `src/app/op-log/sync/operation-log-upload.service.ts:454` (schedule keys, incremental op)\n- `src/app/op-log/sync/operation-log-upload.service.ts:499` (full-state op)\n\n...and **4 preserve/apply sites**:\n\n- `src/app/op-log/persistence/sync-hydration.service.ts:127-128`\n- `src/app/op-log/sync/remote-ops-processing.service.ts:502`\n- `src/app/features/config/store/global-config.reducer.ts:167` (`loadAllData`)\n- `src/app/features/config/store/global-config.reducer.ts:228` (`updateGlobalConfigSection` with `isRemote: true`)\n\nIf any single one regresses, settings leak or get overwritten on one client — a silent corruption that's hard to diagnose from logs. Existing tests cover each piece individually; nothing pins the round-trip invariant.\n\n## Proposed path\n\n### Phase 1 — single source of truth (small, mechanical)\n\nIn `local-only-sync-settings.util.ts`, declare the key arrays first and derive type + helpers from them:\n\n```ts\nexport const LOCAL_ONLY_SYNC_SCHEDULE_KEYS = [\n  'syncInterval',\n  'isManualSyncOnly',\n] as const satisfies readonly (keyof SyncConfig)[];\n\nexport const LOCAL_ONLY_SYNC_DEVICE_KEYS = [\n  'isEnabled',\n  'isEncryptionEnabled',\n  'syncProvider',\n] as const satisfies readonly (keyof SyncConfig)[];\n\nexport const LOCAL_ONLY_SYNC_KEYS = [\n  ...LOCAL_ONLY_SYNC_SCHEDULE_KEYS,\n  ...LOCAL_ONLY_SYNC_DEVICE_KEYS,\n] as const;\n\nexport type LocalOnlySyncSettings =\n  Pick<SyncConfig, (typeof LOCAL_ONLY_SYNC_KEYS)[number]>;\n```\n\nThen rewrite `withLocalOnlySyncSettings` in `global-config.reducer.ts` as a loop over `LOCAL_ONLY_SYNC_KEYS` instead of a hand-rolled list. Add a header comment to the util explaining the two-tier model (schedule vs device). Add one spec assertion that the two key sets are disjoint:\n\n```ts\nexpect(new Set([...LOCAL_ONLY_SYNC_SCHEDULE_KEYS, ...LOCAL_ONLY_SYNC_DEVICE_KEYS]).size)\n  .toBe(LOCAL_ONLY_SYNC_SCHEDULE_KEYS.length + LOCAL_ONLY_SYNC_DEVICE_KEYS.length);\n```\n\nPure refactor, no behavior change.\n\n### Phase 2 — round-trip integration tests (small, focused)\n\nAdd one test in `sync-hydration.service.spec.ts` and one in `remote-ops-processing.service.spec.ts` of the form:\n\n> Local: `{syncProvider: WebDAV, syncInterval: 5min, isManualSyncOnly: true, isEnabled: true, isEncryptionEnabled: false}`. Inbound full-state snapshot/op carries different values for all 5 keys. After hydration/replay, the local store still shows all 5 local values.\n\nAdd one test for the incremental case: dispatch a remote `updateGlobalConfigSection({sectionKey: 'sync', sectionCfg: {syncInterval: 60_000}})` and assert the local `syncInterval` is unchanged.\n\nThese pin the *invariant*, not the implementation; they'll survive a future refactor of the strip/apply layout.\n\n### Phase 3 — replace the `syncProvider === null` \"first load\" heuristic (separate PR)\n\nAt `global-config.reducer.ts:165`:\n\n```ts\nconst hasLocalSettings = oldState.sync.syncProvider !== null;\n```\n\nThis conflates \"never loaded\" with \"user explicitly has no provider.\" A `loadAllData` after the user disables sync would clobber their choice. Replace with an explicit `hasLoadedAppData` (or `isHydrated`) flag in state, flipped to `true` once on first successful `loadAllData`. State-shape change → its own PR.\n\n## Explicitly out of scope\n\n- A `SyncBoundaryService` abstraction over the 5 strip sites — each has different framing (snapshot, file adapter, op upload paths, full-state op); forcing them through one interface grows a worse parameter object.\n- Branded `SyncConfigForWire` / `SyncConfigLocalOnly` subtypes — type-safe but every caller would have to be retyped; runtime guards still needed, so structural ceremony with no dividend.\n\n## Refs\n\n- PR #8077 (`fix(sync): keep schedule settings local`) — context, no overlap\n- Issue #7661 — original bug report\n- `docs/sync-and-op-log/contributor-sync-model.md` — sync-correctness rules\n",
+    "labels": [],
+    "state": "open",
+    "createdAt": "2026-06-09T20:45:48Z",
+    "updatedAtObserved": "2026-06-09T20:45:48Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "maintainer_fixed",
+    "date": "2026-06-09",
+    "detail": "Maintainer johannesjo merged his own PR #8235 same day, ~few hours after filing the issue (verified live: merged=true).",
+    "prUrl": "https://github.com/super-productivity/super-productivity/pull/8235"
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "Maintainer-filed issue, self-fixed same day — no existing PR/claim visible at vet time.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-8275.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-8275.json
@@ -1,0 +1,39 @@
+{
+  "id": "super-productivity-8275",
+  "url": "https://github.com/super-productivity/super-productivity/issues/8275",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 8275,
+  "vetDate": "2026-06-12",
+  "issue": {
+    "title": "🚨 CalDAV Tasks sync connects to Nextcloud server but does not show tasks",
+    "body": "### Note\n\nThis bug is about CalDAV **tasks**. #8259 is about CalDAV **events**.\n\n### Version Used\n\nv18.9.1 snap\n\n### Current Behavior\n\nAfter credentials have been entered into the **Setup CalDAV Config** or **Edit CalDAV Config** dialog box and connection to the CalDAV server has succeeded:\n* In the relevant project or inbox pane of Super Productivity, **NO tasks from the CalDAV server's chosen calendar are shown**.\n\n### Expected Behavior\n\nAfter credentials have been entered into the **Setup CalDAV Config** or **Edit CalDAV Config** dialog box and connection to the CalDAV server has succeeded:\n* In the relevant project or inbox pane of Super Productivity, **ALL tasks from the CalDAV server's chosen calendar are shown**.\n\n### Steps to Reproduce\n\n1. In web browser, go to Calendar page of a Nextcloud server that has some events in its calendar, e.g. https://my.nextcloud.server/apps/calendar/\n2. On that page, click **⚙ Calendar settings** (near bottom left of page)\n3. In the resulting dialog box, click the **CalDAV URL** entry to copy the CalDAV URL to the clipboard. (The URL will be something like https://my.nextcloud.server/remote.php/dav .)\n4. In Super Productivity, press <key>P</key> or click the **Show/hide issue provider panel** button (triskelion icon)\n5. In the **Issue provider panel**, under **Setup Issue Provider**, click the **CalDAV Todo** button\n6. This pops up a dialog box titled **Setup CalDAV Config**\n7. In the **CalDAV server URL** field, paste from the clipboard the URL copied in step 3 above (e.g. https://my.nextcloud.server/remote.php/dav ).\n8. In the **The name of the CalDAV resource (the calendar)** field, type (or copy-paste) the name of the server's calendar containing the tasks of interest (e.g. \"my_tasks\").\n9. In the **Your CalDAV username** field, it is unclear what to enter:\n    * In Nextcloud, the \"username\" (\"display name\") is usually an alphanumeric string (e.g. *foobar*) and is NOT the same as the \"login\", which is usually an email address (e.g. *foobar@example.com*); see https://github.com/super-productivity/super-productivity/issues/7617#issuecomment-4472672548\n    * However, the bug I am reporting appears regardless. At least, it did for me whether I used my username or my login email address.\n10. In the **Your CalDAV password** field, enter the password for the Nextcloud server.\n11. Under **Advanced Config**, set the **Project assigned to tasks created from issues** field to a project or inbox that actually exists in your Super Productivity instance, like **Inbox** or **Finances** or whatever.\n12. Ensure **Poll imported for changes and notify** is checked.\n13. Set **Polling trigger** field to **Always (in background)**.\n14. Set **Poll interval (minutes)** field to **1**.\n15. Tick **Also import subtasks when a task is added**.\n16. Click the **Test Connection** button. It changes to a tick symbol, and a toast message appears saying \"Connection works!\".\n17. Click the **Save** button.\n27. In Super Productivity's left pane, click the tab for the project or inbox you assigned in step 11 above (e.g. **Inbox**).\n28. In the resulting display, no tasks from the CalDAV server are shown.\n\n### Can you reproduce this reliably?\n\nYes, I can reproduce it reliably.\n\n### Console Output\n\n```shell\n\n```\n\n### Documentation\n\n- [ ] The documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) is unclear or incorrect for this case.\n- [ ] There should be a note added to the documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) for this case.",
+    "labels": ["help wanted", "documentation gap"],
+    "state": "open",
+    "createdAt": "2026-06-11T14:16:36Z",
+    "updatedAtObserved": "2026-06-12T22:26:44Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-06-12",
+    "detail": "Skipped after deep investigation found it wasn't a code bug at all — a config trap (an auto-import setting defaulting off), not a defect in the sync code path."
+  },
+  "measurable": false,
+  "expectedVerdict": "skip",
+  "fidelityNote": "The right call here required actually reproducing the reported behavior end-to-end against a live server, not something derivable from the issue text/labels/repo metadata oss-scout's vetter reads. clearRequirements will likely score true (the bug report itself is clear and detailed) even though the correct verdict was 'skip, not a bug' — a good illustration of why this fixture is unmeasurable by the current feature set.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/super-productivity-8651.json
+++ b/packages/core/eval/fixtures/vet/super-productivity-8651.json
@@ -1,0 +1,39 @@
+{
+  "id": "super-productivity-8651",
+  "url": "https://github.com/super-productivity/super-productivity/issues/8651",
+  "owner": "super-productivity",
+  "repo": "super-productivity",
+  "issueNumber": 8651,
+  "vetDate": "2026-06-30",
+  "issue": {
+    "title": "🚨 Couldn't create subtask from right panel",
+    "body": "### Version Used\n\n18.12.0\n\n### Current Behavior\n\nWhen I click the create subtask button on the right panel, it doesn't create subtask. I mean, it doesn't focus on that right panel like previous version. So, because of this we can't create subtask on kanban view/planner or calendar view anymore...\n It focus on the today section like below though:\n\n<img width=\"2057\" height=\"590\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/3a218eed-e3a9-4648-b9be-01ce7dac89e2\" />\n\n### Expected Behavior\n\nWhen I click the create subtask button from the right panel, it's need to focus the right panel section like how it was previous version.\n### Steps to Reproduce\n\n1. Go to kanban view\n2. select task\n3. click add subtask button\n4. nothing happens if you are on kanban view\n5. if you are on project view or today view, it focus on that task to add subtask\n\n### Can you reproduce this reliably?\n\nYes, I can reproduce it reliably.\n\n### Console Output\n\n```shell\nno output when click\n```\n\n### Documentation\n\n- [ ] The documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) is unclear or incorrect for this case.\n- [ ] There should be a note added to the documentation/[wiki](https://github.com/super-productivity/super-productivity/wiki) for this case.",
+    "labels": [],
+    "state": "closed",
+    "createdAt": "2026-06-30T19:34:26Z",
+    "updatedAtObserved": "2026-07-03T07:25:20Z"
+  },
+  "repoMeta": {
+    "stars": 20467,
+    "forks": 1824
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": false,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": true,
+    "mergedPRCount": 1,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "maintainer_fixed",
+    "date": "2026-07-02",
+    "detail": "Maintainer johannesjo fixed the underlying regression via #8630 (against a sibling issue) and shipped 18.13.0; #8651 itself was never cross-referenced (verified live: PR #8630 merged=true)."
+  },
+  "measurable": false,
+  "expectedVerdict": "pursue",
+  "fidelityNote": "No visible existing PR/claim at vet time even after the fact (GitHub never cross-referenced #8630 to this issue) — a comment-content or cross-issue-similarity signal would be needed to catch this, which oss-scout does not implement.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/fixtures/vet/tubesync-1446.json
+++ b/packages/core/eval/fixtures/vet/tubesync-1446.json
@@ -1,0 +1,40 @@
+{
+  "id": "tubesync-1446",
+  "url": "https://github.com/meeb/tubesync/issues/1446",
+  "owner": "meeb",
+  "repo": "tubesync",
+  "issueNumber": 1446,
+  "vetDate": "2026-04-12",
+  "issue": {
+    "title": "Change health check to generate its URL",
+    "body": "We have environment variables for where `gunicorn` is listening, so we should use those to generate the proper URL instead of using a hard-coded argument in the `Dockerfile`.\n\nI'd suggest instead of an error, we should format a string as the URL instead. This preserves the ability to override the URL with an argument but uses the generated one by default.\n\nhttps://github.com/meeb/tubesync/blob/33479e8e36a23320e2107e42e051b7c4b5264c99/tubesync/healthcheck.py#L38-L42\n\nhttps://github.com/meeb/tubesync/blob/33479e8e36a23320e2107e42e051b7c4b5264c99/tubesync/tubesync/gunicorn.py#L19-L24\n\nhttps://github.com/meeb/tubesync/blob/33479e8e36a23320e2107e42e051b7c4b5264c99/Dockerfile#L776-L778",
+    "labels": ["enhancement", "good first issue"],
+    "state": "closed",
+    "createdAt": "2026-04-11T01:12:07Z",
+    "updatedAtObserved": "2026-04-14T21:37:01Z"
+  },
+  "repoMeta": {
+    "stars": 2752,
+    "forks": 164
+  },
+  "vetTimeFacts": {
+    "hasExistingPR": true,
+    "isClaimed": false,
+    "projectActive": true,
+    "contributionGuidelinesFound": false,
+    "mergedPRCount": 0,
+    "orgHasMergedPRs": false,
+    "matchesPreferredCategory": false,
+    "closedWithoutMergeCount": 0
+  },
+  "outcome": {
+    "label": "skip_correct",
+    "date": "2026-04-12",
+    "detail": "Skipped: competing PR #1447 open at vet time (verified live: #1447 merged=true).",
+    "prUrl": "https://github.com/meeb/tubesync/pull/1447"
+  },
+  "measurable": true,
+  "expectedVerdict": "skip",
+  "fidelityNote": "hasExistingPR=true matches checkNoExistingPR.",
+  "vaultSource": "open-source/potential-issue-list.md, open-source/skipped-issues.md"
+}

--- a/packages/core/eval/reports/2026-07-06-vet-eval-full.md
+++ b/packages/core/eval/reports/2026-07-06-vet-eval-full.md
@@ -1,0 +1,73 @@
+# oss-scout vet eval — 2026-07-06
+
+Model: oss-scout deterministic vet/scoring algorithm (`deriveRecommendation` + `calculateViabilityScore`, current `main`). No LLM in the default vet path — see "Honest limits" below for what this does and doesn't mean.
+n: 1 run per fixture (deterministic — see "Why n=1" below). Mode: full. Fixtures: 30 (skip_correct=10, merged=12, maintainer_fixed=6, lost_race=2). Fixture-set hash: `dc01be45d9a9`.
+
+## Verdict accuracy (measurable fixtures only)
+
+Strict (recommendation exactly matches expected): 12/20 (60%). Lenient (counts "needs_review" as acceptable, not wrong — see finding below): 20/20 (100%). Wrong (confidently the opposite call): 0/20. Out of 30 total fixtures — the remaining 10 hinge on signals oss-scout's current vetter doesn't model (see "Out-of-model-scope fixtures" below) and are excluded from these rates rather than silently counted as passes or failures.
+
+> **Finding:** 8/8 "should skip" fixtures landed on `needs_review` rather than a hard `skip`. `deriveRecommendation` (issue-vetting.ts) only emits `skip` when more than 2 reasonsToSkip accumulate — a single signal (existing PR *or* claimed, alone) downgrades to `needs_review` instead. Not wrong on its own (a human in the loop still catches it), but worth knowing for any automation that treats `recommendation !== "skip"` as "safe to proceed" rather than requiring `recommendation === "approve"` — that automation would auto-pursue every one of these correctly-flagged-but-not-hard-skipped cases.
+
+| Fixture | Outcome | Expected | Recommendation | Score | Grade |
+|---|---|---|---|---|---|
+| activist-2084 | skip_correct | skip | needs_review | 79 | 🟡 cautious |
+| backstage-8216 | merged | pursue | approve | 97 | ✅ correct |
+| casa-6836 | skip_correct | skip | needs_review | 77 | 🟡 cautious |
+| casa-6839 | skip_correct | skip | needs_review | 67 | 🟡 cautious |
+| casa-6923 | merged | pursue | approve | 97 | ✅ correct |
+| casa-6948 | merged | pursue | approve | 97 | ✅ correct |
+| dioxus-5477 | merged | pursue | approve | 92 | ✅ correct |
+| directus-27091 | skip_correct | skip | needs_review | 72 | 🟡 cautious |
+| graphite-4011 | skip_correct | skip | needs_review | 62 | 🟡 cautious |
+| near-cli-rs-581 | skip_correct | skip | needs_review | 55 | 🟡 cautious |
+| pg-clickhouse-167 | skip_correct | skip | needs_review | 63 | 🟡 cautious |
+| react-spectrum-9916 | merged | pursue | approve | 100 | ✅ correct |
+| super-productivity-7188 | merged | pursue | approve | 100 | ✅ correct |
+| super-productivity-7191 | merged | pursue | approve | 100 | ✅ correct |
+| super-productivity-7219 | merged | pursue | approve | 100 | ✅ correct |
+| super-productivity-7674 | merged | pursue | approve | 100 | ✅ correct |
+| super-productivity-7785 | merged | pursue | approve | 100 | ✅ correct |
+| super-productivity-7786 | merged | pursue | approve | 100 | ✅ correct |
+| super-productivity-8220 | merged | pursue | approve | 100 | ✅ correct |
+| tubesync-1446 | skip_correct | skip | needs_review | 57 | 🟡 cautious |
+
+## Out-of-model-scope fixtures (reported, not scored)
+
+These outcomes hinge on race timing, maintainer self-fix behavior, or feasibility/business judgment that oss-scout's current deterministic checks don't attempt to predict. Shown so the tool's output is visible on these cases without pretending the verdict was 'graded'.
+
+| Fixture | Outcome | Recommendation | Score | Why unmeasurable |
+|---|---|---|---|---|
+| eslint-plugin-unicorn-3091 | maintainer_fixed | approve | 90 | The maintainer had already posted the exact fix in a thread comment before this vet — a 'maintainer recently commented with a concrete fix sketch' heuristic could plausibly catch this class, but oss-scout's vetter does not read/analyze comment bodies for that signal today. |
+| homebrew-21892 | skip_correct | approve | 100 | The skip reason is 'can't verify a fix works without infra John doesn't have' — a feasibility judgment, not something hasExistingPR/isClaimed/projectActive/clearRequirements models. |
+| homebrew-22206 | lost_race | approve | 100 | hasExistingPR=false is the CORRECT vet-time snapshot (no PR existed yet when John vetted/started); the competing PR was opened and merged entirely within John's build window. |
+| homebrew-22672 | maintainer_fixed | approve | 87 | closedWithoutMergeCount=1 reflects the real prior history: John's #22225 (see homebrew-22206 fixture) had closed without merging a month earlier in this same repo, so calculateViabilityScore's -15 closed-without-merge penalty legitimately applies here even though mergedPRCount=0. |
+| nautilus-trader-4096 | maintainer_fixed | approve | 100 | Not a self-fix in the same sense as the super-productivity cases — maintainer solved a related-but-different root cause and declined the Cython-path fix as legacy. |
+| open-design-5081 | lost_race | approve | 100 | Race timing is not observable from a point-in-time vet snapshot — oss-scout has no signal for 'a competing contributor is about to claim this in the next N minutes'. |
+| super-productivity-8232 | maintainer_fixed | approve | 100 | Same pattern as #8233, same vet round. |
+| super-productivity-8233 | maintainer_fixed | approve | 100 | Maintainer-filed issue, self-fixed same day — no existing PR/claim visible at vet time. |
+| super-productivity-8275 | skip_correct | approve | 100 | The right call here required actually reproducing the reported behavior end-to-end against a live server, not something derivable from the issue text/labels/repo metadata oss-scout's vetter reads. |
+| super-productivity-8651 | maintainer_fixed | approve | 100 | No visible existing PR/claim at vet time even after the fact (GitHub never cross-referenced #8630 to this issue) — a comment-content or cross-issue-similarity signal would be needed to catch this, which oss-scout does not implement. |
+
+## Score calibration
+
+Average current `calculateViabilityScore` output per realized outcome (across ALL fixtures, measurable or not) — a well-calibrated scorer should rank merged > lost_race/maintainer_fixed > skip_correct, since the first three are all 'pursue was the right call' outcomes and only differ in execution/luck, while skip_correct issues should score lower.
+
+| Outcome | n | Avg score | Pursued rate |
+|---|---|---|---|
+| skip_correct | 10 | 73.2 | 100% |
+| merged | 12 | 98.6 | 100% |
+| maintainer_fixed | 6 | 96.2 | 100% |
+| lost_race | 2 | 100.0 | 100% |
+
+## Why n=1
+
+oss-scout's default vet path (`deriveRecommendation` + `calculateViabilityScore` + `analyzeRequirements`) is pure, deterministic TypeScript — no LLM call, no sampling, so repeated runs against the same fixture always produce the same output. Running n>1 here would only prove the functions are pure (already true by inspection), not measure anything about judgment quality. The one place a model actually runs is the OPTIONAL SLM pre-triage pass (Ollama, local-only, off by default) — pass `--slm <model>` to additionally measure ITS run-to-run stability across n repeats; that path is not exercised by this report.
+
+## Honest limits
+
+- **Survivorship bias.** These are issues John already chose to investigate, not a random sample of all GitHub issues — they skew toward things that looked promising enough to spend time on. This eval measures 'given John's existing funnel, does the current vetter's verdict/score line up with what happened', not 'how good is the vetter at cold-sourcing.'
+- **Outcome conflation.** `merged` vs `lost_race` vs `maintainer_fixed` mostly reflect execution speed and luck (who else was watching the same issue, how fast John built and pushed), not vet quality — all three started from a reasonable 'pursue' call. Treating lost_race/maintainer_fixed as vetting failures would overstate what a smarter vetter could realistically prevent.
+- **Reconstruction fidelity.** `vetTimeFacts` (existing-PR/claimed/project-active/merged-PR-count) are hand-derived from John's own vetting notes recorded at the time, not re-derived from a time-traveled GitHub API call — GitHub's search and timeline APIs can't be queried as of a past date. Issue title/body/labels/repo star-fork counts ARE live API reads, but reflect state as of fixture-build time (2026-07-05), which can differ slightly from vet-time if the issue was edited or the repo grew. Each fixture's `fidelityNote` documents this per-case.
+- **Small N, single fixture-set.** 30 fixtures is enough to catch a gross regression (e.g. a recommendation-logic change that starts skipping every clean issue) but not enough to draw fine-grained statistical conclusions about score thresholds.
+- **Capability gaps are not bugs.** The 'out-of-model-scope' fixtures above surface real capability gaps (no maintainer-comment-sentiment signal, no race-timing prediction) — these are candidates for future feature work, not defects in the current scoring math.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
   "files": [
     "dist/",
     "!dist/**/*.map",
-    "!dist/core/test-utils.*"
+    "!dist/core/test-utils.*",
+    "!dist/eval/**"
   ],
   "scripts": {
     "build": "tsc",
@@ -29,6 +30,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
+    "eval:vet": "tsx src/eval/vet-eval-cli.ts --full",
+    "eval:vet:quick": "tsx src/eval/vet-eval-cli.ts --quick",
+    "eval:vet:build-fixtures": "tsx src/eval/build-fixtures.ts",
     "prepublishOnly": "pnpm run build && pnpm run bundle"
   },
   "keywords": [

--- a/packages/core/src/eval/build-fixtures.ts
+++ b/packages/core/src/eval/build-fixtures.ts
@@ -1,0 +1,103 @@
+/**
+ * Vet eval — fixture builder.
+ *
+ * One-off (re-runnable) script that merges the ground-truth manifest
+ * (ground-truth.ts) with a live, READ-ONLY GitHub API fetch of each
+ * issue's title/body/labels/state/timestamps and its repo's star/fork
+ * counts, and writes the result to eval/fixtures/vet/<id>.json.
+ *
+ * Uses the `gh` CLI (already authenticated in this environment) rather
+ * than a token, so nothing secret is read or printed. Makes no writes to
+ * GitHub — issues/comments/PRs are only ever read.
+ *
+ * Run with: pnpm --filter @oss-scout/core exec tsx src/eval/build-fixtures.ts
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { GROUND_TRUTH } from "./ground-truth.js";
+import { VetFixtureSchema, type VetFixture } from "./types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = path.join(
+  __dirname,
+  "..",
+  "..",
+  "eval",
+  "fixtures",
+  "vet",
+);
+
+interface GhIssue {
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  created_at: string;
+  updated_at: string;
+  labels: Array<string | { name?: string }>;
+}
+
+interface GhRepo {
+  stargazers_count: number;
+  forks_count: number;
+}
+
+function ghApiJson<T>(path: string): T {
+  const out = execFileSync("gh", ["api", path], { encoding: "utf8" });
+  return JSON.parse(out) as T;
+}
+
+function buildOne(entry: (typeof GROUND_TRUTH)[number]): VetFixture {
+  const issue = ghApiJson<GhIssue>(
+    `repos/${entry.owner}/${entry.repo}/issues/${entry.issueNumber}`,
+  );
+  const repoMeta = ghApiJson<GhRepo>(`repos/${entry.owner}/${entry.repo}`);
+
+  const fixture: VetFixture = {
+    id: entry.id,
+    url: `https://github.com/${entry.owner}/${entry.repo}/issues/${entry.issueNumber}`,
+    owner: entry.owner,
+    repo: entry.repo,
+    issueNumber: entry.issueNumber,
+    vetDate: entry.vetDate,
+    issue: {
+      title: issue.title,
+      body: issue.body ?? "",
+      labels: issue.labels.map((l) =>
+        typeof l === "string" ? l : (l.name ?? ""),
+      ),
+      state: issue.state,
+      createdAt: issue.created_at,
+      updatedAtObserved: issue.updated_at,
+    },
+    repoMeta: {
+      stars: repoMeta.stargazers_count,
+      forks: repoMeta.forks_count,
+    },
+    vetTimeFacts: entry.vetTimeFacts,
+    outcome: entry.outcome,
+    measurable: entry.measurable,
+    expectedVerdict: entry.expectedVerdict,
+    fidelityNote: entry.fidelityNote,
+    vaultSource:
+      "open-source/potential-issue-list.md, open-source/skipped-issues.md",
+  };
+
+  return VetFixtureSchema.parse(fixture);
+}
+
+function main(): void {
+  mkdirSync(FIXTURES_DIR, { recursive: true });
+  let built = 0;
+  for (const entry of GROUND_TRUTH) {
+    process.stderr.write(`Building fixture ${entry.id}...\n`);
+    const fixture = buildOne(entry);
+    const outPath = path.join(FIXTURES_DIR, `${entry.id}.json`);
+    writeFileSync(outPath, JSON.stringify(fixture, null, 2) + "\n");
+    built++;
+  }
+  process.stderr.write(`Built ${built} fixtures in ${FIXTURES_DIR}\n`);
+}
+
+main();

--- a/packages/core/src/eval/fixture-loader.test.ts
+++ b/packages/core/src/eval/fixture-loader.test.ts
@@ -1,0 +1,132 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fixtureSetHash, loadFixtures, quickSubset } from "./fixture-loader.js";
+import type { VetFixture } from "./types.js";
+
+function makeFixture(
+  id: string,
+  outcomeLabel: VetFixture["outcome"]["label"],
+): VetFixture {
+  return {
+    id,
+    url: `https://github.com/o/r/issues/${id}`,
+    owner: "o",
+    repo: "r",
+    issueNumber: 1,
+    vetDate: "2026-01-01",
+    issue: {
+      title: "t",
+      body: "b",
+      labels: [],
+      state: "open",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAtObserved: "2026-01-01T00:00:00Z",
+    },
+    repoMeta: { stars: 1, forks: 1 },
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      mergedPRCount: 0,
+      orgHasMergedPRs: false,
+      matchesPreferredCategory: false,
+      closedWithoutMergeCount: 0,
+    },
+    outcome: { label: outcomeLabel, date: "2026-01-02", detail: "d" },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote: "n",
+    vaultSource: "test",
+  };
+}
+
+describe("loadFixtures", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "vet-fixtures-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("loads and validates fixtures from a directory, sorted by filename", () => {
+    writeFileSync(
+      path.join(dir, "b.json"),
+      JSON.stringify(makeFixture("b", "merged")),
+    );
+    writeFileSync(
+      path.join(dir, "a.json"),
+      JSON.stringify(makeFixture("a", "skip_correct")),
+    );
+    const fixtures = loadFixtures(dir);
+    expect(fixtures.map((f) => f.id)).toEqual(["a", "b"]);
+  });
+
+  it("throws on a fixture that fails schema validation", () => {
+    writeFileSync(path.join(dir, "bad.json"), JSON.stringify({ id: "bad" }));
+    expect(() => loadFixtures(dir)).toThrow();
+  });
+
+  it("ignores non-JSON files in the directory", () => {
+    writeFileSync(
+      path.join(dir, "a.json"),
+      JSON.stringify(makeFixture("a", "merged")),
+    );
+    writeFileSync(path.join(dir, "README.md"), "not a fixture");
+    expect(loadFixtures(dir).length).toBe(1);
+  });
+});
+
+describe("fixtureSetHash", () => {
+  it("is stable for the same fixture content regardless of array order", () => {
+    const a = makeFixture("a", "merged");
+    const b = makeFixture("b", "skip_correct");
+    expect(fixtureSetHash([a, b])).toBe(fixtureSetHash([b, a]));
+  });
+
+  it("changes when any fixture's content changes", () => {
+    const a = makeFixture("a", "merged");
+    const aEdited = { ...a, issue: { ...a.issue, title: "different title" } };
+    expect(fixtureSetHash([a])).not.toBe(fixtureSetHash([aEdited]));
+  });
+
+  it("changes when a fixture is added or removed", () => {
+    const a = makeFixture("a", "merged");
+    const b = makeFixture("b", "skip_correct");
+    expect(fixtureSetHash([a])).not.toBe(fixtureSetHash([a, b]));
+  });
+});
+
+describe("quickSubset", () => {
+  it("includes at least one fixture per outcome label present", () => {
+    const fixtures = [
+      makeFixture("m1", "merged"),
+      makeFixture("m2", "merged"),
+      makeFixture("lr", "lost_race"),
+      makeFixture("mf", "maintainer_fixed"),
+      makeFixture("sk", "skip_correct"),
+    ];
+    const subset = quickSubset(fixtures);
+    const labels = new Set(subset.map((f) => f.outcome.label));
+    expect(labels).toEqual(
+      new Set(["merged", "lost_race", "maintainer_fixed", "skip_correct"]),
+    );
+  });
+
+  it("caps out around 10 fixtures even when given many more", () => {
+    const fixtures = Array.from({ length: 30 }, (_, i) =>
+      makeFixture(`f${i}`, i % 2 === 0 ? "merged" : "skip_correct"),
+    );
+    expect(quickSubset(fixtures).length).toBeLessThanOrEqual(10);
+  });
+
+  it("never returns more fixtures than it was given", () => {
+    const fixtures = [makeFixture("only", "merged")];
+    expect(quickSubset(fixtures).length).toBe(1);
+  });
+});

--- a/packages/core/src/eval/fixture-loader.ts
+++ b/packages/core/src/eval/fixture-loader.ts
@@ -1,0 +1,65 @@
+/**
+ * Vet eval — fixture loading + fixture-set hashing.
+ */
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { VetFixtureSchema, type VetFixture } from "./types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const FIXTURES_DIR = path.join(
+  __dirname,
+  "..",
+  "..",
+  "eval",
+  "fixtures",
+  "vet",
+);
+
+/** Load and validate all fixtures from a directory (defaults to the real
+ * fixture dir; tests pass a temp dir of synthetic fixtures instead). */
+export function loadFixtures(dir: string = FIXTURES_DIR): VetFixture[] {
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .sort();
+  return files.map((f) => {
+    const raw = readFileSync(path.join(dir, f), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    return VetFixtureSchema.parse(parsed);
+  });
+}
+
+/**
+ * Stable hash over the fixture set's content (not just filenames) so a
+ * report can cite exactly which fixture data it ran against — if any
+ * fixture is edited/added/removed, the hash changes.
+ */
+export function fixtureSetHash(fixtures: VetFixture[]): string {
+  const hash = createHash("sha256");
+  for (const f of [...fixtures].sort((a, b) => a.id.localeCompare(b.id))) {
+    hash.update(f.id);
+    hash.update(JSON.stringify(f));
+  }
+  return hash.digest("hex").slice(0, 12);
+}
+
+/** A fixed, representative subset for --quick mode: at least one fixture
+ * per outcome label, capped small for fast iteration. */
+export function quickSubset(fixtures: VetFixture[]): VetFixture[] {
+  const seen = new Set<string>();
+  const subset: VetFixture[] = [];
+  for (const f of fixtures) {
+    if (seen.has(f.outcome.label)) continue;
+    seen.add(f.outcome.label);
+    subset.push(f);
+  }
+  // Round out to ~10 fixtures total for a broader (but still fast) smoke
+  // check, preferring ones not already included.
+  for (const f of fixtures) {
+    if (subset.length >= 10) break;
+    if (!subset.includes(f)) subset.push(f);
+  }
+  return subset;
+}

--- a/packages/core/src/eval/ground-truth.ts
+++ b/packages/core/src/eval/ground-truth.ts
@@ -1,0 +1,874 @@
+/**
+ * Vet eval — ground-truth manifest.
+ *
+ * 30 historical issues pulled from John's OSS-pipeline notes
+ * (~/dev/obsidian-vault/open-source/potential-issue-list.md and
+ * skipped-issues.md), each with a realized outcome. `vetTimeFacts` are
+ * hand-derived from the vault's own vetting-time notes (the vault records
+ * the existing-PR/claimed/project-active/merged-PR-count checks in prose
+ * at the time each issue was vetted); `issue`/`repoMeta` fields are filled
+ * in by build-fixtures.ts from a live (read-only) GitHub API fetch.
+ *
+ * Every merge status cited in `outcome` was independently re-verified
+ * against the live GitHub API on 2026-07-05 (not just trusted from vault
+ * prose) — see the PR description for the verification commands.
+ */
+import type { OutcomeLabel, VetTimeFacts } from "./types.js";
+
+export interface ManifestEntry {
+  id: string;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  vetDate: string;
+  vetTimeFacts: VetTimeFacts;
+  outcome: {
+    label: OutcomeLabel;
+    date: string;
+    detail: string;
+    prUrl?: string;
+  };
+  measurable: boolean;
+  expectedVerdict: "pursue" | "skip";
+  fidelityNote: string;
+}
+
+const noHistory: Pick<
+  VetTimeFacts,
+  "mergedPRCount" | "orgHasMergedPRs" | "closedWithoutMergeCount"
+> = {
+  mergedPRCount: 0,
+  orgHasMergedPRs: false,
+  closedWithoutMergeCount: 0,
+};
+
+const established: Pick<
+  VetTimeFacts,
+  "mergedPRCount" | "orgHasMergedPRs" | "closedWithoutMergeCount"
+> = {
+  mergedPRCount: 1,
+  orgHasMergedPRs: false,
+  closedWithoutMergeCount: 0,
+};
+
+export const GROUND_TRUTH: ManifestEntry[] = [
+  // ---------------------------------------------------------------------
+  // MERGED — PURSUE tier that converted. oss-scout's current checks
+  // (no existing PR, not claimed, active project, clear requirements)
+  // are exactly what should say "approve" here.
+  // ---------------------------------------------------------------------
+  {
+    id: "casa-6923",
+    owner: "rubyforgood",
+    repo: "casa",
+    issueNumber: 6923,
+    vetDate: "2026-06-09",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-06-10",
+      detail: "PR #6990 merged 2026-06-10 (verified live: merged=true)",
+      prUrl: "https://github.com/rubyforgood/casa/pull/6990",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "vetTimeFacts from potential-issue-list.md: 'Score 8/10 — PR OPEN', fully available/unclaimed at vet time, first PR John opened in this repo (mergedPRCount=0).",
+  },
+  {
+    id: "casa-6948",
+    owner: "rubyforgood",
+    repo: "casa",
+    issueNumber: 6948,
+    vetDate: "2026-06-09",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-06-10",
+      detail: "PR #6991 merged 2026-06-10 (verified live: merged=true)",
+      prUrl: "https://github.com/rubyforgood/casa/pull/6991",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "vault notes: prior claimant (andoq) auto-unassigned 15d before this vet for inactivity, so isClaimed=false at vet time. Same-day vet as #6923 (mergedPRCount=0 for both).",
+  },
+  {
+    id: "super-productivity-7785",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 7785,
+    vetDate: "2026-05-25",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-05-26",
+      detail: "PR #7792 merged 2026-05-26 (verified live: merged=true)",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/7792",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "By this vet date John had several earlier merged PRs in this repo (#7211/#7220/#7222 all landed in April), so mergedPRCount treated as established (>0).",
+  },
+  {
+    id: "super-productivity-7786",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 7786,
+    vetDate: "2026-05-25",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-05-26",
+      detail: "PR #7793 merged 2026-05-26 (verified live: merged=true)",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/7793",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote: "Same vet round as #7785, same repo/history facts.",
+  },
+  {
+    id: "super-productivity-8220",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 8220,
+    vetDate: "2026-06-09",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-06-09",
+      detail:
+        "PR #8229 merged same day, 2026-06-09 (verified live: merged=true)",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/8229",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote: "Fast same-day merge; established repo history by now.",
+  },
+  {
+    id: "super-productivity-7674",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 7674,
+    vetDate: "2026-06-09",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-06-22",
+      detail:
+        "PR #8516 merged 2026-06-22 after a comment-first scoping round " +
+        "(verified live: merged=true)",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/8516",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "Interesting calibration case: the issue body floats 3 mutually-exclusive designs (unclear scope at face value), so analyzeRequirements(body) may legitimately score clearRequirements=false. The eventual merge only happened because John scoped it with a comment before writing code, not from the raw issue alone — a good illustration that 'needs_review' can be the MORE honest verdict than a clean approve/skip binary for this one.",
+  },
+  {
+    id: "super-productivity-7219",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 7219,
+    vetDate: "2026-04-13",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-04-16",
+      detail: "PR #7222 merged 2026-04-16 (verified live: merged=true)",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/7222",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "One of John's earliest contributions to this repo — no prior merged/closed PR history yet (mergedPRCount=0), unlike the June entries above.",
+  },
+  {
+    id: "super-productivity-7188",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 7188,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-04-13",
+      detail: "PR #7211 merged 2026-04-13 (verified live: merged=true)",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/7211",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote: "Cold-start in this repo, same as #7219/#7191.",
+  },
+  {
+    id: "super-productivity-7191",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 7191,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-04-19",
+      detail: "PR #7220 merged 2026-04-19 (verified live: merged=true)",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/7220",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote: "Cold-start in this repo, same as #7219/#7188.",
+  },
+  {
+    id: "react-spectrum-9916",
+    owner: "adobe",
+    repo: "react-spectrum",
+    issueNumber: 9916,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-06-25",
+      detail:
+        "PR #9924 merged 2026-06-25, a much longer review cycle than most " +
+        "(verified live: merged=true)",
+      prUrl: "https://github.com/adobe/react-spectrum/pull/9924",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "Merge landed >2 months after vet/PR-open — long enterprise-repo review latency, unrelated to vet quality.",
+  },
+  {
+    id: "dioxus-5477",
+    owner: "DioxusLabs",
+    repo: "dioxus",
+    issueNumber: 5477,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: false,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-04-14",
+      detail: "PR #5481 merged 2026-04-14 (verified live: merged=true)",
+      prUrl: "https://github.com/DioxusLabs/dioxus/pull/5481",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "No CONTRIBUTING.md found at any of the 4 probed paths (checked live 2026-07-05) — contributionGuidelinesFound=false is a real repo characteristic, not a fixture gap.",
+  },
+  {
+    id: "backstage-8216",
+    owner: "backstage",
+    repo: "community-plugins",
+    issueNumber: 8216,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "merged",
+      date: "2026-07-03",
+      detail:
+        "PR #8547 merged 2026-07-03 — an unusually long ~3 month review " +
+        "cycle (verified live: merged=true)",
+      prUrl: "https://github.com/backstage/community-plugins/pull/8547",
+    },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "Longest merge latency in this fixture set; included deliberately so the report's calibration section isn't only fast-merge success stories.",
+  },
+
+  // ---------------------------------------------------------------------
+  // LOST_RACE — pursuing was the right call; a competitor won on timing.
+  // Not measurable: nothing in oss-scout's vet-time snapshot could have
+  // predicted a competing contributor's timing.
+  // ---------------------------------------------------------------------
+  {
+    id: "open-design-5081",
+    owner: "nexu-io",
+    repo: "open-design",
+    issueNumber: 5081,
+    vetDate: "2026-07-02",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "lost_race",
+      date: "2026-07-02",
+      detail:
+        "Another contributor claimed + opened an identical-fix PR (#5085) " +
+        "while John's clone was still downloading; John's finished, " +
+        "review-gated fix was never pushed (zero external footprint).",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "Race timing is not observable from a point-in-time vet snapshot — oss-scout has no signal for 'a competing contributor is about to claim this in the next N minutes'. Excluded from headline accuracy; reported in the lost-race appendix.",
+  },
+  {
+    id: "homebrew-22206",
+    owner: "Homebrew",
+    repo: "brew",
+    issueNumber: 22206,
+    vetDate: "2026-05-10",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "lost_race",
+      date: "2026-05-10",
+      detail:
+        "John's PR #22225 (opened 2026-05-10) was closed by the maintainer " +
+        "as a duplicate: PR #22211 by another contributor had merged ~9h " +
+        "earlier (verified live: #22211 merged=true, #22225 merged=false). " +
+        "The 'no other open PRs' check passed vacuously because #22211 was " +
+        "no longer open by the time John's PR was opened.",
+      prUrl: "https://github.com/Homebrew/brew/pull/22225",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "hasExistingPR=false is the CORRECT vet-time snapshot (no PR existed yet when John vetted/started); the competing PR was opened and merged entirely within John's build window. This is exactly the class of miss a snapshot-based existing-PR check structurally cannot catch — a fresh recheck immediately before push (which the vault's CLAUDE.md now mandates) is the real fix, not a vetting change.",
+  },
+
+  // ---------------------------------------------------------------------
+  // MAINTAINER_FIXED — pursuing was reasonable; the maintainer shipped
+  // their own fix first. Not measurable: oss-scout has no
+  // maintainer-comment-sentiment or self-fix-risk signal today.
+  // ---------------------------------------------------------------------
+  {
+    id: "super-productivity-8651",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 8651,
+    vetDate: "2026-06-30",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "maintainer_fixed",
+      date: "2026-07-02",
+      detail:
+        "Maintainer johannesjo fixed the underlying regression via #8630 " +
+        "(against a sibling issue) and shipped 18.13.0; #8651 itself was " +
+        "never cross-referenced (verified live: PR #8630 merged=true).",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "No visible existing PR/claim at vet time even after the fact (GitHub never cross-referenced #8630 to this issue) — a comment-content or cross-issue-similarity signal would be needed to catch this, which oss-scout does not implement.",
+  },
+  {
+    id: "eslint-plugin-unicorn-3091",
+    owner: "sindresorhus",
+    repo: "eslint-plugin-unicorn",
+    issueNumber: 3091,
+    vetDate: "2026-06-11",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: false,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "maintainer_fixed",
+      date: "2026-06-11",
+      detail:
+        "Maintainer (Sindre) merged his own PR #3117 same day, ~9h after " +
+        "sketching the fix in a comment (verified live: merged=true).",
+      prUrl: "https://github.com/sindresorhus/eslint-plugin-unicorn/pull/3117",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "The maintainer had already posted the exact fix in a thread comment before this vet — a 'maintainer recently commented with a concrete fix sketch' heuristic could plausibly catch this class, but oss-scout's vetter does not read/analyze comment bodies for that signal today. Flagged as a future-feature candidate in the report, not scored as a miss.",
+  },
+  {
+    id: "homebrew-22672",
+    owner: "Homebrew",
+    repo: "brew",
+    issueNumber: 22672,
+    vetDate: "2026-06-11",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      mergedPRCount: 0,
+      orgHasMergedPRs: false,
+      closedWithoutMergeCount: 1,
+    },
+    outcome: {
+      label: "maintainer_fixed",
+      date: "2026-06-12",
+      detail:
+        "Maintainer swept/closed the issue as completed within the 24-48h " +
+        "window flagged at vet time (verified live: state=closed, " +
+        "state_reason=completed).",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "closedWithoutMergeCount=1 reflects the real prior history: John's #22225 (see homebrew-22206 fixture) had closed without merging a month earlier in this same repo, so calculateViabilityScore's -15 closed-without-merge penalty legitimately applies here even though mergedPRCount=0.",
+  },
+  {
+    id: "super-productivity-8233",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 8233,
+    vetDate: "2026-06-09",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "maintainer_fixed",
+      date: "2026-06-09",
+      detail:
+        "Maintainer johannesjo merged his own PR #8235 same day, ~few " +
+        "hours after filing the issue (verified live: merged=true).",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/8235",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "Maintainer-filed issue, self-fixed same day — no existing PR/claim visible at vet time.",
+  },
+  {
+    id: "super-productivity-8232",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 8232,
+    vetDate: "2026-06-09",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "maintainer_fixed",
+      date: "2026-06-09",
+      detail:
+        "Maintainer johannesjo merged his own PR #8236 same day, an " +
+        "identical fix to the one John had already built locally " +
+        "(verified live: merged=true).",
+      prUrl:
+        "https://github.com/super-productivity/super-productivity/pull/8236",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote: "Same pattern as #8233, same vet round.",
+  },
+  {
+    id: "nautilus-trader-4096",
+    owner: "nautechsystems",
+    repo: "nautilus_trader",
+    issueNumber: 4096,
+    vetDate: "2026-05-19",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "maintainer_fixed",
+      date: "2026-05-19",
+      detail:
+        "Maintainer closed the issue NOT_PLANNED same day, having fixed " +
+        "the underlying problem differently on the Rust data-engine path " +
+        "(verified live: state=closed, state_reason=not_planned).",
+    },
+    measurable: false,
+    expectedVerdict: "pursue",
+    fidelityNote:
+      "Not a self-fix in the same sense as the super-productivity cases — maintainer solved a related-but-different root cause and declined the Cython-path fix as legacy. Bucketed as maintainer_fixed because the practical effect (John's ready fix was never pushed) is the same.",
+  },
+
+  // ---------------------------------------------------------------------
+  // SKIP_CORRECT — correctly not pursued. Split: 8 map cleanly onto
+  // existing-PR/claimed checks oss-scout already runs (measurable); 2
+  // hinge on judgment calls the vetter doesn't attempt (not measurable).
+  // ---------------------------------------------------------------------
+  {
+    id: "casa-6839",
+    owner: "rubyforgood",
+    repo: "casa",
+    issueNumber: 6839,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: true,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-12",
+      detail:
+        "Skipped: competing PR #6844 was already open at vet time " +
+        "(verified live: #6844 merged=true, so the skip was also right in " +
+        "hindsight).",
+      prUrl: "https://github.com/rubyforgood/casa/pull/6844",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote:
+      "hasExistingPR=true directly matches the vault note ('Taken: competing PR #6844 open') — exactly the checkNoExistingPR signal oss-scout's vetter runs today.",
+  },
+  {
+    id: "casa-6836",
+    owner: "rubyforgood",
+    repo: "casa",
+    issueNumber: 6836,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: true,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-12",
+      detail:
+        "Skipped: issue assigned to @cliftonmcintosh at vet time " +
+        "(verified live: assignee still on the closed issue).",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote: "isClaimed=true matches checkNotClaimed's assignee check.",
+  },
+  {
+    id: "activist-2084",
+    owner: "activist-org",
+    repo: "activist",
+    issueNumber: 2084,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: true,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-12",
+      detail:
+        "Skipped: issue assigned to @sh-ran at vet time (verified live: " +
+        "assignee still on the closed issue).",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote: "isClaimed=true matches checkNotClaimed's assignee check.",
+  },
+  {
+    id: "directus-27091",
+    owner: "directus",
+    repo: "directus",
+    issueNumber: 27091,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: true,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-12",
+      detail:
+        "Skipped: competing PR #27099 already open at vet time (verified " +
+        "live: #27099 state=closed, merged=false — it didn't land either, " +
+        "but the skip decision was correct given what was visible then).",
+      prUrl: "https://github.com/directus/directus/pull/27099",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote:
+      "hasExistingPR=true matches checkNoExistingPR. Included even though the competing PR itself never merged, to test that the vetter correctly treats 'has a competing PR' as a skip signal regardless of that PR's eventual fate.",
+  },
+  {
+    id: "graphite-4011",
+    owner: "GraphiteEditor",
+    repo: "Graphite",
+    issueNumber: 4011,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: true,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: false,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-12",
+      detail:
+        "Skipped: competing PR #4025 open at vet time (verified live: " +
+        "issue and PR both still open as of 2026-07-05).",
+      prUrl: "https://github.com/GraphiteEditor/Graphite/pull/4025",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote: "hasExistingPR=true matches checkNoExistingPR.",
+  },
+  {
+    id: "tubesync-1446",
+    owner: "meeb",
+    repo: "tubesync",
+    issueNumber: 1446,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: true,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: false,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-12",
+      detail:
+        "Skipped: competing PR #1447 open at vet time (verified live: " +
+        "#1447 merged=true).",
+      prUrl: "https://github.com/meeb/tubesync/pull/1447",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote: "hasExistingPR=true matches checkNoExistingPR.",
+  },
+  {
+    id: "near-cli-rs-581",
+    owner: "near",
+    repo: "near-cli-rs",
+    issueNumber: 581,
+    vetDate: "2026-04-04",
+    vetTimeFacts: {
+      hasExistingPR: true,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: false,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-04",
+      detail:
+        "Skipped: competing PR #582 already under review at vet time " +
+        "(verified live: #582 merged=true).",
+      prUrl: "https://github.com/near/near-cli-rs/pull/582",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote: "hasExistingPR=true matches checkNoExistingPR.",
+  },
+  {
+    id: "pg-clickhouse-167",
+    owner: "ClickHouse",
+    repo: "pg_clickhouse",
+    issueNumber: 167,
+    vetDate: "2026-04-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: true,
+      projectActive: true,
+      contributionGuidelinesFound: false,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-12",
+      detail:
+        "Skipped: issue assigned to @serprex at vet time (verified live: " +
+        "assignee still on the closed issue).",
+    },
+    measurable: true,
+    expectedVerdict: "skip",
+    fidelityNote: "isClaimed=true matches checkNotClaimed's assignee check.",
+  },
+  {
+    id: "homebrew-21892",
+    owner: "Homebrew",
+    repo: "brew",
+    issueNumber: 21892,
+    vetDate: "2026-04-04",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...noHistory,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-04-04",
+      detail:
+        "Skipped: could not be reproduced or verified end-to-end without " +
+        "a private artifact host (verified live: state_reason=completed — " +
+        "someone else eventually resolved it upstream).",
+    },
+    measurable: false,
+    expectedVerdict: "skip",
+    fidelityNote:
+      "The skip reason is 'can't verify a fix works without infra John doesn't have' — a feasibility judgment, not something hasExistingPR/isClaimed/projectActive/clearRequirements models. Reported, not scored.",
+  },
+  {
+    id: "super-productivity-8275",
+    owner: "super-productivity",
+    repo: "super-productivity",
+    issueNumber: 8275,
+    vetDate: "2026-06-12",
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      matchesPreferredCategory: false,
+      ...established,
+    },
+    outcome: {
+      label: "skip_correct",
+      date: "2026-06-12",
+      detail:
+        "Skipped after deep investigation found it wasn't a code bug at " +
+        "all — a config trap (an auto-import setting defaulting off), not " +
+        "a defect in the sync code path.",
+    },
+    measurable: false,
+    expectedVerdict: "skip",
+    fidelityNote:
+      "The right call here required actually reproducing the reported behavior end-to-end against a live server, not something derivable from the issue text/labels/repo metadata oss-scout's vetter reads. clearRequirements will likely score true (the bug report itself is clear and detailed) even though the correct verdict was 'skip, not a bug' — a good illustration of why this fixture is unmeasurable by the current feature set.",
+  },
+];

--- a/packages/core/src/eval/report.test.ts
+++ b/packages/core/src/eval/report.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { buildReport } from "./report.js";
+import type { VetEvalResult, VetFixture } from "./types.js";
+import type { VetEvalSummary } from "./vet-eval.js";
+import { summarize } from "./vet-eval.js";
+
+interface ResultOverrides extends Partial<Omit<VetEvalResult, "fixture">> {
+  fixture?: Partial<VetFixture>;
+}
+
+function makeResult(overrides: ResultOverrides = {}): VetEvalResult {
+  const base: VetEvalResult = {
+    fixture: {
+      id: "canned-1",
+      url: "https://github.com/o/r/issues/1",
+      owner: "o",
+      repo: "r",
+      issueNumber: 1,
+      vetDate: "2026-01-01",
+      issue: {
+        title: "t",
+        body: "b",
+        labels: [],
+        state: "open",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAtObserved: "2026-01-01T00:00:00Z",
+      },
+      repoMeta: { stars: 10, forks: 1 },
+      vetTimeFacts: {
+        hasExistingPR: false,
+        isClaimed: false,
+        projectActive: true,
+        contributionGuidelinesFound: true,
+        mergedPRCount: 0,
+        orgHasMergedPRs: false,
+        matchesPreferredCategory: false,
+        closedWithoutMergeCount: 0,
+      },
+      outcome: {
+        label: "merged",
+        date: "2026-01-02",
+        detail: "canned outcome detail",
+      },
+      measurable: true,
+      expectedVerdict: "pursue",
+      fidelityNote: "canned fidelity note",
+      vaultSource: "test",
+    },
+    clearRequirements: true,
+    recommendation: "approve",
+    viabilityScore: 90,
+    pursued: true,
+    verdictGrade: "correct",
+  };
+  return {
+    ...base,
+    ...overrides,
+    fixture: { ...base.fixture, ...overrides.fixture },
+  };
+}
+
+describe("buildReport", () => {
+  const meta = {
+    date: "2026-07-05",
+    mode: "full" as const,
+    fixtureCount: 2,
+    fixtureSetHash: "deadbeef1234",
+  };
+
+  it("states the model, n, mode, fixture count, and hash in the header", () => {
+    const summary: VetEvalSummary = summarize([makeResult()]);
+    const report = buildReport(summary, meta);
+    expect(report).toContain("deriveRecommendation");
+    expect(report).toContain("n: 1 run per fixture");
+    expect(report).toContain("Mode: full");
+    expect(report).toContain("deadbeef1234");
+  });
+
+  it("includes a row per measurable fixture with its grade", () => {
+    const summary = summarize([
+      makeResult({
+        fixture: { id: "canned-correct" },
+        verdictGrade: "correct",
+      }),
+      makeResult({
+        fixture: {
+          id: "canned-cautious",
+          outcome: { label: "skip_correct", date: "2026-01-02", detail: "d" },
+          expectedVerdict: "skip",
+        },
+        recommendation: "needs_review",
+        verdictGrade: "cautious",
+      }),
+    ]);
+    const report = buildReport(summary, meta);
+    expect(report).toContain("canned-correct");
+    expect(report).toContain("canned-cautious");
+    expect(report).toContain("🟡 cautious");
+    expect(report).toContain("✅ correct");
+  });
+
+  it("surfaces the needs_review-dominance finding only when it actually occurs", () => {
+    const allCorrect = summarize([makeResult()]);
+    expect(buildReport(allCorrect, meta)).not.toContain("**Finding:**");
+
+    const withCautiousSkip = summarize([
+      makeResult({
+        fixture: {
+          id: "canned-cautious-skip",
+          outcome: { label: "skip_correct", date: "2026-01-02", detail: "d" },
+          expectedVerdict: "skip",
+        },
+        recommendation: "needs_review",
+        verdictGrade: "cautious",
+      }),
+    ]);
+    expect(buildReport(withCautiousSkip, meta)).toContain("**Finding:**");
+  });
+
+  it("lists unmeasurable fixtures separately from the graded table", () => {
+    const summary = summarize([
+      makeResult({
+        fixture: { id: "canned-unmeasurable", measurable: false },
+        verdictGrade: "cautious",
+      }),
+    ]);
+    const report = buildReport(summary, meta);
+    expect(report).toContain("Out-of-model-scope fixtures");
+    expect(report).toContain("canned-unmeasurable");
+  });
+
+  it("includes the honest-limits section verbatim caveats", () => {
+    const summary = summarize([makeResult()]);
+    const report = buildReport(summary, meta);
+    expect(report).toContain("Survivorship bias");
+    expect(report).toContain("Outcome conflation");
+    expect(report).toContain("Reconstruction fidelity");
+  });
+
+  it("is stable output for identical input (no Date.now()/Math.random() leakage)", () => {
+    const summary = summarize([makeResult()]);
+    const a = buildReport(summary, meta);
+    const b = buildReport(summary, meta);
+    expect(a).toBe(b);
+  });
+});

--- a/packages/core/src/eval/report.ts
+++ b/packages/core/src/eval/report.ts
@@ -1,0 +1,197 @@
+/**
+ * Vet eval — markdown report generation. Pure function of a summary +
+ * run metadata; no I/O, so it's covered by deterministic tests with
+ * canned results (no live vet/model calls needed).
+ */
+import type { VetEvalResult } from "./types.js";
+import type { VetEvalSummary } from "./vet-eval.js";
+
+export interface ReportMeta {
+  date: string;
+  mode: "quick" | "full";
+  fixtureCount: number;
+  fixtureSetHash: string;
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(0)}%`;
+}
+
+function outcomeMixLine(results: VetEvalResult[]): string {
+  const counts: Record<string, number> = {};
+  for (const r of results) {
+    counts[r.fixture.outcome.label] =
+      (counts[r.fixture.outcome.label] ?? 0) + 1;
+  }
+  return Object.entries(counts)
+    .map(([label, n]) => `${label}=${n}`)
+    .join(", ");
+}
+
+export function buildReport(summary: VetEvalSummary, meta: ReportMeta): string {
+  const lines: string[] = [];
+
+  lines.push(`# oss-scout vet eval — ${meta.date}`);
+  lines.push("");
+  lines.push(
+    `Model: oss-scout deterministic vet/scoring algorithm (\`deriveRecommendation\` + ` +
+      `\`calculateViabilityScore\`, current \`main\`). No LLM in the default vet path — ` +
+      `see "Honest limits" below for what this does and doesn't mean.`,
+  );
+  lines.push(
+    `n: 1 run per fixture (deterministic — see "Why n=1" below). ` +
+      `Mode: ${meta.mode}. Fixtures: ${meta.fixtureCount} (${outcomeMixLine(summary.results)}). ` +
+      `Fixture-set hash: \`${meta.fixtureSetHash}\`.`,
+  );
+  lines.push("");
+
+  lines.push("## Verdict accuracy (measurable fixtures only)");
+  lines.push("");
+  lines.push(
+    `Strict (recommendation exactly matches expected): ${summary.accuracy.correct}/` +
+      `${summary.accuracy.total} (${pct(summary.accuracy.strictRate)}). Lenient ` +
+      `(counts "needs_review" as acceptable, not wrong — see finding below): ` +
+      `${summary.accuracy.correct + summary.accuracy.cautious}/${summary.accuracy.total} ` +
+      `(${pct(summary.accuracy.lenientRate)}). Wrong (confidently the opposite call): ` +
+      `${summary.accuracy.wrong}/${summary.accuracy.total}. ` +
+      `Out of ${summary.results.length} total fixtures — the remaining ` +
+      `${summary.unmeasurable.length} hinge on signals oss-scout's current vetter ` +
+      `doesn't model (see "Out-of-model-scope fixtures" below) and are excluded from ` +
+      `these rates rather than silently counted as passes or failures.`,
+  );
+  lines.push("");
+
+  const expectSkipCautious = summary.measurable.filter(
+    (r) =>
+      r.fixture.expectedVerdict === "skip" && r.verdictGrade === "cautious",
+  );
+  const expectSkipTotal = summary.measurable.filter(
+    (r) => r.fixture.expectedVerdict === "skip",
+  ).length;
+  if (expectSkipCautious.length > 0) {
+    lines.push(
+      `> **Finding:** ${expectSkipCautious.length}/${expectSkipTotal} "should skip" ` +
+        `fixtures landed on \`needs_review\` rather than a hard \`skip\`. ` +
+        "`deriveRecommendation` (issue-vetting.ts) only emits `skip` when more than " +
+        "2 reasonsToSkip accumulate — a single signal (existing PR *or* claimed, " +
+        "alone) downgrades to `needs_review` instead. Not wrong on its own (a human " +
+        "in the loop still catches it), but worth knowing for any automation that " +
+        'treats `recommendation !== "skip"` as "safe to proceed" rather than ' +
+        'requiring `recommendation === "approve"` — that automation would auto-' +
+        "pursue every one of these correctly-flagged-but-not-hard-skipped cases.",
+    );
+    lines.push("");
+  }
+
+  lines.push(
+    "| Fixture | Outcome | Expected | Recommendation | Score | Grade |",
+  );
+  lines.push("|---|---|---|---|---|---|");
+  const gradeIcon: Record<string, string> = {
+    correct: "✅",
+    cautious: "🟡",
+    wrong: "❌",
+  };
+  for (const r of summary.measurable) {
+    lines.push(
+      `| ${r.fixture.id} | ${r.fixture.outcome.label} | ${r.fixture.expectedVerdict} | ` +
+        `${r.recommendation} | ${r.viabilityScore} | ${gradeIcon[r.verdictGrade]} ${r.verdictGrade} |`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Out-of-model-scope fixtures (reported, not scored)");
+  lines.push("");
+  lines.push(
+    "These outcomes hinge on race timing, maintainer self-fix behavior, or " +
+      "feasibility/business judgment that oss-scout's current deterministic " +
+      "checks don't attempt to predict. Shown so the tool's output is visible " +
+      "on these cases without pretending the verdict was 'graded'.",
+  );
+  lines.push("");
+  lines.push(
+    "| Fixture | Outcome | Recommendation | Score | Why unmeasurable |",
+  );
+  lines.push("|---|---|---|---|---|");
+  for (const r of summary.unmeasurable) {
+    lines.push(
+      `| ${r.fixture.id} | ${r.fixture.outcome.label} | ${r.recommendation} | ` +
+        `${r.viabilityScore} | ${r.fixture.fidelityNote.split(".")[0]}. |`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Score calibration");
+  lines.push("");
+  lines.push(
+    "Average current `calculateViabilityScore` output per realized outcome " +
+      "(across ALL fixtures, measurable or not) — a well-calibrated scorer " +
+      "should rank merged > lost_race/maintainer_fixed > skip_correct, since " +
+      "the first three are all 'pursue was the right call' outcomes and only " +
+      "differ in execution/luck, while skip_correct issues should score lower.",
+  );
+  lines.push("");
+  lines.push("| Outcome | n | Avg score | Pursued rate |");
+  lines.push("|---|---|---|---|");
+  for (const [label, bucket] of Object.entries(summary.byOutcomeLabel)) {
+    lines.push(
+      `| ${label} | ${bucket.count} | ${bucket.avgScore.toFixed(1)} | ${pct(bucket.pursuedRate)} |`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Why n=1");
+  lines.push("");
+  lines.push(
+    "oss-scout's default vet path (`deriveRecommendation` + `calculateViabilityScore` + " +
+      "`analyzeRequirements`) is pure, deterministic TypeScript — no LLM call, no " +
+      "sampling, so repeated runs against the same fixture always produce the same " +
+      "output. Running n>1 here would only prove the functions are pure (already true " +
+      "by inspection), not measure anything about judgment quality. The one place a " +
+      "model actually runs is the OPTIONAL SLM pre-triage pass (Ollama, local-only, " +
+      "off by default) — pass `--slm <model>` to additionally measure ITS run-to-run " +
+      "stability across n repeats; that path is not exercised by this report.",
+  );
+  lines.push("");
+
+  lines.push("## Honest limits");
+  lines.push("");
+  lines.push(
+    "- **Survivorship bias.** These are issues John already chose to investigate, not " +
+      "a random sample of all GitHub issues — they skew toward things that looked " +
+      "promising enough to spend time on. This eval measures 'given John's existing " +
+      "funnel, does the current vetter's verdict/score line up with what happened', " +
+      "not 'how good is the vetter at cold-sourcing.'",
+  );
+  lines.push(
+    "- **Outcome conflation.** `merged` vs `lost_race` vs `maintainer_fixed` mostly " +
+      "reflect execution speed and luck (who else was watching the same issue, how " +
+      "fast John built and pushed), not vet quality — all three started from a " +
+      "reasonable 'pursue' call. Treating lost_race/maintainer_fixed as vetting " +
+      "failures would overstate what a smarter vetter could realistically prevent.",
+  );
+  lines.push(
+    "- **Reconstruction fidelity.** `vetTimeFacts` (existing-PR/claimed/project-active/" +
+      "merged-PR-count) are hand-derived from John's own vetting notes recorded at the " +
+      "time, not re-derived from a time-traveled GitHub API call — GitHub's search and " +
+      "timeline APIs can't be queried as of a past date. Issue title/body/labels/repo " +
+      "star-fork counts ARE live API reads, but reflect state as of fixture-build time " +
+      "(2026-07-05), which can differ slightly from vet-time if the issue was edited " +
+      "or the repo grew. Each fixture's `fidelityNote` documents this per-case.",
+  );
+  lines.push(
+    "- **Small N, single fixture-set.** 30 fixtures is enough to catch a gross " +
+      "regression (e.g. a recommendation-logic change that starts skipping every " +
+      "clean issue) but not enough to draw fine-grained statistical conclusions about " +
+      "score thresholds.",
+  );
+  lines.push(
+    "- **Capability gaps are not bugs.** The 'out-of-model-scope' fixtures above " +
+      "surface real capability gaps (no maintainer-comment-sentiment signal, no " +
+      "race-timing prediction) — these are candidates for future feature work, not " +
+      "defects in the current scoring math.",
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/packages/core/src/eval/types.test.ts
+++ b/packages/core/src/eval/types.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { loadFixtures } from "./fixture-loader.js";
+import { VetFixtureSchema } from "./types.js";
+
+describe("VetFixtureSchema", () => {
+  it("accepts a minimal well-formed fixture", () => {
+    const fixture = {
+      id: "example-1",
+      url: "https://github.com/o/r/issues/1",
+      owner: "o",
+      repo: "r",
+      issueNumber: 1,
+      vetDate: "2026-01-01",
+      issue: {
+        title: "t",
+        body: "b",
+        labels: ["bug"],
+        state: "open",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAtObserved: "2026-01-01T00:00:00Z",
+      },
+      repoMeta: { stars: 10, forks: 2 },
+      vetTimeFacts: {
+        hasExistingPR: false,
+        isClaimed: false,
+        projectActive: true,
+        contributionGuidelinesFound: true,
+        mergedPRCount: 0,
+        orgHasMergedPRs: false,
+        matchesPreferredCategory: false,
+        closedWithoutMergeCount: 0,
+      },
+      outcome: { label: "merged", date: "2026-01-02", detail: "d" },
+      measurable: true,
+      expectedVerdict: "pursue",
+      fidelityNote: "n",
+      vaultSource: "s",
+    };
+    expect(() => VetFixtureSchema.parse(fixture)).not.toThrow();
+  });
+
+  it("rejects an unknown outcome label", () => {
+    const fixture = {
+      id: "example-1",
+      url: "https://github.com/o/r/issues/1",
+      owner: "o",
+      repo: "r",
+      issueNumber: 1,
+      vetDate: "2026-01-01",
+      issue: {
+        title: "t",
+        body: "b",
+        labels: [],
+        state: "open",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAtObserved: "2026-01-01T00:00:00Z",
+      },
+      repoMeta: { stars: 0, forks: 0 },
+      vetTimeFacts: {
+        hasExistingPR: false,
+        isClaimed: false,
+        projectActive: true,
+        contributionGuidelinesFound: true,
+        mergedPRCount: 0,
+        orgHasMergedPRs: false,
+        matchesPreferredCategory: false,
+        closedWithoutMergeCount: 0,
+      },
+      outcome: { label: "abandoned_hope", date: "2026-01-02", detail: "d" },
+      measurable: true,
+      expectedVerdict: "pursue",
+      fidelityNote: "n",
+      vaultSource: "s",
+    };
+    expect(() => VetFixtureSchema.parse(fixture)).toThrow();
+  });
+
+  it("rejects a negative issueNumber", () => {
+    const fixture = {
+      id: "example-1",
+      url: "https://github.com/o/r/issues/1",
+      owner: "o",
+      repo: "r",
+      issueNumber: -1,
+      vetDate: "2026-01-01",
+      issue: {
+        title: "t",
+        body: "b",
+        labels: [],
+        state: "open",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAtObserved: "2026-01-01T00:00:00Z",
+      },
+      repoMeta: { stars: 0, forks: 0 },
+      vetTimeFacts: {
+        hasExistingPR: false,
+        isClaimed: false,
+        projectActive: true,
+        contributionGuidelinesFound: true,
+        mergedPRCount: 0,
+        orgHasMergedPRs: false,
+        matchesPreferredCategory: false,
+        closedWithoutMergeCount: 0,
+      },
+      outcome: { label: "merged", date: "2026-01-02", detail: "d" },
+      measurable: true,
+      expectedVerdict: "pursue",
+      fidelityNote: "n",
+      vaultSource: "s",
+    };
+    expect(() => VetFixtureSchema.parse(fixture)).toThrow();
+  });
+});
+
+describe("real vet fixtures (eval/fixtures/vet/*.json)", () => {
+  const fixtures = loadFixtures();
+
+  it("loads exactly 30 fixtures", () => {
+    expect(fixtures.length).toBe(30);
+  });
+
+  it("every fixture has a unique id", () => {
+    const ids = fixtures.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every fixture parses against VetFixtureSchema", () => {
+    for (const fixture of fixtures) {
+      expect(() => VetFixtureSchema.parse(fixture)).not.toThrow();
+    }
+  });
+
+  it("every unmeasurable fixture explains why in fidelityNote", () => {
+    for (const fixture of fixtures.filter((f) => !f.measurable)) {
+      expect(fixture.fidelityNote.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("covers all four outcome labels", () => {
+    const labels = new Set(fixtures.map((f) => f.outcome.label));
+    expect(labels).toEqual(
+      new Set(["merged", "lost_race", "maintainer_fixed", "skip_correct"]),
+    );
+  });
+});

--- a/packages/core/src/eval/types.ts
+++ b/packages/core/src/eval/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Vet eval — fixture schema.
+ *
+ * A fixture freezes what oss-scout's vetter would have seen for one
+ * historical issue, plus the realized outcome recorded later in John's
+ * OSS-pipeline notes. The runner (vet-eval.ts) feeds `vetTimeFacts` and
+ * `issue`/`repo` fields into the CURRENT production scoring/recommendation
+ * functions (issue-scoring.ts, issue-vetting.ts's `deriveRecommendation`,
+ * issue-eligibility.ts's `analyzeRequirements`) and compares the result
+ * against `outcome`.
+ *
+ * See build-fixtures.ts for how these are constructed and
+ * eval/fixtures/vet/README.md for the reconstruction methodology.
+ */
+import { z } from "zod";
+
+export const OutcomeLabelSchema = z.enum([
+  "merged",
+  "lost_race",
+  "maintainer_fixed",
+  "skip_correct",
+]);
+export type OutcomeLabel = z.infer<typeof OutcomeLabelSchema>;
+
+export const VetTimeFactsSchema = z.object({
+  /** Was there already a PR addressing this issue at vet time? */
+  hasExistingPR: z.boolean(),
+  /** Was the issue already claimed (assignee or claim comment) at vet time? */
+  isClaimed: z.boolean(),
+  /** Was the repo judged active (recent commits, not abandoned)? */
+  projectActive: z.boolean(),
+  /** Did the repo have a discoverable CONTRIBUTING.md (or variant)? */
+  contributionGuidelinesFound: z.boolean(),
+  /** John's merged-PR count in this repo as of vet time. */
+  mergedPRCount: z.number().int().min(0),
+  /** Did John have merged PRs in a sibling repo under the same org? */
+  orgHasMergedPRs: z.boolean(),
+  /** Did the repo match one of John's preferred project categories? */
+  matchesPreferredCategory: z.boolean(),
+  /** John's closed-without-merge count in this repo as of vet time. */
+  closedWithoutMergeCount: z.number().int().min(0),
+});
+export type VetTimeFacts = z.infer<typeof VetTimeFactsSchema>;
+
+export const FixtureOutcomeSchema = z.object({
+  label: OutcomeLabelSchema,
+  date: z.string(),
+  detail: z.string(),
+  prUrl: z.string().optional(),
+});
+export type FixtureOutcome = z.infer<typeof FixtureOutcomeSchema>;
+
+export const VetFixtureSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  owner: z.string(),
+  repo: z.string(),
+  issueNumber: z.number().int().positive(),
+  /** Date John's notes record this issue as having been vetted. */
+  vetDate: z.string(),
+  issue: z.object({
+    title: z.string(),
+    body: z.string(),
+    labels: z.array(z.string()),
+    state: z.enum(["open", "closed"]),
+    createdAt: z.string(),
+    /** Issue's updatedAt as observed at fixture-build time (reconstruction
+     * time), NOT necessarily vet time — see fidelity notes. */
+    updatedAtObserved: z.string(),
+  }),
+  repoMeta: z.object({
+    stars: z.number().int().min(0),
+    forks: z.number().int().min(0),
+  }),
+  vetTimeFacts: VetTimeFactsSchema,
+  outcome: FixtureOutcomeSchema,
+  /**
+   * Whether oss-scout's CURRENT deterministic checks (existing-PR, claimed,
+   * project-active, clear-requirements) could plausibly have produced the
+   * right call for this fixture. False for outcomes that hinge on signals
+   * oss-scout doesn't model at all (maintainer self-fix sentiment, race
+   * timing, subjective business judgment) — those are still run and
+   * reported, but excluded from the headline accuracy score so the report
+   * doesn't overclaim. See docs/plans/fleet-evals-design.md.
+   */
+  measurable: z.boolean(),
+  /** What the ground truth says the right call was, independent of
+   * whether oss-scout's current features could detect it. */
+  expectedVerdict: z.enum(["pursue", "skip"]),
+  /** Free-text: why measurable is what it is, provenance of vetTimeFacts,
+   * and any known drift between reconstruction and actual vet-time state. */
+  fidelityNote: z.string(),
+  /** Vault file this fixture's ground truth was extracted from. */
+  vaultSource: z.string(),
+});
+export type VetFixture = z.infer<typeof VetFixtureSchema>;
+
+/**
+ * Three-way grade against `expectedVerdict`, not a binary pass/fail —
+ * `deriveRecommendation` has three outputs (approve/skip/needs_review) and
+ * collapsing "needs_review" into either bucket hides real signal. A
+ * `needs_review` on an expected-skip fixture isn't wrong (a human in the
+ * loop still catches it), but it's also not the confident "skip" a fully
+ * correct verdict would be — "cautious" reports that distinction instead
+ * of forcing a binary that would either overstate accuracy or wrongly
+ * penalize appropriate caution.
+ */
+export type VerdictGrade = "correct" | "cautious" | "wrong";
+
+/** Per-fixture eval result: current vet output + how it graded. */
+export interface VetEvalResult {
+  fixture: VetFixture;
+  clearRequirements: boolean;
+  recommendation: "approve" | "skip" | "needs_review";
+  viabilityScore: number;
+  /** recommendation !== "skip" */
+  pursued: boolean;
+  /** Only meaningful when fixture.measurable is true. */
+  verdictGrade: VerdictGrade;
+}

--- a/packages/core/src/eval/vet-eval-cli.ts
+++ b/packages/core/src/eval/vet-eval-cli.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Vet eval — CLI entry point.
+ *
+ * Usage:
+ *   tsx src/eval/vet-eval-cli.ts --quick          # fast subset, smoke check
+ *   tsx src/eval/vet-eval-cli.ts --full            # all fixtures (default)
+ *   tsx src/eval/vet-eval-cli.ts --full --slm <model>  # also measure SLM
+ *       pre-triage stability (n repeats per fixture); requires a local
+ *       Ollama instance with <model> pulled. Runs locally only, never in CI.
+ *
+ * Writes a dated markdown report to eval/reports/ and prints its path.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { triageWithSLM } from "../core/slm-triage.js";
+import {
+  FIXTURES_DIR,
+  fixtureSetHash,
+  loadFixtures,
+  quickSubset,
+} from "./fixture-loader.js";
+import { buildReport } from "./report.js";
+import { runFixture, summarize } from "./vet-eval.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPORTS_DIR = path.join(__dirname, "..", "..", "eval", "reports");
+
+interface CliOptions {
+  mode: "quick" | "full";
+  slmModel: string | null;
+  slmRuns: number;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const mode = argv.includes("--quick") ? "quick" : "full";
+  const slmIdx = argv.indexOf("--slm");
+  const slmModel = slmIdx >= 0 ? (argv[slmIdx + 1] ?? null) : null;
+  const runsIdx = argv.indexOf("--slm-runs");
+  const slmRuns = runsIdx >= 0 ? Number(argv[runsIdx + 1]) : 5;
+  return { mode, slmModel, slmRuns };
+}
+
+async function runSlmStability(
+  model: string,
+  runs: number,
+  fixtures: ReturnType<typeof loadFixtures>,
+): Promise<string> {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    `## SLM pre-triage stability (model: ${model}, n=${runs}, local Ollama)`,
+  );
+  lines.push("");
+  lines.push("| Fixture | Decisions across n runs | Agreement rate |");
+  lines.push("|---|---|---|");
+
+  let reachable = true;
+  for (const fixture of fixtures) {
+    const decisions: string[] = [];
+    for (let i = 0; i < runs; i++) {
+      const result = await triageWithSLM(
+        {
+          issue: {
+            title: fixture.issue.title,
+            labels: fixture.issue.labels,
+            body: fixture.issue.body,
+          },
+          linkedPRExists: fixture.vetTimeFacts.hasExistingPR,
+        },
+        { model },
+      );
+      if (result === null) {
+        reachable = false;
+        break;
+      }
+      decisions.push(result.decision);
+    }
+    if (!reachable) break;
+    const modeCount = Math.max(
+      ...Object.values(
+        decisions.reduce<Record<string, number>>((acc, d) => {
+          acc[d] = (acc[d] ?? 0) + 1;
+          return acc;
+        }, {}),
+      ),
+    );
+    lines.push(
+      `| ${fixture.id} | ${decisions.join(", ")} | ${((modeCount / runs) * 100).toFixed(0)}% |`,
+    );
+  }
+
+  if (!reachable) {
+    return (
+      "\n## SLM pre-triage stability\n\n" +
+      `Could not reach Ollama at the default host with model \`${model}\` — ` +
+      "skipping SLM stability measurement rather than reporting fabricated numbers. " +
+      "Start Ollama locally (`ollama pull <model>` + `ollama serve`) and re-run with " +
+      "`--slm <model>` to measure it.\n"
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+
+  const allFixtures = loadFixtures(FIXTURES_DIR);
+  const fixtures =
+    opts.mode === "quick" ? quickSubset(allFixtures) : allFixtures;
+
+  const results = fixtures.map((f) => runFixture(f));
+  const summary = summarize(results);
+
+  const date = new Date().toISOString().slice(0, 10);
+  let report = buildReport(summary, {
+    date,
+    mode: opts.mode,
+    fixtureCount: fixtures.length,
+    fixtureSetHash: fixtureSetHash(fixtures),
+  });
+
+  if (opts.slmModel) {
+    report += await runSlmStability(opts.slmModel, opts.slmRuns, fixtures);
+  }
+
+  mkdirSync(REPORTS_DIR, { recursive: true });
+  const outPath = path.join(REPORTS_DIR, `${date}-vet-eval-${opts.mode}.md`);
+  writeFileSync(outPath, report);
+
+  process.stdout.write(report);
+  process.stdout.write(`\nReport written to ${outPath}\n`);
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/core/src/eval/vet-eval.test.ts
+++ b/packages/core/src/eval/vet-eval.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import type { VetFixture } from "./types.js";
+import {
+  gradeVerdict,
+  runFixture,
+  summarize,
+  syntheticUpdatedAt,
+} from "./vet-eval.js";
+
+function makeFixture(overrides: Partial<VetFixture> = {}): VetFixture {
+  return {
+    id: "synthetic-1",
+    url: "https://github.com/o/r/issues/1",
+    owner: "o",
+    repo: "r",
+    issueNumber: 1,
+    vetDate: "2026-01-01",
+    issue: {
+      title: "A clear bug report",
+      body:
+        "Steps to reproduce:\n1. Do the thing\n2. Watch it fail\n\nExpected: it should not fail. " +
+        "This is a longer body so the length indicator crosses the 200-char threshold easily, " +
+        "giving analyzeRequirements enough signal to call this clear.",
+      labels: ["bug"],
+      state: "open",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAtObserved: "2026-01-01T00:00:00Z",
+    },
+    repoMeta: { stars: 100, forks: 10 },
+    vetTimeFacts: {
+      hasExistingPR: false,
+      isClaimed: false,
+      projectActive: true,
+      contributionGuidelinesFound: true,
+      mergedPRCount: 0,
+      orgHasMergedPRs: false,
+      matchesPreferredCategory: false,
+      closedWithoutMergeCount: 0,
+    },
+    outcome: { label: "merged", date: "2026-01-02", detail: "test fixture" },
+    measurable: true,
+    expectedVerdict: "pursue",
+    fidelityNote: "synthetic test fixture",
+    vaultSource: "test",
+    ...overrides,
+  };
+}
+
+describe("gradeVerdict", () => {
+  it("grades an approve on an expected-pursue fixture as correct", () => {
+    expect(gradeVerdict("approve", "pursue")).toBe("correct");
+  });
+  it("grades a needs_review on an expected-pursue fixture as cautious", () => {
+    expect(gradeVerdict("needs_review", "pursue")).toBe("cautious");
+  });
+  it("grades a skip on an expected-pursue fixture as wrong", () => {
+    expect(gradeVerdict("skip", "pursue")).toBe("wrong");
+  });
+  it("grades a skip on an expected-skip fixture as correct", () => {
+    expect(gradeVerdict("skip", "skip")).toBe("correct");
+  });
+  it("grades a needs_review on an expected-skip fixture as cautious", () => {
+    expect(gradeVerdict("needs_review", "skip")).toBe("cautious");
+  });
+  it("grades an approve on an expected-skip fixture as wrong", () => {
+    expect(gradeVerdict("approve", "skip")).toBe("wrong");
+  });
+});
+
+describe("syntheticUpdatedAt", () => {
+  it("preserves the vet-time freshness gap against a fixed 'now'", () => {
+    const now = new Date("2026-07-05T00:00:00Z");
+    // Issue was updated exactly on vetDate (0-day-old at vet time) —
+    // synthetic timestamp should land exactly on `now`.
+    const result = syntheticUpdatedAt(
+      "2026-06-01T00:00:00Z",
+      "2026-06-01",
+      now,
+    );
+    expect(new Date(result).getTime()).toBe(now.getTime());
+  });
+
+  it("preserves a nonzero staleness gap", () => {
+    const now = new Date("2026-07-05T00:00:00Z");
+    // Issue was already 10 days stale at vet time.
+    const result = syntheticUpdatedAt(
+      "2026-05-22T00:00:00Z",
+      "2026-06-01",
+      now,
+    );
+    const gapDays =
+      (now.getTime() - new Date(result).getTime()) / (1000 * 60 * 60 * 24);
+    expect(gapDays).toBeCloseTo(10, 5);
+  });
+
+  it("never produces a negative gap when updatedAt is after vetDate", () => {
+    const now = new Date("2026-07-05T00:00:00Z");
+    const result = syntheticUpdatedAt(
+      "2026-06-10T00:00:00Z",
+      "2026-06-01",
+      now,
+    );
+    expect(new Date(result).getTime()).toBe(now.getTime());
+  });
+});
+
+describe("runFixture", () => {
+  it("recommends approve for a clean pursue-shaped fixture", () => {
+    const result = runFixture(makeFixture());
+    expect(result.recommendation).toBe("approve");
+    expect(result.pursued).toBe(true);
+    expect(result.verdictGrade).toBe("correct");
+  });
+
+  it(
+    "does not recommend a hard skip for a single existing-PR signal, " +
+      "and grades that as cautious rather than wrong (real deriveRecommendation " +
+      "behavior: skip requires >2 reasonsToSkip)",
+    () => {
+      const result = runFixture(
+        makeFixture({
+          vetTimeFacts: {
+            hasExistingPR: true,
+            isClaimed: false,
+            projectActive: true,
+            contributionGuidelinesFound: true,
+            mergedPRCount: 0,
+            orgHasMergedPRs: false,
+            matchesPreferredCategory: false,
+            closedWithoutMergeCount: 0,
+          },
+          outcome: {
+            label: "skip_correct",
+            date: "2026-01-02",
+            detail: "taken",
+          },
+          expectedVerdict: "skip",
+        }),
+      );
+      expect(result.recommendation).toBe("needs_review");
+      expect(result.verdictGrade).toBe("cautious");
+    },
+  );
+
+  it("recommends skip when enough negative signals stack up", () => {
+    const result = runFixture(
+      makeFixture({
+        vetTimeFacts: {
+          hasExistingPR: true,
+          isClaimed: true,
+          projectActive: false,
+          contributionGuidelinesFound: false,
+          mergedPRCount: 0,
+          orgHasMergedPRs: false,
+          matchesPreferredCategory: false,
+          closedWithoutMergeCount: 0,
+        },
+        outcome: { label: "skip_correct", date: "2026-01-02", detail: "dead" },
+        expectedVerdict: "skip",
+      }),
+    );
+    expect(result.recommendation).toBe("skip");
+    expect(result.verdictGrade).toBe("correct");
+  });
+
+  it("marks unmeasurable fixtures as cautious regardless of recommendation", () => {
+    const result = runFixture(makeFixture({ measurable: false }));
+    expect(result.verdictGrade).toBe("cautious");
+  });
+
+  it("computes clearRequirements from the real issue body via analyzeRequirements", () => {
+    const result = runFixture(
+      makeFixture({ issue: { ...makeFixture().issue, body: "short" } }),
+    );
+    expect(result.clearRequirements).toBe(false);
+  });
+});
+
+describe("summarize", () => {
+  it("excludes unmeasurable fixtures from accuracy but includes them in byOutcomeLabel", () => {
+    const results = [
+      runFixture(makeFixture({ id: "a" })),
+      runFixture(
+        makeFixture({
+          id: "b",
+          measurable: false,
+          outcome: { label: "lost_race", date: "2026-01-02", detail: "x" },
+        }),
+      ),
+    ];
+    const summary = summarize(results);
+    expect(summary.accuracy.total).toBe(1);
+    expect(summary.unmeasurable.length).toBe(1);
+    expect(Object.keys(summary.byOutcomeLabel).sort()).toEqual([
+      "lost_race",
+      "merged",
+    ]);
+  });
+
+  it("computes lenientRate and strictRate distinctly when needs_review is involved", () => {
+    const cautiousResult = runFixture(
+      makeFixture({
+        id: "c",
+        vetTimeFacts: {
+          hasExistingPR: true,
+          isClaimed: false,
+          projectActive: true,
+          contributionGuidelinesFound: true,
+          mergedPRCount: 0,
+          orgHasMergedPRs: false,
+          matchesPreferredCategory: false,
+          closedWithoutMergeCount: 0,
+        },
+        outcome: { label: "skip_correct", date: "2026-01-02", detail: "taken" },
+        expectedVerdict: "skip",
+      }),
+    );
+    const summary = summarize([cautiousResult]);
+    expect(summary.accuracy.strictRate).toBe(0);
+    expect(summary.accuracy.lenientRate).toBe(1);
+  });
+});

--- a/packages/core/src/eval/vet-eval.ts
+++ b/packages/core/src/eval/vet-eval.ts
@@ -1,0 +1,205 @@
+/**
+ * Vet eval — runner.
+ *
+ * Feeds each fixture's frozen vet-time facts into oss-scout's CURRENT
+ * production decision functions:
+ *   - analyzeRequirements (issue-eligibility.ts) on the real issue body
+ *   - calculateRepoQualityBonus + calculateViabilityScore (issue-scoring.ts)
+ *   - deriveRecommendation (issue-vetting.ts)
+ *
+ * This deliberately does NOT replay the full vetIssue() I/O pipeline
+ * (Octokit calls, GraphQL prefetch, etc.) — see the PR description for
+ * why: there is no existing full-Octokit fixture harness in this repo,
+ * and GitHub's search/timeline APIs cannot be reliably time-traveled to
+ * reconstruct historical existing-PR/claim state. Targeting the pure
+ * decision-layer functions directly is higher-fidelity and lower-risk:
+ * these functions ARE the actual judgment; the rest of vetIssue is I/O
+ * plumbing to gather their inputs.
+ *
+ * One important wrinkle: calculateViabilityScore's freshness bonus calls
+ * `daysBetween(issueUpdatedAt)`, which compares against the REAL current
+ * date. Replaying a historical fixture naively would make every fixture
+ * look maximally stale (freshness bonus ~0) regardless of how fresh the
+ * issue actually was at vet time, corrupting scores uniformly. We correct
+ * for this with a time-shifted synthetic timestamp that preserves the
+ * vet-time freshness gap: `now - (vetDate - issueUpdatedAt)`.
+ */
+import { analyzeRequirements } from "../core/issue-eligibility.js";
+import {
+  calculateRepoQualityBonus,
+  calculateViabilityScore,
+} from "../core/issue-scoring.js";
+import {
+  deriveRecommendation,
+  type RecommendationInput,
+} from "../core/issue-vetting.js";
+import type { VerdictGrade, VetEvalResult, VetFixture } from "./types.js";
+
+/**
+ * Grade a recommendation against the ground-truth expected verdict. Three
+ * outcomes, not two — see VerdictGrade's doc comment for why "cautious"
+ * (a needs_review that isn't confidently right, but isn't a confident
+ * miss either) is kept distinct from "correct" and "wrong".
+ */
+export function gradeVerdict(
+  recommendation: "approve" | "skip" | "needs_review",
+  expectedVerdict: "pursue" | "skip",
+): VerdictGrade {
+  if (expectedVerdict === "pursue") {
+    if (recommendation === "approve") return "correct";
+    if (recommendation === "needs_review") return "cautious";
+    return "wrong"; // recommendation === "skip"
+  }
+  // expectedVerdict === "skip"
+  if (recommendation === "skip") return "correct";
+  if (recommendation === "needs_review") return "cautious";
+  return "wrong"; // recommendation === "approve"
+}
+
+/**
+ * Freshness-preserving synthetic updatedAt: shifts the real historical
+ * updatedAt forward so that `daysBetween(synthetic, Date.now())` equals
+ * `daysBetween(actualUpdatedAt, vetDate)` — i.e. reproduces the same
+ * "how stale was this issue AT VET TIME" gap against today's clock.
+ */
+export function syntheticUpdatedAt(
+  issueUpdatedAt: string,
+  vetDate: string,
+  now: Date = new Date(),
+): string {
+  const updatedMs = new Date(issueUpdatedAt).getTime();
+  const vetMs = new Date(vetDate).getTime();
+  const gapMs = Math.max(0, vetMs - updatedMs);
+  return new Date(now.getTime() - gapMs).toISOString();
+}
+
+export function runFixture(
+  fixture: VetFixture,
+  now: Date = new Date(),
+): VetEvalResult {
+  const clearRequirements = analyzeRequirements(fixture.issue.body);
+  const repoQualityBonus = calculateRepoQualityBonus(
+    fixture.repoMeta.stars,
+    fixture.repoMeta.forks,
+  );
+
+  const viabilityScore = calculateViabilityScore({
+    repoScore: null,
+    hasExistingPR: fixture.vetTimeFacts.hasExistingPR,
+    isClaimed: fixture.vetTimeFacts.isClaimed,
+    clearRequirements,
+    hasContributionGuidelines: fixture.vetTimeFacts.contributionGuidelinesFound,
+    issueUpdatedAt: syntheticUpdatedAt(
+      fixture.issue.updatedAtObserved,
+      fixture.vetDate,
+      now,
+    ),
+    closedWithoutMergeCount: fixture.vetTimeFacts.closedWithoutMergeCount,
+    mergedPRCount: fixture.vetTimeFacts.mergedPRCount,
+    orgHasMergedPRs: fixture.vetTimeFacts.orgHasMergedPRs,
+    repoQualityBonus,
+    matchesPreferredCategory: fixture.vetTimeFacts.matchesPreferredCategory,
+  });
+
+  const recInput: RecommendationInput = {
+    noExistingPR: !fixture.vetTimeFacts.hasExistingPR,
+    ownPR: false,
+    linkedPRMerged: false,
+    linkedPRClosed: false,
+    notClaimed: !fixture.vetTimeFacts.isClaimed,
+    clearRequirements,
+    contributionGuidelinesFound:
+      fixture.vetTimeFacts.contributionGuidelinesFound,
+    projectIsActive: fixture.vetTimeFacts.projectActive,
+    projectCheckFailed: false,
+    existingPRInconclusive: false,
+    claimInconclusive: false,
+    mergedCountInconclusive: false,
+    effectiveMergedCount: fixture.vetTimeFacts.mergedPRCount,
+    orgName: fixture.owner,
+    orgHasMergedPRs: fixture.vetTimeFacts.orgHasMergedPRs,
+    matchesCategory: fixture.vetTimeFacts.matchesPreferredCategory,
+    issueClosed: false, // fixtures freeze the OPEN, at-vet-time state
+    passedAllChecks:
+      !fixture.vetTimeFacts.hasExistingPR &&
+      !fixture.vetTimeFacts.isClaimed &&
+      fixture.vetTimeFacts.projectActive &&
+      clearRequirements,
+  };
+  const { recommendation } = deriveRecommendation(recInput);
+
+  const pursued = recommendation !== "skip";
+  const verdictGrade: VerdictGrade = fixture.measurable
+    ? gradeVerdict(recommendation, fixture.expectedVerdict)
+    : "cautious"; // unmeasurable fixtures aren't graded; see summarize()
+
+  return {
+    fixture,
+    clearRequirements,
+    recommendation,
+    viabilityScore,
+    pursued,
+    verdictGrade,
+  };
+}
+
+export interface VetEvalSummary {
+  results: VetEvalResult[];
+  measurable: VetEvalResult[];
+  unmeasurable: VetEvalResult[];
+  accuracy: {
+    correct: number;
+    cautious: number;
+    wrong: number;
+    total: number;
+    /** (correct + cautious) / total — a needs_review isn't a confident
+     * miss, so it's not counted against the lenient rate. */
+    lenientRate: number;
+    /** correct / total — only a confident, exactly-right verdict counts. */
+    strictRate: number;
+  };
+  byOutcomeLabel: Record<
+    string,
+    { count: number; avgScore: number; pursuedRate: number }
+  >;
+}
+
+export function summarize(results: VetEvalResult[]): VetEvalSummary {
+  const measurable = results.filter((r) => r.fixture.measurable);
+  const unmeasurable = results.filter((r) => !r.fixture.measurable);
+  const correct = measurable.filter((r) => r.verdictGrade === "correct").length;
+  const cautious = measurable.filter(
+    (r) => r.verdictGrade === "cautious",
+  ).length;
+  const wrong = measurable.filter((r) => r.verdictGrade === "wrong").length;
+
+  const byOutcomeLabel: VetEvalSummary["byOutcomeLabel"] = {};
+  for (const r of results) {
+    const label = r.fixture.outcome.label;
+    byOutcomeLabel[label] ??= { count: 0, avgScore: 0, pursuedRate: 0 };
+    const bucket = byOutcomeLabel[label];
+    bucket.count += 1;
+    bucket.avgScore += r.viabilityScore;
+    bucket.pursuedRate += r.pursued ? 1 : 0;
+  }
+  for (const bucket of Object.values(byOutcomeLabel)) {
+    bucket.avgScore = bucket.avgScore / bucket.count;
+    bucket.pursuedRate = bucket.pursuedRate / bucket.count;
+  }
+
+  return {
+    results,
+    measurable,
+    unmeasurable,
+    accuracy: {
+      correct,
+      cautious,
+      wrong,
+      total: measurable.length,
+      lenientRate:
+        measurable.length > 0 ? (correct + cautious) / measurable.length : 0,
+      strictRate: measurable.length > 0 ? correct / measurable.length : 0,
+    },
+    byOutcomeLabel,
+  };
+}


### PR DESCRIPTION
## What

Slice 2 of the fleet-evals design (vault: `docs/plans/fleet-evals-design.md`): an eval suite that measures whether oss-scout's vet/scoring logic still makes good calls, using 30 past issues with known real-world outcomes as ground truth, instead of relying on vibes when the scoring formula or recommendation logic changes.

- `eval/fixtures/vet/*.json` (30 fixtures) — for each historical issue: real title/body/labels/state/repo star+fork counts (live `gh api` reads, read-only), plus `vetTimeFacts` (existing-PR/claimed/project-active/merged-PR-count/etc.) hand-derived from John's own vetting-time notes, plus the realized `outcome` (`merged` / `lost_race` / `maintainer_fixed` / `skip_correct`) with dates, each independently re-verified against the live GitHub API today (not just trusted from notes). Provenance in `eval/fixtures/vet/README.md`.
- `src/eval/vet-eval.ts` + `vet-eval-cli.ts` — runner. `pnpm run eval:vet` (full, 30 fixtures) / `eval:vet:quick` (10-fixture representative subset). Writes a dated markdown report to `eval/reports/` stating model, n, mode, and a fixture-set content hash.
- Deterministic tests (`*.test.ts` alongside the eval code) — fixture schema validation, grading logic, report generation from canned data. No live model/network calls; safe for CI.

## Adapted from the design (read this before the numbers)

The design assumed something LLM-judge-shaped ("run the current vet prompt/model against each fixture"). Verified against current `main` first: oss-scout's default vet path has **no LLM call at all** — `deriveRecommendation` (issue-vetting.ts) and `calculateViabilityScore`/`calculateRepoQualityBonus` (issue-scoring.ts) are pure, deterministic TypeScript. The only model call anywhere in the vet pipeline is the *optional* SLM pre-triage (Ollama, `slm-triage.ts`), gated off by default.

Given that, I adapted the eval to target those pure decision-layer functions directly (plus `analyzeRequirements` on the real issue body) rather than mocking the full `vetIssue()` Octokit/GraphQL I/O pipeline. Two reasons:
1. There's no existing full-Octokit fixture harness in this repo — `issue-vetting.test.ts` mocks the *helper modules* (`issue-eligibility.js`, `repo-health.js`, `anti-llm-policy.js`), not raw Octokit calls. Building one from scratch would be new, untested surface area, not a reuse of an established pattern.
2. GitHub's search/timeline APIs can't be queried as of a past date, so "faithfully replaying the full pipeline" would still require hand-reconstructing the existing-PR/claim state from notes anyway — targeting the decision functions directly is more honest about what's actually being measured.

`n=1` per fixture, not multiple runs — these functions are pure, so repeated runs are identical by construction; running n>1 would only prove purity, not measure judgment stability. `--slm <model>` is wired up as an *optional* addition that measures the Ollama pre-triage's real run-to-run stability (n repeats) against the same fixtures, local-only, never in CI, and fails loudly (not with fabricated numbers) if Ollama isn't reachable.

One more wrinkle caught while building this: `calculateViabilityScore`'s freshness bonus compares against the real current date, so naively replaying a months-old fixture would always show it as maximally stale regardless of how fresh it actually was at vet time. Fixed with a time-shifted synthetic timestamp (`syntheticUpdatedAt` in `vet-eval.ts`) that preserves the vet-time freshness gap against today's clock — documented inline.

## A real finding, not just a scaffold

First run already surfaces something worth knowing about `deriveRecommendation`: it only emits a hard `"skip"` once **more than 2** `reasonsToSkip` stack up. A single existing-PR-or-claimed signal alone downgrades to `"needs_review"`, not `"skip"`. Across the 8 measurable "should skip" fixtures in this set, **all 8** landed on `needs_review` rather than a hard skip. That's not wrong on its own — a human in the loop still catches it — but it means any automation treating `recommendation !== "skip"` as "safe to proceed" (rather than requiring `recommendation === "approve"`) would auto-pursue every one of these. The report grades this as `"cautious"` (a third bucket, not collapsed into pass/fail) and calls it out explicitly rather than burying it in an accuracy percentage.

## Fixture mix (30 total)

- 12 `merged` — PURSUE tier that converted (merge status re-verified live for every one)
- 2 `lost_race` — pursuing was right, a competitor won on timing (not scored — see below)
- 6 `maintainer_fixed` — pursuing was right, maintainer shipped their own fix first (not scored)
- 10 `skip_correct` — correctly not pursued; 8 map onto existing-PR/claimed checks the vetter already runs (scored), 2 hinge on feasibility/investigation judgment the vetter doesn't attempt (not scored)

Of the 20 "measurable" fixtures (i.e. the outcome hinges on something the current deterministic checks could plausibly get right or wrong): 12/20 exactly match the expected verdict, 8/20 land on the more-cautious-than-strictly-needed `needs_review` (the finding above), 0/20 are a confident miss. The other 10 fixtures hinge on race timing, maintainer self-fix behavior, or feasibility judgment the current feature set doesn't model at all — they're run and reported (see the report's "Out-of-model-scope" section) but deliberately excluded from the headline accuracy number rather than silently counted either way.

Full report: `eval/reports/2026-07-06-vet-eval-full.md` (also reproducible with `pnpm run eval:vet`).

## Honest limits (also in the report itself)

- **Survivorship bias**: these are issues John already chose to investigate, not a random GitHub sample.
- **Outcome conflation**: merged vs. lost-race vs. maintainer-fixed mostly reflects execution speed and luck, not vet quality — all three started from a reasonable "pursue" call.
- **Reconstruction fidelity**: `vetTimeFacts` are hand-derived from notes, not time-traveled API calls; issue/repo objective fields are live reads as of today, which can drift slightly from true vet-time state. Documented per-fixture in `fidelityNote`.
- **Small N**: 30 fixtures catches a gross regression, not fine-grained score-threshold tuning.

## Verification

- `pnpm --filter @oss-scout/core run typecheck` — clean
- `pnpm run lint` — clean
- `pnpm run format:check` — clean
- `pnpm -r run test` — 1090 passed (1058 core + 32 mcp-server), including the new deterministic eval tests
- `pnpm -r run build` / `pnpm -r run bundle` — clean
- Every `merged`/`lost_race`/`maintainer_fixed` outcome claim independently re-verified against the live GitHub API (`gh api .../pulls/<n>` for merge status, `.../issues/<n>` for state/state_reason) as part of building the fixtures, not just trusted from vault notes.

Does not modify vet/scoring behavior itself — this only measures it. No external posting anywhere in this suite (read-only `gh api` calls only).