### PR TITLE
feat(core): move broad issue search to GraphQL and rotate language slices across runs

### DIFF
--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -9,6 +9,7 @@ const mockSaveResults = vi.fn();
 const mockCheckpoint = vi.fn<() => Promise<boolean>>();
 const mockGetState = vi.fn<() => ScoutState>();
 const mockGetRepoScoreRecord = vi.fn<(repo: string) => RepoScore | undefined>();
+const mockIsDirty = vi.fn<() => boolean>();
 
 vi.mock("../scout.js", () => ({
   createScout: vi.fn().mockImplementation(() =>
@@ -18,6 +19,7 @@ vi.mock("../scout.js", () => ({
       checkpoint: mockCheckpoint,
       getState: mockGetState,
       getRepoScoreRecord: mockGetRepoScoreRecord,
+      isDirty: mockIsDirty,
     }),
   ),
 }));
@@ -247,6 +249,41 @@ describe("runSearch", () => {
     await runSearch({ maxResults: 5 });
 
     expect(mockCheckpoint).toHaveBeenCalled();
+  });
+
+  it("persists dirty state when a zero-candidate ValidationError is thrown", async () => {
+    // withScout's persist epilogue never runs when search throws, but the
+    // language-rotation cursor advances even on a zero-candidate broad run
+    // (#249 follow-up) — that advance must land on disk before rethrowing.
+    const { ValidationError } = await import("../core/errors.js");
+    const { saveLocalState } = await import("../core/local-state.js");
+    mockSearch.mockRejectedValue(
+      new ValidationError("No issue candidates found", ["broad"]),
+    );
+    mockIsDirty.mockReturnValue(true);
+    mockGetState.mockReturnValue({ version: 1 } as ScoutState);
+
+    const { runSearch } = await import("./search.js");
+    await expect(runSearch({ maxResults: 5 })).rejects.toThrow(
+      "No issue candidates found",
+    );
+
+    expect(saveLocalState).toHaveBeenCalled();
+    expect(mockCheckpoint).toHaveBeenCalled();
+  });
+
+  it("does not persist on non-ValidationError failures", async () => {
+    const { saveLocalState } = await import("../core/local-state.js");
+    mockSearch.mockRejectedValue(new Error("network exploded"));
+    mockIsDirty.mockReturnValue(true);
+
+    const { runSearch } = await import("./search.js");
+    await expect(runSearch({ maxResults: 5 })).rejects.toThrow(
+      "network exploded",
+    );
+
+    expect(saveLocalState).not.toHaveBeenCalled();
+    expect(mockCheckpoint).not.toHaveBeenCalled();
   });
 
   it("marks linkedPR.isStalled when the linked PR is open and stale (#97)", async () => {

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -2,8 +2,9 @@
  * Search command — finds contributable issues using multi-strategy search.
  */
 
-import { withScout } from "./with-scout.js";
+import { withScout, persistScout } from "./with-scout.js";
 import { isLinkedPRStalled } from "../core/linked-pr.js";
+import { ValidationError } from "../core/errors.js";
 import type { ScoutState, SearchStrategy } from "../core/schemas.js";
 
 export interface SearchOutput {
@@ -83,15 +84,29 @@ export async function runSearch(
   return withScout(
     options.state,
     async (scout) => {
-      const result = await scout.search({
-        maxResults: options.maxResults,
-        strategies: options.strategies,
-        preferLanguages: options.preferLanguages,
-        preferRepos: options.preferRepos,
-        avoidRepos: options.avoidRepos,
-        boostIssueTypes: options.boostIssueTypes,
-        diversityRatio: options.diversityRatio,
-      });
+      let result;
+      try {
+        result = await scout.search({
+          maxResults: options.maxResults,
+          strategies: options.strategies,
+          preferLanguages: options.preferLanguages,
+          preferRepos: options.preferRepos,
+          avoidRepos: options.avoidRepos,
+          boostIssueTypes: options.boostIssueTypes,
+          diversityRatio: options.diversityRatio,
+        });
+      } catch (err) {
+        // withScout's persist epilogue only runs when fn resolves, so state
+        // mutated before a zero-candidate ValidationError (notably the
+        // language-rotation cursor, which advances even when the broad phase
+        // found nothing) would be silently dropped. Persist it before
+        // rethrowing so the next run leads with a different language slice
+        // (#249 follow-up).
+        if (err instanceof ValidationError && scout.isDirty()) {
+          await persistScout(scout);
+        }
+        throw err;
+      }
 
       scout.saveResults(result.candidates);
 

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -27,7 +27,17 @@ export class ConfigurationError extends OssScoutError {
 }
 
 export class ValidationError extends OssScoutError {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    /**
+     * Strategies that actually ran before this error was thrown (#249
+     * follow-up). searchIssues() attaches this on its zero-candidate throw so
+     * scout.search() can still advance the language-rotation cursor when the
+     * broad phase ran but found nothing — the exact case rotation exists to
+     * fix, since a barren language slice should not lead the next run too.
+     */
+    public readonly strategiesUsed?: string[],
+  ) {
     super(message, "VALIDATION_ERROR");
     this.name = "ValidationError";
   }

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -1164,6 +1164,67 @@ describe("mergeStates", () => {
 
     expect(merged.gistId).toBe("remote-gist");
   });
+
+  describe("searchRotation (#249 follow-up)", () => {
+    it("picks the side with the fresher lastRotatedAt", () => {
+      const local = makeState({
+        searchRotation: {
+          languageOffset: 1,
+          lastRotatedAt: "2026-06-02T00:00:00Z",
+        },
+      });
+      const remote = makeState({
+        searchRotation: {
+          languageOffset: 5,
+          lastRotatedAt: "2026-06-01T00:00:00Z",
+        },
+      });
+
+      // Local is fresher despite a smaller offset — timestamp wins.
+      expect(mergeStates(local, remote).searchRotation).toEqual({
+        languageOffset: 1,
+        lastRotatedAt: "2026-06-02T00:00:00Z",
+      });
+      // ...and remote wins when remote is fresher.
+      expect(mergeStates(remote, local).searchRotation).toEqual({
+        languageOffset: 1,
+        lastRotatedAt: "2026-06-02T00:00:00Z",
+      });
+    });
+
+    it("falls back to the larger languageOffset when neither side has a timestamp", () => {
+      const local = makeState({
+        searchRotation: { languageOffset: 2 },
+      });
+      const remote = makeState({
+        searchRotation: { languageOffset: 7 },
+      });
+
+      expect(mergeStates(local, remote).searchRotation).toEqual({
+        languageOffset: 7,
+      });
+      expect(mergeStates(remote, local).searchRotation).toEqual({
+        languageOffset: 7,
+      });
+    });
+
+    it("prefers the side with a timestamp over the side without one", () => {
+      const local = makeState({
+        searchRotation: {
+          languageOffset: 0,
+          lastRotatedAt: "2026-06-01T00:00:00Z",
+        },
+      });
+      const remote = makeState({
+        searchRotation: { languageOffset: 9 },
+      });
+
+      expect(mergeStates(local, remote).searchRotation).toEqual({
+        languageOffset: 0,
+        lastRotatedAt: "2026-06-01T00:00:00Z",
+      });
+    });
+  });
 });
 
 describe("mergeStates unknown-key round-trip (#137)", () => {

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -507,7 +507,36 @@ export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
       pickFresherTimestamp(local.lastRunAt, remote.lastRunAt) ??
       new Date().toISOString(),
     gistId: remote.gistId ?? local.gistId,
+    searchRotation: mergeSearchRotation(
+      local.searchRotation,
+      remote.searchRotation,
+    ),
   };
+}
+
+/**
+ * Merge the language-rotation cursor: prefer the side with the fresher
+ * `lastRotatedAt`; if neither (or both) have a timestamp, fall back to the
+ * larger `languageOffset` so a merge never regresses the rotation cursor.
+ */
+function mergeSearchRotation(
+  local: ScoutState["searchRotation"],
+  remote: ScoutState["searchRotation"],
+): ScoutState["searchRotation"] {
+  const localRotation = local ?? { languageOffset: 0 };
+  const remoteRotation = remote ?? { languageOffset: 0 };
+  const localTs = localRotation.lastRotatedAt;
+  const remoteTs = remoteRotation.lastRotatedAt;
+
+  if (localTs && remoteTs) {
+    return localTs >= remoteTs ? localRotation : remoteRotation;
+  }
+  if (localTs) return localRotation;
+  if (remoteTs) return remoteRotation;
+
+  return remoteRotation.languageOffset >= localRotation.languageOffset
+    ? remoteRotation
+    : localRotation;
 }
 
 function mergeRepoScores(

--- a/packages/core/src/core/issue-discovery-strategies.test.ts
+++ b/packages/core/src/core/issue-discovery-strategies.test.ts
@@ -29,7 +29,9 @@ vi.mock("./search-budget.js", () => ({
 vi.mock("./search-phases.js", () => ({
   buildEffectiveLabels: vi.fn((_scopes: unknown, labels: string[]) => labels),
   interleaveArrays: vi.fn((arrays: unknown[][]) => arrays.flat()),
-  cachedSearchIssues: vi.fn().mockResolvedValue({ total_count: 0, items: [] }),
+  searchIssuesGraphQLFirst: vi
+    .fn()
+    .mockResolvedValue({ total_count: 0, items: [] }),
   fetchIssuesFromMaintainedRepos: vi.fn().mockResolvedValue([]),
   filterVetAndScore: vi.fn().mockResolvedValue({
     candidates: [],
@@ -41,7 +43,9 @@ vi.mock("./search-phases.js", () => ({
     allReposFailed: false,
     rateLimitHit: false,
   }),
-  searchWithChunkedLabels: vi.fn().mockResolvedValue([]),
+  searchAcrossLanguagesAndLabels: vi.fn().mockResolvedValue([]),
+  getGraphQLSearchQueryCount: () => 0,
+  resetGraphQLSearchQueryCount: () => {},
 }));
 
 vi.mock("./issue-vetting.js", () => {

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -1282,10 +1282,12 @@ describe("IssueDiscovery", () => {
       // Pre-flight init() ran on the injected instance, not the singleton.
       expect(tracker.init).toHaveBeenCalledOnce();
 
-      // The same instance is threaded into the search-phases helper as its
-      // trailing argument, so concurrent searches no longer share budget state.
+      // The same instance is threaded into the search-phases helper as the
+      // `tracker` argument (now second-to-last: `languageRotationOffset`
+      // trails it, #249 follow-up), so concurrent searches no longer share
+      // budget state.
       const phaseCall = mockSearchAcrossLanguagesAndLabels.mock.calls.at(-1)!;
-      expect(phaseCall.at(-1)).toBe(tracker);
+      expect(phaseCall.at(-2)).toBe(tracker);
     });
 
     it("falls back to the shared singleton when no tracker is injected", async () => {
@@ -1306,9 +1308,56 @@ describe("IssueDiscovery", () => {
       await discovery.searchIssues({ maxResults: 5 });
 
       // Default path threads the mocked singleton (a defined tracker object),
-      // never undefined, into the search-phases helper.
+      // never undefined, into the search-phases helper (second-to-last arg;
+      // `languageRotationOffset` trails it, #249 follow-up).
       const phaseCall = mockSearchAcrossLanguagesAndLabels.mock.calls.at(-1)!;
-      expect(phaseCall.at(-1)).toBeDefined();
+      expect(phaseCall.at(-2)).toBeDefined();
+    });
+  });
+
+  describe("languageRotationOffset threading (#249 follow-up)", () => {
+    it("passes languageRotationOffset through to searchAcrossLanguagesAndLabels", async () => {
+      const item: GitHubSearchItem = {
+        html_url: "https://github.com/broad/repo/issues/1",
+        repository_url: "https://api.github.com/repos/broad/repo",
+        updated_at: "2026-01-01T00:00:00Z",
+      };
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue([item]);
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [makeCandidate("broad/repo", "normal")],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery();
+      await discovery.searchIssues({
+        maxResults: 5,
+        languageRotationOffset: 3,
+      });
+
+      // Trailing arg on the search-phases helper (tracker, languageRotationOffset).
+      const phaseCall = mockSearchAcrossLanguagesAndLabels.mock.calls.at(-1)!;
+      expect(phaseCall.at(-1)).toBe(3);
+    });
+
+    it("defaults languageRotationOffset to 0 when not provided", async () => {
+      const item: GitHubSearchItem = {
+        html_url: "https://github.com/broad/repo/issues/1",
+        repository_url: "https://api.github.com/repos/broad/repo",
+        updated_at: "2026-01-01T00:00:00Z",
+      };
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue([item]);
+      mockFilterVetAndScore.mockResolvedValue({
+        candidates: [makeCandidate("broad/repo", "normal")],
+        allVetFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery();
+      await discovery.searchIssues({ maxResults: 5 });
+
+      const phaseCall = mockSearchAcrossLanguagesAndLabels.mock.calls.at(-1)!;
+      expect(phaseCall.at(-1)).toBe(0);
     });
   });
 });

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -110,7 +110,7 @@ const mockFilterVetAndScore = vi.fn().mockResolvedValue({
   rateLimitHit: false,
 });
 
-const mockCachedSearchIssues = vi.fn().mockResolvedValue({
+const mockSearchIssuesGraphQLFirst = vi.fn().mockResolvedValue({
   total_count: 0,
   items: [],
 });
@@ -118,6 +118,8 @@ const mockCachedSearchIssues = vi.fn().mockResolvedValue({
 const mockFetchIssuesFromMaintainedRepos = vi
   .fn()
   .mockResolvedValue([] as GitHubSearchItem[]);
+
+let mockGraphqlSearchQueryCount = 0;
 
 vi.mock("./search-phases.js", () => ({
   buildEffectiveLabels: vi.fn((_scopes: string[], labels: string[]) =>
@@ -129,9 +131,14 @@ vi.mock("./search-phases.js", () => ({
   searchAcrossLanguagesAndLabels: (...args: unknown[]) =>
     mockSearchAcrossLanguagesAndLabels(...args),
   filterVetAndScore: (...args: unknown[]) => mockFilterVetAndScore(...args),
-  cachedSearchIssues: (...args: unknown[]) => mockCachedSearchIssues(...args),
+  searchIssuesGraphQLFirst: (...args: unknown[]) =>
+    mockSearchIssuesGraphQLFirst(...args),
   fetchIssuesFromMaintainedRepos: (...args: unknown[]) =>
     mockFetchIssuesFromMaintainedRepos(...args),
+  getGraphQLSearchQueryCount: () => mockGraphqlSearchQueryCount,
+  resetGraphQLSearchQueryCount: () => {
+    mockGraphqlSearchQueryCount = 0;
+  },
 }));
 
 import { IssueDiscovery } from "./issue-discovery.js";
@@ -272,7 +279,7 @@ describe("IssueDiscovery", () => {
       allVetFailed: false,
       rateLimitHit: false,
     });
-    mockCachedSearchIssues.mockResolvedValue({
+    mockSearchIssuesGraphQLFirst.mockResolvedValue({
       total_count: 0,
       items: [],
     });
@@ -609,7 +616,7 @@ describe("IssueDiscovery", () => {
       // REST returns empty
       mockFetchIssuesFromMaintainedRepos.mockResolvedValue([]);
 
-      mockCachedSearchIssues.mockResolvedValue({
+      mockSearchIssuesGraphQLFirst.mockResolvedValue({
         total_count: 5,
         items: [
           {
@@ -639,7 +646,7 @@ describe("IssueDiscovery", () => {
       await discovery.searchIssues({ maxResults: 5 });
 
       // Should fall back to Search API
-      expect(mockCachedSearchIssues).toHaveBeenCalled();
+      expect(mockSearchIssuesGraphQLFirst).toHaveBeenCalled();
     });
 
     it("Phase 3: propagates 401 from Search API fallback instead of swallowing", async () => {
@@ -648,7 +655,7 @@ describe("IssueDiscovery", () => {
 
       // The Search API call rejects with 401.
       const authErr = Object.assign(new Error("Unauthorized"), { status: 401 });
-      mockCachedSearchIssues.mockRejectedValue(authErr);
+      mockSearchIssuesGraphQLFirst.mockRejectedValue(authErr);
 
       // Phase 2 returns empty so we get to Phase 3.
       mockFilterVetAndScore.mockResolvedValue({
@@ -667,7 +674,7 @@ describe("IssueDiscovery", () => {
     });
 
     it("Phase 3: falls back to Search API when no starred repos available", async () => {
-      mockCachedSearchIssues.mockResolvedValue({
+      mockSearchIssuesGraphQLFirst.mockResolvedValue({
         total_count: 5,
         items: [
           {
@@ -696,7 +703,7 @@ describe("IssueDiscovery", () => {
 
       // No starred repos, so REST is skipped, falls back to Search API
       expect(mockFetchIssuesFromMaintainedRepos).not.toHaveBeenCalled();
-      expect(mockCachedSearchIssues).toHaveBeenCalled();
+      expect(mockSearchIssuesGraphQLFirst).toHaveBeenCalled();
     });
   });
 
@@ -750,7 +757,9 @@ describe("IssueDiscovery", () => {
   });
 
   describe("searchIssues — budget management", () => {
-    it("only runs Phase 0 when budget is critical (<10)", async () => {
+    it("skips only the starred phase when REST budget is critical (<10)", async () => {
+      // Critical REST budget gates the starred phase (still REST-based) but not
+      // broad/maintained, which now run on the GraphQL points bucket.
       vi.mocked(checkRateLimit).mockResolvedValue({
         remaining: 5,
         limit: 30,
@@ -771,19 +780,31 @@ describe("IssueDiscovery", () => {
 
       const { strategiesUsed } = await discovery.searchIssues({
         maxResults: 10,
+        interPhaseDelayMs: 0,
+        broadPhaseDelayMs: 0,
       });
 
       expect(strategiesUsed).toContain("merged");
       expect(strategiesUsed).not.toContain("starred");
-      expect(strategiesUsed).not.toContain("broad");
-      expect(strategiesUsed).not.toContain("maintained");
+      expect(strategiesUsed).toContain("broad");
+      expect(strategiesUsed).toContain("maintained");
     });
 
-    it("skips Phases 2 and 3 when budget is low (<20)", async () => {
+    it("still runs Phases 2 and 3 when REST budget is low (<20) since they use GraphQL", async () => {
+      // Broad/maintained now bill the GraphQL points bucket, not the REST
+      // Search bucket, so a low REST budget must NOT gate them off anymore.
       vi.mocked(checkRateLimit).mockResolvedValue({
         remaining: 15,
         limit: 30,
         resetAt: new Date(Date.now() + 60000).toISOString(),
+      });
+
+      // A merged-PR candidate keeps allCandidates > 0 (so the run doesn't throw)
+      // while staying in the affinity set, so it doesn't trip the broad-skip gate.
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [makeCandidate("org/merged", "merged_pr")],
+        allReposFailed: false,
+        rateLimitHit: false,
       });
 
       const discovery = makeDiscovery({
@@ -793,10 +814,12 @@ describe("IssueDiscovery", () => {
 
       const { strategiesUsed } = await discovery.searchIssues({
         maxResults: 10,
+        interPhaseDelayMs: 0,
+        broadPhaseDelayMs: 0,
       });
 
-      expect(strategiesUsed).not.toContain("broad");
-      expect(strategiesUsed).not.toContain("maintained");
+      expect(strategiesUsed).toContain("broad");
+      expect(strategiesUsed).toContain("maintained");
     });
   });
 

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -65,7 +65,10 @@ vi.mock("./category-mapping.js", () => ({
 vi.mock("./errors.js", () => ({
   ValidationError: class ValidationError extends Error {
     code = "VALIDATION_ERROR";
-    constructor(message: string) {
+    constructor(
+      message: string,
+      public readonly strategiesUsed?: string[],
+    ) {
       super(message);
       this.name = "ValidationError";
     }
@@ -1022,6 +1025,19 @@ describe("IssueDiscovery", () => {
       await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(
         "No issue candidates found",
       );
+    });
+
+    it("attaches strategiesUsed to the zero-candidate ValidationError", async () => {
+      // scout.search() reads strategiesUsed off the error to advance the
+      // language-rotation cursor even when the search found nothing — a broad
+      // phase that ran and came up empty must still rotate (#249 follow-up).
+      const discovery = makeDiscovery();
+      await expect(
+        discovery.searchIssues({ maxResults: 5 }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        strategiesUsed: expect.any(Array),
+      });
     });
 
     it("returns empty with warning when rate limited", async () => {

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -229,6 +229,7 @@ async function runPhase2(
   existingCandidates: IssueCandidate[],
   filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
   tracker: SearchBudgetTracker,
+  languageRotationOffset = 0,
 ): Promise<PhaseResult> {
   info(MODULE, "Phase 2: General issue search...");
   const seenRepos = new Set(existingCandidates.map((c) => c.issue.repo));
@@ -271,6 +272,7 @@ async function runPhase2(
           `is:issue is:open ${langQ} no:assignee`.replace(/  +/g, " ").trim(),
         budgetPerTier * 3,
         tracker,
+        languageRotationOffset,
       );
 
       info(MODULE, `Phase 2 [${tier}]: processing ${allItems.length} items...`);
@@ -565,6 +567,13 @@ export class IssueDiscovery {
       diversityRatio?: number;
       interPhaseDelayMs?: number;
       broadPhaseDelayMs?: number;
+      /**
+       * Rotation cursor (#249 follow-up) for Phase 2's language-variant
+       * fan-out. Rotates which language leads the broad search each run
+       * instead of always starting at languages[0]. Modulo'd against the
+       * variant count at use site, so any value is safe to pass.
+       */
+      languageRotationOffset?: number;
     } = {},
   ): Promise<{
     candidates: IssueCandidate[];
@@ -852,6 +861,7 @@ export class IssueDiscovery {
           allCandidates,
           filterIssues,
           tracker,
+          options.languageRotationOffset ?? 0,
         );
         recordPhaseResult("2", result);
         // Recorded only when the phase actually queried, not when the

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -48,11 +48,13 @@ import { getTopicsForCategories } from "./category-mapping.js";
 import {
   buildEffectiveLabels,
   interleaveArrays,
-  cachedSearchIssues,
+  searchIssuesGraphQLFirst,
   fetchIssuesFromMaintainedRepos,
   filterVetAndScore,
   fetchIssuesFromKnownRepos,
   searchAcrossLanguagesAndLabels,
+  getGraphQLSearchQueryCount,
+  resetGraphQLSearchQueryCount,
 } from "./search-phases.js";
 import {
   annotateBoost,
@@ -415,7 +417,7 @@ async function runPhase3(
       .trim();
 
   try {
-    const data = await cachedSearchIssues(
+    const data = await searchIssuesGraphQLFirst(
       octokit,
       {
         q: phase3Query,
@@ -623,6 +625,9 @@ export class IssueDiscovery {
 
     // Pre-flight rate limit check
     this.rateLimitWarning = null;
+    // Fresh GraphQL broad-search counter for this run so the summary reports
+    // only this search's GraphQL query spend.
+    resetGraphQLSearchQueryCount();
     const tracker = this.budgetTracker;
     let searchBudget = LOW_BUDGET_THRESHOLD - 1;
     try {
@@ -640,12 +645,12 @@ export class IssueDiscovery {
       if (searchBudget < CRITICAL_BUDGET_THRESHOLD) {
         info(
           MODULE,
-          `Search budget critical (${searchBudget} remaining) — running only Phase 0`,
+          `Search budget critical (${searchBudget} remaining) — skipping the starred phase; broad/maintained still run on GraphQL (points bucket)`,
         );
       } else if (searchBudget < LOW_BUDGET_THRESHOLD) {
         info(
           MODULE,
-          `Search budget low (${searchBudget} remaining) — skipping heavy phases (2, 3)`,
+          `Search budget low (${searchBudget} remaining) — broad/maintained run on GraphQL (points bucket), unaffected by REST search quota`,
         );
       }
     } catch (error) {
@@ -797,11 +802,7 @@ export class IssueDiscovery {
         ? Math.min(configuredSkipThreshold, maxResults - 1)
         : 0;
 
-    if (
-      allCandidates.length < maxResults &&
-      searchBudget >= LOW_BUDGET_THRESHOLD &&
-      enabledStrategies.has("broad")
-    ) {
+    if (allCandidates.length < maxResults && enabledStrategies.has("broad")) {
       // Skip broad search only if we already have enough candidates from NEW
       // repos. Phases 0/1 only ever search the user's affinity + starred repos,
       // so counting their candidates here would gate off the broad phase — the
@@ -862,7 +863,6 @@ export class IssueDiscovery {
     // Phase 3: Actively maintained repos
     if (
       allCandidates.length < maxResults &&
-      searchBudget >= LOW_BUDGET_THRESHOLD &&
       enabledStrategies.has("maintained")
     ) {
       await applyInterPhaseDelay();
@@ -885,14 +885,14 @@ export class IssueDiscovery {
       strategiesUsed.push("maintained");
     }
 
-    // Build result / error summary
-    const phasesSkippedForBudget = searchBudget < LOW_BUDGET_THRESHOLD;
-    let budgetNote = "";
-    if (searchBudget < CRITICAL_BUDGET_THRESHOLD) {
-      budgetNote = ` Most search phases were skipped due to critically low API quota (${searchBudget} remaining).`;
-    } else if (phasesSkippedForBudget) {
-      budgetNote = ` Some search phases were skipped due to low API quota (${searchBudget} remaining).`;
-    }
+    // Build result / error summary. With broad/maintained now on GraphQL (which
+    // does not draw from the REST Search bucket), only the starred phase is
+    // still REST-budget-gated (CRITICAL). So "phases skipped for budget" now
+    // means the starred phase was dropped, not the heavy broad/maintained ones.
+    const phasesSkippedForBudget = searchBudget < CRITICAL_BUDGET_THRESHOLD;
+    const budgetNote = phasesSkippedForBudget
+      ? ` The starred-repo phase was skipped due to critically low API quota (${searchBudget} remaining); broad and maintained phases still ran on GraphQL.`
+      : "";
 
     if (allCandidates.length === 0) {
       const errorDetails = [
@@ -984,7 +984,7 @@ export class IssueDiscovery {
 
     info(
       MODULE,
-      `Search complete: ${tracker.getTotalCalls()} Search API calls used, ${finalPicks.length} candidates returned`,
+      `Search complete: ${tracker.getTotalCalls()} REST Search API call(s) + ${getGraphQLSearchQueryCount()} GraphQL broad-search query/queries used, ${finalPicks.length} candidates returned`,
     );
     return { candidates: finalPicks, strategiesUsed };
   }

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -930,6 +930,7 @@ export class IssueDiscovery {
       throw new ValidationError(
         `No issue candidates found across all search phases.${details} ` +
           "Try adjusting your search criteria (languages, labels) or check your network connection.",
+        strategiesUsed,
       );
     }
 

--- a/packages/core/src/core/issue-graphql.test.ts
+++ b/packages/core/src/core/issue-graphql.test.ts
@@ -178,7 +178,9 @@ describe("graphqlSearchIssues", () => {
       url: "https://github.com/owner/repo/issues/7",
       title: "Add dark mode",
       updatedAt: "2026-03-01T00:00:00Z",
-      labels: { nodes: [{ name: "good first issue" }, { name: "enhancement" }] },
+      labels: {
+        nodes: [{ name: "good first issue" }, { name: "enhancement" }],
+      },
       repository: { nameWithOwner: "owner/repo" },
       ...over,
     };

--- a/packages/core/src/core/issue-graphql.test.ts
+++ b/packages/core/src/core/issue-graphql.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { Octokit } from "@octokit/rest";
 import {
   prefetchIssueCores,
+  graphqlSearchIssues,
   issueCoreKey,
   type IssueRef,
 } from "./issue-graphql.js";
@@ -167,6 +168,165 @@ describe("prefetchIssueCores", () => {
     const graphql = vi.fn().mockRejectedValue(err);
     await expect(
       prefetchIssueCores(makeOctokit(graphql), ISSUES),
+    ).rejects.toThrow("rate limit");
+  });
+});
+
+describe("graphqlSearchIssues", () => {
+  function searchNode(over: Partial<Record<string, unknown>> = {}) {
+    return {
+      url: "https://github.com/owner/repo/issues/7",
+      title: "Add dark mode",
+      updatedAt: "2026-03-01T00:00:00Z",
+      labels: { nodes: [{ name: "good first issue" }, { name: "enhancement" }] },
+      repository: { nameWithOwner: "owner/repo" },
+      ...over,
+    };
+  }
+
+  it("maps GraphQL nodes into GitHubSearchItem shape incl. total_count", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      search: { issueCount: 42, nodes: [searchNode()] },
+    });
+    const result = await graphqlSearchIssues(
+      makeOctokit(graphql),
+      "is:issue is:open",
+      10,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.total_count).toBe(42);
+    expect(result!.items).toEqual([
+      {
+        html_url: "https://github.com/owner/repo/issues/7",
+        repository_url: "https://api.github.com/repos/owner/repo",
+        updated_at: "2026-03-01T00:00:00Z",
+        title: "Add dark mode",
+        labels: [{ name: "good first issue" }, { name: "enhancement" }],
+      },
+    ]);
+  });
+
+  it("filters out empty / non-Issue nodes (no url) and repository-less nodes", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      search: {
+        issueCount: 3,
+        nodes: [
+          searchNode({ url: "https://github.com/a/b/issues/1" }),
+          {}, // non-Issue node the fragment skipped → no url
+          null, // partial-error null
+          searchNode({ repository: null }), // has url but no repo
+        ],
+      },
+    });
+    const result = await graphqlSearchIssues(
+      makeOctokit(graphql),
+      "is:issue",
+      10,
+    );
+
+    expect(result!.items).toHaveLength(1);
+    expect(result!.items[0].html_url).toBe("https://github.com/a/b/issues/1");
+  });
+
+  it("defaults missing labels/updatedAt without throwing", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      search: {
+        issueCount: 1,
+        nodes: [
+          {
+            url: "https://github.com/a/b/issues/1",
+            title: "No labels",
+            repository: { nameWithOwner: "a/b" },
+          },
+        ],
+      },
+    });
+    const result = await graphqlSearchIssues(
+      makeOctokit(graphql),
+      "is:issue",
+      10,
+    );
+    expect(result!.items[0].labels).toEqual([]);
+    expect(result!.items[0].updated_at).toBe("");
+  });
+
+  it("clamps first into GitHub's [1, 100] range", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      search: { issueCount: 0, nodes: [] },
+    });
+
+    await graphqlSearchIssues(makeOctokit(graphql), "q", 250);
+    expect(graphql.mock.calls[0][1]).toMatchObject({ first: 100 });
+
+    graphql.mockClear();
+    await graphqlSearchIssues(makeOctokit(graphql), "q", 0);
+    expect(graphql.mock.calls[0][1]).toMatchObject({ first: 1 });
+  });
+
+  it("passes the query through as a variable (sort qualifier included)", async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      search: { issueCount: 0, nodes: [] },
+    });
+    await graphqlSearchIssues(
+      makeOctokit(graphql),
+      "is:issue is:open sort:created-desc",
+      30,
+    );
+
+    const [document, variables] = graphql.mock.calls[0];
+    // Query text is a variable, never interpolated into the document.
+    expect(document).toContain("search(query: $q, type: ISSUE, first: $first)");
+    expect(variables).toMatchObject({
+      q: "is:issue is:open sort:created-desc",
+      first: 30,
+    });
+  });
+
+  it("keeps partial data attached to a GraphQL error", async () => {
+    const err = Object.assign(new Error("Something failed on one node"), {
+      data: {
+        search: {
+          issueCount: 5,
+          nodes: [searchNode({ url: "https://github.com/a/b/issues/1" }), null],
+        },
+      },
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    const result = await graphqlSearchIssues(makeOctokit(graphql), "q", 10);
+
+    expect(result!.total_count).toBe(5);
+    expect(result!.items).toHaveLength(1);
+    expect(result!.items[0].html_url).toBe("https://github.com/a/b/issues/1");
+  });
+
+  it("returns null on a non-fatal error with no partial data", async () => {
+    const graphql = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    const result = await graphqlSearchIssues(makeOctokit(graphql), "q", 10);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the response has no search connection", async () => {
+    const graphql = vi.fn().mockResolvedValue({});
+    const result = await graphqlSearchIssues(makeOctokit(graphql), "q", 10);
+    expect(result).toBeNull();
+  });
+
+  it("propagates a 401 auth error (rethrowIfFatal)", async () => {
+    const err = Object.assign(new Error("Bad credentials"), { status: 401 });
+    const graphql = vi.fn().mockRejectedValue(err);
+    await expect(
+      graphqlSearchIssues(makeOctokit(graphql), "q", 10),
+    ).rejects.toThrow("Bad credentials");
+  });
+
+  it("propagates a rate-limit error (rethrowIfFatal)", async () => {
+    const err = Object.assign(new Error("API rate limit exceeded"), {
+      status: 429,
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    await expect(
+      graphqlSearchIssues(makeOctokit(graphql), "q", 10),
     ).rejects.toThrow("rate limit");
   });
 });

--- a/packages/core/src/core/issue-graphql.ts
+++ b/packages/core/src/core/issue-graphql.ts
@@ -22,6 +22,7 @@ import { rethrowIfFatal, errorMessage } from "./errors.js";
 import { warn } from "./logger.js";
 import { getHttpCache } from "./http-cache.js";
 import { mergedPRsCacheKey } from "./issue-eligibility.js";
+import type { GitHubSearchItem } from "./issue-filtering.js";
 
 const MODULE = "issue-graphql";
 
@@ -358,4 +359,111 @@ async function fetchMergedPRBatch(
     if (typeof count !== "number") return;
     cache.set(mergedPRsCacheKey(r.owner, r.repo), "", count);
   });
+}
+
+// ---------------------------------------------------------------------------
+// Broad issue search via GraphQL (Phase 2 / Phase 3 fallback)
+// ---------------------------------------------------------------------------
+
+/** A single node from a GraphQL `search(type: ISSUE)` connection. */
+interface GraphQLSearchIssueNode {
+  url?: string;
+  title?: string;
+  updatedAt?: string;
+  labels?: { nodes: { name: string }[] } | null;
+  repository?: { nameWithOwner: string } | null;
+}
+
+/** Shape of the `search` connection response. */
+interface GraphQLSearchResponse {
+  search?: {
+    issueCount: number;
+    nodes: (GraphQLSearchIssueNode | null)[];
+  };
+}
+
+/**
+ * Broad issue search via GraphQL `search(type: ISSUE)`.
+ *
+ * This is the GraphQL-first replacement for the REST `search/issues` broad
+ * queries (Phase 2 chunked-label search and Phase 3's Search-API fallback).
+ * A GraphQL `search` connection bills the GraphQL points bucket (5000/hr)
+ * rather than the scarce REST Search bucket (30/min), so it is NOT recorded
+ * against the SearchBudgetTracker — the caller reserves that accounting for
+ * the REST fallback.
+ *
+ * The query text is passed as a GraphQL *variable* (`$q`), never interpolated
+ * into the query document. GitHub's `search` has no `sort` argument, so the
+ * caller folds any ordering into the query string (e.g. `sort:created-desc`).
+ *
+ * Returns `null` on a non-fatal error (so the caller can degrade to REST);
+ * fatal errors (401 / rate limit) propagate via {@link rethrowIfFatal}. A
+ * partial-data GraphQL error keeps whatever nodes resolved.
+ *
+ * @param first Requested result count; clamped to GitHub's [1, 100] range.
+ */
+export async function graphqlSearchIssues(
+  octokit: Octokit,
+  query: string,
+  first: number,
+): Promise<{ total_count: number; items: GitHubSearchItem[] } | null> {
+  const clampedFirst = Math.min(Math.max(Math.trunc(first) || 1, 1), 100);
+
+  const document = `query searchIssuesBroad($q: String!, $first: Int!) {
+    search(query: $q, type: ISSUE, first: $first) {
+      issueCount
+      nodes {
+        ... on Issue {
+          url
+          title
+          updatedAt
+          labels(first: 20) { nodes { name } }
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }`;
+
+  let data: GraphQLSearchResponse | undefined;
+  try {
+    data = await octokit.graphql<GraphQLSearchResponse>(document, {
+      q: query,
+      first: clampedFirst,
+    });
+  } catch (err) {
+    rethrowIfFatal(err);
+    // octokit attaches resolved data to `.data` when only some nodes errored.
+    const partial = (err as { data?: GraphQLSearchResponse }).data;
+    if (partial) {
+      data = partial;
+    } else {
+      warn(
+        MODULE,
+        `GraphQL broad search failed, falling back to REST: ${errorMessage(err)}`,
+      );
+      return null;
+    }
+  }
+
+  const search = data?.search;
+  if (!search) return null;
+
+  const items: GitHubSearchItem[] = [];
+  for (const node of search.nodes ?? []) {
+    // Empty objects (non-Issue nodes the `... on Issue` fragment skipped) and
+    // partial-error nulls have no `url` — drop them so only real issues remain.
+    if (!node?.url) continue;
+    const nameWithOwner = node.repository?.nameWithOwner;
+    if (!nameWithOwner) continue;
+    items.push({
+      html_url: node.url,
+      // Same construction as the REST search adapter (search-phases.ts).
+      repository_url: `https://api.github.com/repos/${nameWithOwner}`,
+      updated_at: node.updatedAt ?? "",
+      title: node.title,
+      labels: node.labels?.nodes ?? [],
+    });
+  }
+
+  return { total_count: search.issueCount ?? 0, items };
 }

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -407,8 +407,8 @@ describe("searchRotation", () => {
       version: 1,
       searchRotation: { languageOffset: 1, futureField: "kept" },
     });
-    expect(
-      (parsed.searchRotation as Record<string, unknown>).futureField,
-    ).toBe("kept");
+    expect((parsed.searchRotation as Record<string, unknown>).futureField).toBe(
+      "kept",
+    );
   });
 });

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -152,9 +152,9 @@ describe("ScoutPreferencesSchema", () => {
     ).toThrow();
   });
 
-  it("applies broadPhaseDelayMs default of 90000", () => {
+  it("applies broadPhaseDelayMs default of 0 (broad phase now runs on GraphQL)", () => {
     const prefs = ScoutPreferencesSchema.parse({});
-    expect(prefs.broadPhaseDelayMs).toBe(90000);
+    expect(prefs.broadPhaseDelayMs).toBe(0);
   });
 
   it("applies skipBroadWhenSufficientResults default of 8 (below default maxResults)", () => {

--- a/packages/core/src/core/schemas.test.ts
+++ b/packages/core/src/core/schemas.test.ts
@@ -373,3 +373,42 @@ describe("parseScoutState", () => {
     expect(() => parseScoutState({ version: 2 })).toThrow();
   });
 });
+
+// ── searchRotation (#249 follow-up) ──────────────────────────────────
+
+describe("searchRotation", () => {
+  it("defaults on legacy state with no searchRotation key", () => {
+    const state = parseScoutState({ version: 1 });
+    expect(state.searchRotation).toEqual({ languageOffset: 0 });
+  });
+
+  it("defaults languageOffset when searchRotation is present but empty", () => {
+    const state = parseScoutState({ version: 1, searchRotation: {} });
+    expect(state.searchRotation.languageOffset).toBe(0);
+    expect(state.searchRotation.lastRotatedAt).toBeUndefined();
+  });
+
+  it("round-trips a persisted offset and timestamp", () => {
+    const state = parseScoutState({
+      version: 1,
+      searchRotation: {
+        languageOffset: 3,
+        lastRotatedAt: "2026-07-01T00:00:00Z",
+      },
+    });
+    expect(state.searchRotation).toEqual({
+      languageOffset: 3,
+      lastRotatedAt: "2026-07-01T00:00:00Z",
+    });
+  });
+
+  it("round-trips unknown keys on searchRotation (loose object)", () => {
+    const parsed = parseScoutState({
+      version: 1,
+      searchRotation: { languageOffset: 1, futureField: "kept" },
+    });
+    expect(
+      (parsed.searchRotation as Record<string, unknown>).futureField,
+    ).toBe("kept");
+  });
+});

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -224,7 +224,11 @@ export const ScoutPreferencesSchema = z.looseObject({
   // Soft boost for candidates whose issue labels match one of these types,
   // case-insensitive (e.g. "bug", "good first issue") (#168).
   boostIssueTypes: z.array(z.string()).default([]),
-  broadPhaseDelayMs: z.number().min(0).max(300000).default(90000),
+  // Broad-phase cooldown. Now that the broad phase runs on GraphQL (points
+  // bucket, 5000/hr) rather than the REST Search bucket (30/min), the long
+  // secondary-rate-limit cooldown is no longer needed; defaults to 0 (no extra
+  // pause). Retained as a knob for hosts that still want to throttle the phase.
+  broadPhaseDelayMs: z.number().min(0).max(300000).default(0),
   /**
    * Skip the expensive broad phase once this many candidates were found by
    * the cheaper phases. Clamped at runtime to maxResults - 1 so it stays

--- a/packages/core/src/core/schemas.ts
+++ b/packages/core/src/core/schemas.ts
@@ -313,6 +313,22 @@ export const ScoutStateSchema = z.looseObject({
   lastRunAt: z.string().default(() => new Date().toISOString()),
 
   gistId: z.string().optional(),
+
+  /**
+   * Diversity cursor for Phase 2's broad search (#249 follow-up). Without
+   * this, every run started the language-variant fan-out at index 0, so the
+   * broad phase only ever queried the first configured language before
+   * moving on. Not a rate-limit mechanism — purely rotates which language
+   * variant leads each run. `languageOffset` advances (no modulo; the
+   * consumer wraps at use time so a shrinking language list never needs
+   * clamping here).
+   */
+  searchRotation: z
+    .looseObject({
+      languageOffset: z.number().int().min(0).default(0),
+      lastRotatedAt: z.string().optional(),
+    })
+    .default(() => ({ languageOffset: 0 })),
 });
 
 /**
@@ -347,3 +363,4 @@ export type Horizon = z.infer<typeof HorizonSchema>;
 export type SavedCandidate = z.infer<typeof SavedCandidateSchema>;
 export type SkippedIssue = z.infer<typeof SkippedIssueSchema>;
 export type ScoutState = z.infer<typeof ScoutStateSchema>;
+export type SearchRotation = ScoutState["searchRotation"];

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -71,10 +71,18 @@ vi.mock("./issue-vetting.js", () => ({
   IssueVetter: vi.fn(),
 }));
 
+const mockGraphqlSearchIssues = vi.fn();
+vi.mock("./issue-graphql.js", () => ({
+  graphqlSearchIssues: (...args: unknown[]) => mockGraphqlSearchIssues(...args),
+}));
+
 import {
   buildEffectiveLabels,
   interleaveArrays,
   cachedSearchIssues,
+  searchIssuesGraphQLFirst,
+  getGraphQLSearchQueryCount,
+  resetGraphQLSearchQueryCount,
   fetchIssuesFromMaintainedRepos,
   searchWithChunkedLabels,
   searchAcrossLanguagesAndLabels,
@@ -315,6 +323,119 @@ describe("cachedSearchIssues", () => {
 
     // Different queries produce different cache keys, so API is called both times
     expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("searchIssuesGraphQLFirst", () => {
+  const params = {
+    q: "is:issue is:open",
+    sort: "created" as const,
+    order: "desc" as const,
+    per_page: 10,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCache.getIfFresh.mockReturnValue(null);
+    resetGraphQLSearchQueryCount();
+  });
+
+  it("returns GraphQL results without a REST search call or budget accounting", async () => {
+    const gqlResult = {
+      total_count: 3,
+      items: [makeItem("https://github.com/a/b/issues/1", "a/b")],
+    };
+    mockGraphqlSearchIssues.mockResolvedValue(gqlResult);
+    const octokit = makeMockOctokit([]);
+    const tracker = {
+      waitForBudget: vi.fn().mockResolvedValue(undefined),
+      recordCall: vi.fn(),
+    } as unknown as import("./search-budget.js").SearchBudgetTracker;
+
+    const result = await searchIssuesGraphQLFirst(octokit, params, tracker);
+
+    expect(result).toEqual(gqlResult);
+    expect(octokit.search.issuesAndPullRequests).not.toHaveBeenCalled();
+    expect(tracker.recordCall).not.toHaveBeenCalled();
+    expect(getGraphQLSearchQueryCount()).toBe(1);
+  });
+
+  it("folds sort/order into the query string passed to GraphQL", async () => {
+    mockGraphqlSearchIssues.mockResolvedValue({ total_count: 0, items: [] });
+    await searchIssuesGraphQLFirst(makeMockOctokit([]), {
+      ...params,
+      sort: "updated",
+      order: "desc",
+    });
+    expect(mockGraphqlSearchIssues).toHaveBeenCalledWith(
+      expect.anything(),
+      "is:issue is:open sort:updated-desc",
+      10,
+    );
+  });
+
+  it("clamps per_page to 100 when passing first to GraphQL", async () => {
+    mockGraphqlSearchIssues.mockResolvedValue({ total_count: 0, items: [] });
+    await searchIssuesGraphQLFirst(makeMockOctokit([]), {
+      ...params,
+      per_page: 300,
+    });
+    expect(mockGraphqlSearchIssues).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      100,
+    );
+  });
+
+  it("falls back to REST search with budget accounting on GraphQL null", async () => {
+    mockGraphqlSearchIssues.mockResolvedValue(null);
+    const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+    const octokit = makeMockOctokit(items);
+    const tracker = {
+      waitForBudget: vi.fn().mockResolvedValue(undefined),
+      recordCall: vi.fn(),
+    } as unknown as import("./search-budget.js").SearchBudgetTracker;
+
+    const result = await searchIssuesGraphQLFirst(octokit, params, tracker);
+
+    expect(result.items).toHaveLength(1);
+    expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
+    // REST fallback pays the budget tracker.
+    expect(tracker.recordCall).toHaveBeenCalledTimes(1);
+    // GraphQL query count only counts successful GraphQL calls.
+    expect(getGraphQLSearchQueryCount()).toBe(0);
+  });
+
+  it("caches a non-empty GraphQL result under the gqlsearch: key", async () => {
+    mockGraphqlSearchIssues.mockResolvedValue({
+      total_count: 1,
+      items: [makeItem("https://github.com/a/b/issues/1", "a/b")],
+    });
+    await searchIssuesGraphQLFirst(makeMockOctokit([]), params);
+
+    expect(mockCache.set).toHaveBeenCalledTimes(1);
+    expect(mockCache.set.mock.calls[0][0]).toContain("gqlsearch:");
+  });
+
+  it("does not cache an empty GraphQL result", async () => {
+    mockGraphqlSearchIssues.mockResolvedValue({ total_count: 0, items: [] });
+    await searchIssuesGraphQLFirst(makeMockOctokit([]), params);
+    expect(mockCache.set).not.toHaveBeenCalled();
+  });
+
+  it("returns a gqlsearch cache hit without calling GraphQL", async () => {
+    const cached = {
+      total_count: 1,
+      items: [makeItem("https://github.com/a/b/issues/1", "a/b")],
+    };
+    mockCache.getIfFresh.mockReturnValue(cached);
+    const octokit = makeMockOctokit([]);
+
+    const result = await searchIssuesGraphQLFirst(octokit, params);
+
+    expect(result).toEqual(cached);
+    expect(mockGraphqlSearchIssues).not.toHaveBeenCalled();
+    expect(octokit.search.issuesAndPullRequests).not.toHaveBeenCalled();
   });
 });
 
@@ -809,6 +930,30 @@ describe("searchWithChunkedLabels", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCache.getIfFresh.mockReturnValue(null);
+    // Default: GraphQL unavailable so these tests exercise the REST fallback
+    // and keep asserting on octokit.search.issuesAndPullRequests unchanged.
+    mockGraphqlSearchIssues.mockResolvedValue(null);
+  });
+
+  it("uses GraphQL (no REST search) when GraphQL succeeds", async () => {
+    mockGraphqlSearchIssues.mockResolvedValue({
+      total_count: 1,
+      items: [makeItem("https://github.com/a/b/issues/1", "a/b")],
+    });
+    const octokit = makeMockOctokit([]);
+
+    const result = await searchWithChunkedLabels(
+      octokit,
+      ["good first issue"],
+      0,
+      (labelQ) => `is:issue is:open ${labelQ}`,
+      10,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(mockGraphqlSearchIssues).toHaveBeenCalledTimes(1);
+    // GraphQL answered → the REST Search API is never touched.
+    expect(octokit.search.issuesAndPullRequests).not.toHaveBeenCalled();
   });
 
   it("issues a single query when labels fit within operator limit", async () => {
@@ -915,6 +1060,9 @@ describe("searchAcrossLanguagesAndLabels", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCache.getIfFresh.mockReturnValue(null);
+    // Exercise the REST fallback so these tests keep asserting on the REST
+    // Search mock (GraphQL is covered directly elsewhere).
+    mockGraphqlSearchIssues.mockResolvedValue(null);
   });
 
   it("issues one search call when only one language is configured", async () => {

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -1186,6 +1186,79 @@ describe("searchAcrossLanguagesAndLabels", () => {
     ).mock.calls[0][0];
     expect(call.q).not.toContain("language:");
   });
+
+  describe("startOffset rotation (#249 follow-up)", () => {
+    it("rotates the variant order so the offset-th language leads", async () => {
+      const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+      const octokit = makeMockOctokit(items);
+
+      await searchAcrossLanguagesAndLabels(
+        octokit,
+        ["typescript", "python", "rust"],
+        false,
+        ["good first issue", "help wanted"],
+        (langQ) => `is:issue is:open ${langQ} no:assignee`,
+        10,
+        undefined,
+        1,
+      );
+
+      const calls = (
+        octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      const queries = calls.map((c) => c[0].q);
+      // offset 1 → [python, rust, typescript]
+      expect(queries[0]).toContain("language:python");
+      expect(queries[1]).toContain("language:rust");
+      expect(queries[2]).toContain("language:typescript");
+    });
+
+    it("wraps via modulo when the offset is >= the variant count", async () => {
+      const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+      const octokit = makeMockOctokit(items);
+
+      await searchAcrossLanguagesAndLabels(
+        octokit,
+        ["typescript", "python", "rust"],
+        false,
+        ["good first issue", "help wanted"],
+        (langQ) => `is:issue is:open ${langQ} no:assignee`,
+        10,
+        undefined,
+        4, // 4 % 3 === 1, same rotation as offset 1
+      );
+
+      const calls = (
+        octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      const queries = calls.map((c) => c[0].q);
+      expect(queries[0]).toContain("language:python");
+      expect(queries[1]).toContain("language:rust");
+      expect(queries[2]).toContain("language:typescript");
+    });
+
+    it("is a no-op with a single variant regardless of offset", async () => {
+      const items = [makeItem("https://github.com/a/b/issues/1", "a/b")];
+      const octokit = makeMockOctokit(items);
+
+      await searchAcrossLanguagesAndLabels(
+        octokit,
+        ["typescript"],
+        false,
+        ["good first issue"],
+        (langQ) => `is:issue is:open ${langQ} no:assignee`,
+        10,
+        undefined,
+        5,
+      );
+
+      expect(octokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(1);
+      const call = (
+        octokit.search.issuesAndPullRequests as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0];
+      expect(call.q).toContain("language:typescript");
+    });
+  });
 });
 
 describe("fetchIssuesFromMaintainedRepos", () => {

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -25,6 +25,7 @@ import {
   getSearchBudgetTracker,
   type SearchBudgetTracker,
 } from "./search-budget.js";
+import { graphqlSearchIssues } from "./issue-graphql.js";
 
 const MODULE = "search-phases";
 
@@ -35,6 +36,33 @@ const GITHUB_MAX_BOOLEAN_OPS = 5;
  * Set to 2000ms as a safety floor (max 30/min at the limit). The SearchBudgetTracker
  * adds additional adaptive delays when needed. */
 const INTER_QUERY_DELAY_MS = 2000;
+
+/**
+ * Delay between broad GraphQL search queries (Phase 2 chunked-label and
+ * language fan-out loops). GraphQL `search` bills the points bucket (5000/hr)
+ * rather than the REST Search bucket (30/min), so it does not need the 2000ms
+ * secondary-rate-limit floor the REST paths use — a lighter 500ms pace keeps
+ * the loops civil without the old broad-phase stall.
+ */
+const GRAPHQL_INTER_QUERY_DELAY_MS = 500;
+
+/**
+ * Count of broad GraphQL `search` queries actually issued (cache misses that
+ * reached GraphQL) since the last reset. Threaded into the final search
+ * summary so the GraphQL points spend is observable alongside the REST Search
+ * call count. Module-level to keep the call sites simple; reset per search run.
+ */
+let graphqlSearchQueryCount = 0;
+
+/** Read the broad GraphQL search query count for the current run. */
+export function getGraphQLSearchQueryCount(): number {
+  return graphqlSearchQueryCount;
+}
+
+/** Reset the broad GraphQL search query counter at the start of a search run. */
+export function resetGraphQLSearchQueryCount(): void {
+  graphqlSearchQueryCount = 0;
+}
 
 /**
  * Chunk labels into groups that fit within the operator budget.
@@ -158,6 +186,69 @@ export async function cachedSearchIssues(
   }
 
   return data;
+}
+
+/**
+ * GraphQL-first broad issue search with a REST fallback.
+ *
+ * Same param shape as {@link cachedSearchIssues}. Tries GraphQL
+ * `search(type: ISSUE)` first (points bucket, 5000/hr — NOT charged to the
+ * SearchBudgetTracker), caching non-empty results under a dedicated
+ * `gqlsearch:` cache key so a GraphQL hit and a REST hit never collide. On a
+ * non-fatal GraphQL failure it warns and delegates to the existing
+ * budget-tracked `cachedSearchIssues` REST path unchanged. Fatal errors (401 /
+ * rate limit) propagate from either layer.
+ */
+export async function searchIssuesGraphQLFirst(
+  octokit: Octokit,
+  params: {
+    q: string;
+    sort: "created" | "updated" | "comments" | "reactions" | "interactions";
+    order: "asc" | "desc";
+    per_page: number;
+  },
+  tracker: SearchBudgetTracker = getSearchBudgetTracker(),
+): Promise<{ total_count: number; items: GitHubSearchItem[] }> {
+  const cacheKey = versionedCacheKey(
+    `gqlsearch:${params.q}:${params.sort}:${params.order}:${params.per_page}`,
+  );
+  const cache = getHttpCache();
+
+  const cached = cache.getIfFresh(cacheKey, SEARCH_CACHE_TTL_MS);
+  if (cached) {
+    debug(MODULE, `GraphQL search cache hit for query`);
+    return cached as { total_count: number; items: GitHubSearchItem[] };
+  }
+
+  // GraphQL `search` has no `sort` argument — fold ordering into the query.
+  const gqlQuery = `${params.q} sort:${params.sort}-${params.order}`;
+  const gql = await graphqlSearchIssues(
+    octokit,
+    gqlQuery,
+    Math.min(params.per_page, 100),
+  );
+
+  if (gql) {
+    graphqlSearchQueryCount++;
+    // Mirror cachedSearchIssues: only cache non-empty results so a transient
+    // empty response can't poison the cache for the TTL.
+    if (gql.items.length > 0) {
+      cache.set(cacheKey, "", gql);
+    } else {
+      debug(
+        MODULE,
+        `Skipping cache for empty GraphQL search result (possible transient artifact)`,
+      );
+    }
+    return gql;
+  }
+
+  // Non-fatal GraphQL failure: fall back to the REST Search path (budget-tracked).
+  warn(
+    MODULE,
+    `GraphQL broad search unavailable; falling back to REST search API`,
+  );
+  return cachedSearchIssues(octokit, params, tracker);
 }
 
 // ── REST-based search functions ──
@@ -388,10 +479,10 @@ export async function searchWithChunkedLabels(
   const allItems: GitHubSearchItem[] = [];
 
   for (let i = 0; i < labelChunks.length; i++) {
-    if (i > 0) await sleep(INTER_QUERY_DELAY_MS);
+    if (i > 0) await sleep(GRAPHQL_INTER_QUERY_DELAY_MS);
 
     const query = buildQuery(buildLabelQuery(labelChunks[i]));
-    const data = await cachedSearchIssues(
+    const data = await searchIssuesGraphQLFirst(
       octokit,
       {
         q: query,
@@ -464,7 +555,7 @@ export async function searchAcrossLanguagesAndLabels(
   const allItems: GitHubSearchItem[] = [];
 
   for (let i = 0; i < langVariants.length; i++) {
-    if (i > 0) await sleep(INTER_QUERY_DELAY_MS);
+    if (i > 0) await sleep(GRAPHQL_INTER_QUERY_DELAY_MS);
     const items = await searchWithChunkedLabels(
       octokit,
       labels,

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -536,6 +536,12 @@ export function buildLanguageVariants(
  * @param buildBaseQuery  Builds the query prefix from a language qualifier string;
  *                        e.g. `(langQ) => `is:issue is:open ${langQ} no:assignee`.trim()`
  * @param perPage         Results per API call
+ * @param startOffset     Rotation cursor (#249 follow-up): rotates the
+ *                        language-variant list so consecutive runs don't all
+ *                        start the fan-out at the same variant. Wrapped via
+ *                        modulo here, so a persisted offset that outgrew the
+ *                        current variant count (or a shrunk language list)
+ *                        never needs clamping by the caller.
  */
 export async function searchAcrossLanguagesAndLabels(
   octokit: Octokit,
@@ -545,12 +551,15 @@ export async function searchAcrossLanguagesAndLabels(
   buildBaseQuery: (langQuery: string) => string,
   perPage: number,
   tracker: SearchBudgetTracker = getSearchBudgetTracker(),
+  startOffset = 0,
 ): Promise<GitHubSearchItem[]> {
-  const langVariants = buildLanguageVariants(
+  const variants = buildLanguageVariants(
     languages,
     isAnyLanguage,
     labels.length > 0,
   );
+  const k = variants.length > 0 ? startOffset % variants.length : 0;
+  const langVariants = [...variants.slice(k), ...variants.slice(0, k)];
   const seenUrls = new Set<string>();
   const allItems: GitHubSearchItem[] = [];
 

--- a/packages/core/src/e2e/search-flow.test.ts
+++ b/packages/core/src/e2e/search-flow.test.ts
@@ -56,10 +56,70 @@ const { fakeOctokit } = vi.hoisted(() => {
         if (typeof q === "string" && q.includes("is:pr")) {
           return { data: { total_count: 0, items: [] } };
         }
-        // Issue discovery phases.
+        // Issue discovery broad phases now go through GraphQL (see `graphql`
+        // below), so a REST is:issue search here would be a regression.
         return { data: { total_count: 1, items: [issueItem] } };
       }),
     },
+    // GraphQL boundary. Routes by operation-name substring so all three
+    // GraphQL shapes the pipeline issues answer correctly:
+    //   - searchIssuesBroad   → broad issue search (Phase 2 / Phase 3 fallback)
+    //   - batchMergedPRCounts → merged-PR affinity prefetch
+    //   - batchIssueCores     → per-issue core prefetch used by the vetter
+    graphql: vi.fn(
+      async (query: string, variables: Record<string, unknown>) => {
+        if (typeof query === "string" && query.includes("searchIssuesBroad")) {
+          return {
+            search: {
+              issueCount: 1,
+              nodes: [
+                {
+                  url: issueItem.html_url,
+                  title: issueItem.title,
+                  updatedAt: issueItem.updated_at,
+                  labels: { nodes: issueItem.labels },
+                  repository: { nameWithOwner: "test-org/test-repo" },
+                },
+              ],
+            },
+          };
+        }
+        if (
+          typeof query === "string" &&
+          query.includes("batchMergedPRCounts")
+        ) {
+          // Identity gate needs viewer.login === configured username ("tester").
+          const res: Record<string, unknown> = { viewer: { login: "tester" } };
+          for (const key of Object.keys(variables ?? {})) {
+            const m = key.match(/^q(\d+)$/);
+            if (m) res[`r${m[1]}`] = { issueCount: 0 };
+          }
+          return res;
+        }
+        if (typeof query === "string" && query.includes("batchIssueCores")) {
+          const res: Record<string, unknown> = {};
+          for (const key of Object.keys(variables ?? {})) {
+            const m = key.match(/^num(\d+)$/);
+            if (m) {
+              res[`i${m[1]}`] = {
+                issue: {
+                  databaseId: 101,
+                  title: issueItem.title,
+                  body: issueItem.body,
+                  state: "OPEN",
+                  labels: { nodes: issueItem.labels },
+                  comments: { totalCount: 0 },
+                  createdAt: issueItem.created_at,
+                  updatedAt: issueItem.updated_at,
+                },
+              };
+            }
+          }
+          return res;
+        }
+        return {};
+      },
+    ),
     issues: {
       // vetIssue re-fetches the full issue by URL.
       get: vi.fn().mockResolvedValue({
@@ -198,8 +258,17 @@ describe("search pipeline e2e (#161)", () => {
     // The real project-health check consumed the repo + commits responses.
     expect(fakeOctokit.repos.get).toHaveBeenCalled();
 
-    // Real search-API calls were issued (not a mocked IssueDiscovery).
-    expect(fakeOctokit.search.issuesAndPullRequests).toHaveBeenCalled();
+    // The broad issue search now runs on GraphQL, so no REST is:issue search
+    // should ever be issued (is:pr affinity/vetting queries are unaffected).
+    const issueSearchCalls =
+      fakeOctokit.search.issuesAndPullRequests.mock.calls.filter(
+        ([arg]: [{ q?: string }]) =>
+          typeof arg?.q === "string" && arg.q.includes("is:issue"),
+      );
+    expect(issueSearchCalls).toHaveLength(0);
+
+    // The GraphQL boundary was exercised for the broad search.
+    expect(fakeOctokit.graphql).toHaveBeenCalled();
   });
 
   it("persists vetted results via saveResults (the command-layer bookkeeping)", async () => {

--- a/packages/core/src/e2e/search-flow.test.ts
+++ b/packages/core/src/e2e/search-flow.test.ts
@@ -288,4 +288,30 @@ describe("search pipeline e2e (#161)", () => {
       true,
     );
   });
+
+  it("advances the persisted language-rotation offset across consecutive runs (#249 follow-up)", async () => {
+    const scout = freshScout();
+    expect(scout.getState().searchRotation.languageOffset).toBe(0);
+
+    const first = await scout.search({
+      maxResults: 5,
+      interPhaseDelayMs: 0,
+      broadPhaseDelayMs: 0,
+    });
+    expect(first.strategiesUsed).toContain("broad");
+    expect(scout.getState().searchRotation.languageOffset).toBe(1);
+    const firstRotatedAt = scout.getState().searchRotation.lastRotatedAt;
+    expect(firstRotatedAt).toBeDefined();
+
+    // A second, consecutive run reads back the advanced cursor and moves it
+    // forward again, so the broad phase's language fan-out starts somewhere
+    // new each time instead of always at languages[0].
+    const second = await scout.search({
+      maxResults: 5,
+      interPhaseDelayMs: 0,
+      broadPhaseDelayMs: 0,
+    });
+    expect(second.strategiesUsed).toContain("broad");
+    expect(scout.getState().searchRotation.languageOffset).toBe(2);
+  });
 });

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -971,3 +971,76 @@ describe("OssScout.search recently-surfaced rotation (#249)", () => {
     expect(skipped!.has(RECENT_URL)).toBe(false);
   });
 });
+
+describe("OssScout.search language rotation cursor (#249 follow-up)", () => {
+  function makeRotationScout(searchRotation?: {
+    languageOffset: number;
+    lastRotatedAt?: string;
+  }) {
+    return new OssScout(
+      "test-token",
+      ScoutStateSchema.parse({
+        version: 1,
+        ...(searchRotation ? { searchRotation } : {}),
+      }),
+    );
+  }
+
+  function mockDiscoverySearch(strategiesUsed: string[]) {
+    let capturedOffset: number | undefined;
+    vi.spyOn(IssueDiscovery.prototype, "searchIssues").mockImplementation(
+      async (opts: { languageRotationOffset?: number }) => {
+        capturedOffset = opts.languageRotationOffset;
+        return {
+          candidates: [],
+          strategiesUsed: strategiesUsed as never[],
+        };
+      },
+    );
+    return () => capturedOffset;
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reads the persisted offset and passes it to searchIssues", async () => {
+    const scout = makeRotationScout({ languageOffset: 2 });
+    const getCapturedOffset = mockDiscoverySearch(["broad"]);
+
+    await scout.search();
+
+    expect(getCapturedOffset()).toBe(2);
+  });
+
+  it("advances the offset and stamps lastRotatedAt when the broad phase ran", async () => {
+    const scout = makeRotationScout({ languageOffset: 2 });
+    mockDiscoverySearch(["merged", "broad"]);
+
+    await scout.search();
+
+    const rotation = scout.getState().searchRotation;
+    expect(rotation.languageOffset).toBe(3);
+    expect(rotation.lastRotatedAt).toBeDefined();
+  });
+
+  it("does not advance the offset when the broad phase did not run", async () => {
+    const scout = makeRotationScout({ languageOffset: 2 });
+    mockDiscoverySearch(["merged", "starred"]);
+
+    await scout.search();
+
+    const rotation = scout.getState().searchRotation;
+    expect(rotation.languageOffset).toBe(2);
+  });
+
+  it("starts at offset 0 for a fresh state with no prior rotation", async () => {
+    const scout = makeRotationScout();
+    const getCapturedOffset = mockDiscoverySearch(["broad"]);
+
+    await scout.search();
+
+    expect(getCapturedOffset()).toBe(0);
+    expect(scout.getState().searchRotation.languageOffset).toBe(1);
+  });
+});

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -7,6 +7,7 @@ import type { ScoutState } from "./core/schemas.js";
 import type { IssueCandidate } from "./core/types.js";
 import type { Octokit } from "@octokit/rest";
 import { IssueDiscovery } from "./core/issue-discovery.js";
+import { ValidationError } from "./core/errors.js";
 
 vi.mock("./core/feature-discovery.js", async (importOriginal) => {
   const actual =
@@ -1042,5 +1043,45 @@ describe("OssScout.search language rotation cursor (#249 follow-up)", () => {
 
     expect(getCapturedOffset()).toBe(0);
     expect(scout.getState().searchRotation.languageOffset).toBe(1);
+  });
+
+  it("advances the offset when a zero-candidate search throws after the broad phase ran", async () => {
+    // A broad phase that ran and found nothing must still rotate — otherwise
+    // the same barren language slice leads every subsequent run (#249
+    // follow-up). searchIssues throws ValidationError with strategiesUsed
+    // attached; scout.search advances off the error, then rethrows.
+    const scout = makeRotationScout({ languageOffset: 2 });
+    vi.spyOn(IssueDiscovery.prototype, "searchIssues").mockRejectedValue(
+      new ValidationError("No issue candidates found", ["merged", "broad"]),
+    );
+
+    await expect(scout.search()).rejects.toThrow("No issue candidates found");
+
+    const rotation = scout.getState().searchRotation;
+    expect(rotation.languageOffset).toBe(3);
+    expect(rotation.lastRotatedAt).toBeDefined();
+    expect(scout.isDirty()).toBe(true);
+  });
+
+  it("does not advance the offset when the zero-candidate error's broad phase did not run", async () => {
+    const scout = makeRotationScout({ languageOffset: 2 });
+    vi.spyOn(IssueDiscovery.prototype, "searchIssues").mockRejectedValue(
+      new ValidationError("No issue candidates found", ["merged", "starred"]),
+    );
+
+    await expect(scout.search()).rejects.toThrow("No issue candidates found");
+
+    expect(scout.getState().searchRotation.languageOffset).toBe(2);
+  });
+
+  it("does not advance the offset on a non-ValidationError failure", async () => {
+    const scout = makeRotationScout({ languageOffset: 2 });
+    vi.spyOn(IssueDiscovery.prototype, "searchIssues").mockRejectedValue(
+      new Error("network exploded"),
+    );
+
+    await expect(scout.search()).rejects.toThrow("network exploded");
+
+    expect(scout.getState().searchRotation.languageOffset).toBe(2);
   });
 });

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -24,6 +24,7 @@ import type {
   SavedCandidate,
   SkippedIssue,
   Horizon,
+  SearchRotation,
 } from "./core/schemas.js";
 import type {
   ScoutConfig,
@@ -56,6 +57,7 @@ import {
   getHttpStatusCode,
   isRateLimitError,
   rethrowIfFatal,
+  ValidationError,
 } from "./core/errors.js";
 import { getHttpCache } from "./core/http-cache.js";
 
@@ -272,31 +274,38 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
     // fan-out at a different variant each run instead of always index 0.
     const rotation = this.state.searchRotation ?? { languageOffset: 0 };
 
-    const { candidates, strategiesUsed } = await discovery.searchIssues({
-      maxResults: options?.maxResults,
-      strategies: options?.strategies,
-      skippedUrls,
-      preferLanguages,
-      preferRepos,
-      avoidRepos,
-      boostIssueTypes,
-      diversityRatio,
-      interPhaseDelayMs: options?.interPhaseDelayMs,
-      broadPhaseDelayMs: options?.broadPhaseDelayMs,
-      languageRotationOffset: rotation.languageOffset,
-    });
+    let candidates: IssueCandidate[];
+    let strategiesUsed: SearchResult["strategiesUsed"];
+    try {
+      ({ candidates, strategiesUsed } = await discovery.searchIssues({
+        maxResults: options?.maxResults,
+        strategies: options?.strategies,
+        skippedUrls,
+        preferLanguages,
+        preferRepos,
+        avoidRepos,
+        boostIssueTypes,
+        diversityRatio,
+        interPhaseDelayMs: options?.interPhaseDelayMs,
+        broadPhaseDelayMs: options?.broadPhaseDelayMs,
+        languageRotationOffset: rotation.languageOffset,
+      }));
+    } catch (err) {
+      // A zero-candidate search throws ValidationError (see issue-discovery.ts)
+      // instead of returning normally — the exact case rotation exists to fix,
+      // since a broad phase that ran and found nothing must not leave the same
+      // barren language slice leading the next run. Advance the cursor off the
+      // strategiesUsed the error carries, then rethrow unchanged (#249 follow-up).
+      if (err instanceof ValidationError) {
+        this.advanceRotationIfBroadRan(rotation, err.strategiesUsed ?? []);
+      }
+      throw err;
+    }
 
     // Advance the rotation cursor only when the broad phase actually ran —
     // otherwise a search that skipped it (e.g. sufficient results from
     // cheaper phases) would still shift the next run's starting variant.
-    if (strategiesUsed.includes("broad")) {
-      this.state.searchRotation = {
-        ...rotation,
-        languageOffset: rotation.languageOffset + 1,
-        lastRotatedAt: new Date().toISOString(),
-      };
-      this.dirty = true;
-    }
+    this.advanceRotationIfBroadRan(rotation, strategiesUsed);
 
     // Feed the freshly observed maintainer-responsiveness signals back into the
     // repo scores so the next search ranks responsive/active repos higher (#167).
@@ -314,6 +323,26 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       rateLimitWarning: discovery.rateLimitWarning ?? undefined,
       strategiesUsed,
     };
+  }
+
+  /**
+   * Advance the language-rotation cursor when the broad phase actually ran.
+   * Called on both the success path and the zero-candidate ValidationError
+   * path — a broad phase that ran and found nothing must still rotate, or the
+   * same barren language slice would lead every subsequent run (#249
+   * follow-up). Skipped/gated broad phases don't burn a rotation slot.
+   */
+  private advanceRotationIfBroadRan(
+    rotation: SearchRotation,
+    strategiesUsed: readonly string[],
+  ): void {
+    if (!strategiesUsed.includes("broad")) return;
+    this.state.searchRotation = {
+      ...rotation,
+      languageOffset: rotation.languageOffset + 1,
+      lastRotatedAt: new Date().toISOString(),
+    };
+    this.dirty = true;
   }
 
   /**

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -268,6 +268,10 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       (prefBoostTypes.length > 0 ? prefBoostTypes : undefined);
     const diversityRatio = options?.diversityRatio ?? prefs.diversityRatio ?? 0;
 
+    // Rotation cursor (#249 follow-up): start Phase 2's broad-search language
+    // fan-out at a different variant each run instead of always index 0.
+    const rotation = this.state.searchRotation ?? { languageOffset: 0 };
+
     const { candidates, strategiesUsed } = await discovery.searchIssues({
       maxResults: options?.maxResults,
       strategies: options?.strategies,
@@ -279,7 +283,20 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       diversityRatio,
       interPhaseDelayMs: options?.interPhaseDelayMs,
       broadPhaseDelayMs: options?.broadPhaseDelayMs,
+      languageRotationOffset: rotation.languageOffset,
     });
+
+    // Advance the rotation cursor only when the broad phase actually ran —
+    // otherwise a search that skipped it (e.g. sufficient results from
+    // cheaper phases) would still shift the next run's starting variant.
+    if (strategiesUsed.includes("broad")) {
+      this.state.searchRotation = {
+        ...rotation,
+        languageOffset: rotation.languageOffset + 1,
+        lastRotatedAt: new Date().toISOString(),
+      };
+      this.dirty = true;
+    }
 
     // Feed the freshly observed maintainer-responsiveness signals back into the
     // repo scores so the next search ranks responsive/active repos higher (#167).


### PR DESCRIPTION
The broad search phase kept dying on the REST Search API's 30/min secondary limit (a full run collapsed 96 raw candidates to 2 and never got past language:python). This moves Phase 2 and Phase 3's search fallback to GraphQL `search(type: ISSUE)`, which bills the points bucket (5000/hr) instead, with the REST path kept as automatic fallback and budget accounting intact.

Since the broad phase no longer consumes the Search budget, the low-budget gates on Phases 2/3 and the 90s broad-phase cooldown are gone, and the summary line now reports both counters (`N REST Search API call(s) + M GraphQL broad-search queries used`).

Also adds a persisted rotation cursor so consecutive runs lead the broad fan-out with a different language slice, advancing even when a broad run finds nothing (a barren slice shouldn't lead twice). That required attaching `strategiesUsed` to the zero-candidate ValidationError and persisting dirty state from `runSearch` before rethrowing, since `withScout`'s persist epilogue only runs when the search resolves.

Live-verified: three full searches, zero secondary-limit hits (previously 4+ per run), GraphQL cost ~3 points/run, cursor advanced 0→1→2 across runs. 1099 tests pass, typecheck clean.
