### PR TITLE
feat(vetting): gate approve on repo-intrinsic merge acceptance

### DIFF
--- a/packages/core/src/core/derive-recommendation.test.ts
+++ b/packages/core/src/core/derive-recommendation.test.ts
@@ -1,8 +1,26 @@
 import { describe, it, expect } from "vitest";
 import {
   deriveRecommendation,
+  repoAcceptsContributionsFromHealth,
   type RecommendationInput,
 } from "./issue-vetting.js";
+import type { ProjectHealth } from "./types.js";
+
+// Minimal healthy snapshot; override the merge fields per case.
+function health(overrides: Partial<ProjectHealth> = {}): ProjectHealth {
+  return {
+    repo: "owner/repo",
+    lastCommitAt: "2026-07-01T00:00:00Z",
+    daysSinceLastCommit: 1,
+    openIssuesCount: 5,
+    avgIssueResponseDays: 0,
+    ciStatus: "unknown",
+    isActive: true,
+    recentMergedPRCount: 10,
+    recentMergeRate: 0.8,
+    ...overrides,
+  } as ProjectHealth;
+}
 
 // All checks passing, no affinity signals — the "clean approve" baseline.
 function baseInput(
@@ -25,6 +43,7 @@ function baseInput(
     matchesCategory: false,
     issueClosed: false,
     passedAllChecks: true,
+    repoAcceptsContributions: true,
     ...overrides,
   };
 }
@@ -140,5 +159,80 @@ describe("deriveRecommendation (#157)", () => {
     );
     expect(out.recommendation).toBe("needs_review");
     expect(out.reasonsToSkip).toContain("Has existing PR");
+  });
+
+  // Repo-intrinsic merge-acceptance gate (#248/#249/#1575).
+  it("withholds approve from a repo that merges no external PRs", () => {
+    // The spam case: high-star, active, clear requirements, no existing PR,
+    // not claimed — every eligibility check passes — but the repo has merged
+    // nobody in 90 days. Must not be auto-approved.
+    const out = deriveRecommendation(
+      baseInput({ repoAcceptsContributions: false }),
+    );
+    expect(out.recommendation).not.toBe("approve");
+    expect(out.reasonsToSkip).toContain("Repo has no recent merged PRs");
+    expect(out.notes).toContain("Repo has merged no PRs in the last 90 days");
+  });
+
+  it("downgrades approve to needs_review when merge-acceptance is unknown", () => {
+    const out = deriveRecommendation(
+      baseInput({ repoAcceptsContributions: null }),
+    );
+    expect(out.recommendation).toBe("needs_review");
+    expect(out.notes).toContain(
+      "Recommendation downgraded: one or more checks were inconclusive",
+    );
+    expect(out.notes).toContain("Could not verify whether the repo merges PRs");
+  });
+
+  it("still approves a repo with recent merged PRs", () => {
+    const out = deriveRecommendation(
+      baseInput({ repoAcceptsContributions: true }),
+    );
+    expect(out.recommendation).toBe("approve");
+  });
+});
+
+describe("repoAcceptsContributionsFromHealth (#248/#249/#1575)", () => {
+  it("true when the repo merged at least one PR", () => {
+    expect(
+      repoAcceptsContributionsFromHealth(
+        health({ recentMergedPRCount: 3, recentMergeRate: 0.5 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("false when it had closed PRs but merged none (rejects contributions)", () => {
+    expect(
+      repoAcceptsContributionsFromHealth(
+        health({ recentMergedPRCount: 0, recentMergeRate: 0 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("null when there was no PR activity in the window (new/quiet repo)", () => {
+    expect(
+      repoAcceptsContributionsFromHealth(
+        health({ recentMergedPRCount: 0, recentMergeRate: null }),
+      ),
+    ).toBeNull();
+  });
+
+  it("null when the health check failed", () => {
+    expect(
+      repoAcceptsContributionsFromHealth({
+        repo: "owner/repo",
+        checkFailed: true,
+        failureReason: "boom",
+      }),
+    ).toBeNull();
+  });
+
+  it("null when the merge count was not fetched", () => {
+    expect(
+      repoAcceptsContributionsFromHealth(
+        health({ recentMergedPRCount: undefined, recentMergeRate: undefined }),
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -82,6 +82,8 @@ vi.mock("./repo-health.js", () => ({
     isActive: true,
     stargazersCount: 500,
     forksCount: 50,
+    recentMergedPRCount: 20,
+    recentMergeRate: 0.9,
   } satisfies ProjectHealth),
   fetchContributionGuidelines: vi.fn().mockResolvedValue({
     url: "https://github.com/owner/repo/blob/main/CONTRIBUTING.md",
@@ -195,6 +197,8 @@ describe("IssueVetter", () => {
       isActive: true,
       stargazersCount: 500,
       forksCount: 50,
+      recentMergedPRCount: 20,
+      recentMergeRate: 0.9,
     });
     vi.mocked(fetchContributionGuidelines).mockResolvedValue({
       url: "https://github.com/owner/repo/blob/main/CONTRIBUTING.md",

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -15,6 +15,7 @@ import {
   type SearchPriority,
   type IssueCandidate,
   type ProjectCategory,
+  type ProjectHealth,
   type ScoutPreferences,
   type ScoutState,
   type MergedPRRecord,
@@ -160,6 +161,33 @@ export interface ScoutStateWriter {
 }
 
 /**
+ * Repo-intrinsic contribution-acceptance signal from the health snapshot
+ * (#248/#249/#1575). Does the repo merge PR-based contributions at all over the
+ * last 90 days?
+ *   - `true`  — merged at least one PR
+ *   - `false` — had closed PRs but merged none (it rejects the work it receives)
+ *   - `null`  — no PR activity in the window, or health/counts unavailable;
+ *               inconclusive → needs_review, never a hard skip
+ *
+ * This deliberately does NOT distinguish maintainer self-merges from outside
+ * contributions — a solo repo that merges only its own PRs still reads `true`.
+ * That contributor-diversity refinement is deferred (#248 secondary); the point
+ * here is only to stop auto-approving repos that merge nothing at all.
+ */
+export function repoAcceptsContributionsFromHealth(
+  projectHealth: ProjectHealth,
+): boolean | null {
+  if (projectHealth.checkFailed || projectHealth.recentMergedPRCount == null) {
+    return null;
+  }
+  if (projectHealth.recentMergedPRCount > 0) return true;
+  // No merged PRs. A number (0) for the rate means there WERE closed PRs, none
+  // merged — real evidence the repo rejects contributions. A null rate means no
+  // closed PRs in the window at all (new/quiet repo) — too little to skip on.
+  return projectHealth.recentMergeRate == null ? null : false;
+}
+
+/**
  * Inputs to deriveRecommendation: the already-computed check results and
  * affinity signals. Kept as a flat record of primitives so the derivation is a
  * pure function, independently unit-testable (#157).
@@ -203,6 +231,16 @@ export interface RecommendationInput {
   issueClosed: boolean;
   /** noExistingPR && notClaimed && projectActive && clearRequirements. */
   passedAllChecks: boolean;
+  /**
+   * Whether the repo merges PR-based contributions, from repo-wide recent merge
+   * history (#248/#249/#1575). `true` = has recent merged PRs; `false` = had
+   * closed PRs but merged none, so "approve" is withheld even when the
+   * eligibility checks pass (the high-star zero-merge spam case); `null` =
+   * couldn't compute or no PR activity in the window, treated as inconclusive →
+   * needs_review, never a hard skip. Distinct from effectiveMergedCount, which
+   * is the VIEWER's own history. See repoAcceptsContributionsFromHealth.
+   */
+  repoAcceptsContributions: boolean | null;
 }
 
 export interface RecommendationOutput {
@@ -257,6 +295,10 @@ export function deriveRecommendation(
   if (!input.clearRequirements) notes.push("Issue requirements are unclear");
   if (!input.contributionGuidelinesFound)
     notes.push("No CONTRIBUTING.md found");
+  if (input.repoAcceptsContributions === false)
+    notes.push("Repo has merged no PRs in the last 90 days");
+  else if (input.repoAcceptsContributions === null)
+    notes.push("Could not verify whether the repo merges PRs");
 
   // Reasons to skip / approve.
   if (!input.noExistingPR) {
@@ -271,6 +313,8 @@ export function deriveRecommendation(
   if (!input.projectIsActive && !input.projectCheckFailed)
     reasonsToSkip.push("Inactive project");
   if (!input.clearRequirements) reasonsToSkip.push("Unclear requirements");
+  if (input.repoAcceptsContributions === false)
+    reasonsToSkip.push("Repo has no recent merged PRs");
 
   if (input.noExistingPR) reasonsToApprove.push("No existing PR");
   if (input.notClaimed) reasonsToApprove.push("Not claimed");
@@ -309,7 +353,13 @@ export function deriveRecommendation(
   } else if (input.ownPR) {
     // You're already working on this; don't re-surface it as competition.
     recommendation = "skip";
-  } else if (input.passedAllChecks) {
+  } else if (
+    input.passedAllChecks &&
+    input.repoAcceptsContributions !== false
+  ) {
+    // Withhold "approve" from a repo that merges nobody, even when the
+    // eligibility checks pass — the high-star zero-merge spam case (#249/#1575).
+    // A `null` (couldn't compute) still reaches here and is downgraded below.
     recommendation = "approve";
   } else if (reasonsToSkip.length > 2) {
     recommendation = "skip";
@@ -323,7 +373,8 @@ export function deriveRecommendation(
     input.projectCheckFailed ||
     input.existingPRInconclusive ||
     input.claimInconclusive ||
-    input.mergedCountInconclusive;
+    input.mergedCountInconclusive ||
+    input.repoAcceptsContributions === null;
   if (recommendation === "approve" && hasInconclusiveChecks) {
     recommendation = "needs_review";
     notes.push(
@@ -425,7 +476,7 @@ export class IssueVetter {
     ] = await Promise.all([
       checkNoExistingPR(this.octokit, owner, repo, number),
       checkNotClaimed(this.octokit, owner, repo, number, core.commentCount),
-      checkProjectHealth(this.octokit, owner, repo),
+      checkProjectHealth(this.octokit, owner, repo, this.budgetTracker),
       fetchContributionGuidelines(this.octokit, owner, repo),
       hasMergedPRsInRepo
         ? Promise.resolve(0)
@@ -480,6 +531,13 @@ export class IssueVetter {
     const projectActive = projectHealth.checkFailed
       ? true
       : projectHealth.isActive;
+
+    // Repo-intrinsic merge-acceptance gate (#248/#249/#1575): does this repo
+    // merge PR-based contributions at all? A high-star repo that merges nothing
+    // is exactly the spam case that used to get auto-approved. Independent of
+    // our own contribution history, unlike effectiveMergedCount below.
+    const repoAcceptsContributions =
+      repoAcceptsContributionsFromHealth(projectHealth);
 
     const vettingResult: IssueVettingResult = {
       passedAllChecks:
@@ -546,7 +604,8 @@ export class IssueVetter {
       projectHealth.checkFailed ||
       !!existingPRCheck.inconclusive ||
       !!claimCheck.inconclusive ||
-      mergedCountInconclusive;
+      mergedCountInconclusive ||
+      repoAcceptsContributions === null;
 
     const { notes, reasonsToApprove, reasonsToSkip, recommendation } =
       deriveRecommendation({
@@ -575,6 +634,7 @@ export class IssueVetter {
         matchesCategory,
         issueClosed,
         passedAllChecks: vettingResult.passedAllChecks,
+        repoAcceptsContributions,
       });
     vettingResult.notes = notes;
 

--- a/packages/core/src/core/repo-health.test.ts
+++ b/packages/core/src/core/repo-health.test.ts
@@ -54,6 +54,13 @@ describe("checkProjectHealth", () => {
           data: [{ commit: { author: { date: recentDate } } }],
         }),
       },
+      search: {
+        // Two calls: merged count, then closed-unmerged count.
+        issuesAndPullRequests: vi
+          .fn()
+          .mockResolvedValueOnce({ data: { total_count: 9 } })
+          .mockResolvedValueOnce({ data: { total_count: 1 } }),
+      },
     } as unknown as Octokit;
 
     const health = await checkProjectHealth(
@@ -67,6 +74,10 @@ describe("checkProjectHealth", () => {
     expect(health.forksCount).toBe(50);
     expect(health.language).toBe("TypeScript");
     expect(health.checkFailed).toBeUndefined();
+    if (!health.checkFailed) {
+      expect(health.recentMergedPRCount).toBe(9);
+      expect(health.recentMergeRate).toBeCloseTo(0.9);
+    }
   });
 
   it("returns inactive health for an old repo", async () => {
@@ -87,6 +98,11 @@ describe("checkProjectHealth", () => {
           data: [{ commit: { author: { date: oldDate } } }],
         }),
       },
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockResolvedValue({ data: { total_count: 0 } }),
+      },
     } as unknown as Octokit;
 
     const health = await checkProjectHealth(
@@ -96,6 +112,38 @@ describe("checkProjectHealth", () => {
     );
     expect(health.isActive).toBe(false);
     expect(health.daysSinceLastCommit).toBeGreaterThan(30);
+  });
+
+  it("propagates a non-fatal merge-stats failure as checkFailed (not a cached success)", async () => {
+    // Issue-2 guard: a transient Search API blip must not be baked into the 4h
+    // health snapshot as a null merge signal — it fails the whole check so the
+    // next call self-heals, mirroring a real health-check failure.
+    const recentDate = new Date().toISOString();
+    const octokit = {
+      repos: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            open_issues_count: 3,
+            pushed_at: recentDate,
+            stargazers_count: 100,
+            forks_count: 5,
+            language: "Go",
+          },
+          headers: {},
+        }),
+        listCommits: vi.fn().mockResolvedValue({
+          data: [{ commit: { author: { date: recentDate } } }],
+        }),
+      },
+      search: {
+        issuesAndPullRequests: vi
+          .fn()
+          .mockRejectedValue(new Error("search blip")),
+      },
+    } as unknown as Octokit;
+
+    const health = await checkProjectHealth(octokit, "blip-org", "blip-repo");
+    expect(health.checkFailed).toBe(true);
   });
 
   it("returns checkFailed: true on API error", async () => {

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -17,8 +17,61 @@ import {
 import { warn } from "./logger.js";
 import { getHttpCache, cachedRequest, cachedTimeBased } from "./http-cache.js";
 import { probeRepoFile } from "./probe-repo-file.js";
+import {
+  type SearchBudgetTracker,
+  getSearchBudgetTracker,
+} from "./search-budget.js";
 
 const MODULE = "repo-health";
+
+/** Window for measuring repo-wide merge behavior. */
+const MERGE_WINDOW_DAYS = 90;
+
+/**
+ * Repo-intrinsic merge signal: how much outside work a repo actually merges,
+ * measured from repo-wide PR history over the last 90 days (#248/#249/#1575) —
+ * NOT the viewer's own contribution relationship. Two budget-tracked Search API
+ * calls (merged count, closed-unmerged count); the result is cached with the
+ * surrounding health snapshot, so repeated candidates from one repo pay nothing.
+ *
+ * Errors are NOT swallowed here: they propagate to checkProjectHealth's outer
+ * catch, which turns the whole snapshot into `checkFailed` (and, crucially, does
+ * not cache it) so a transient search blip self-heals on the next call. Handling
+ * the error here and returning nulls instead would pin an inconclusive signal in
+ * the 4h health cache for the whole repo. `recentMergedPRCount` is therefore
+ * always a real number on the success path; `recentMergeRate` is null only when
+ * there were genuinely no closed PRs in the window.
+ */
+async function fetchRepoMergeStats(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  tracker: SearchBudgetTracker,
+): Promise<{ recentMergedPRCount: number; recentMergeRate: number | null }> {
+  const since = new Date(Date.now() - MERGE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const count = async (qualifiers: string): Promise<number> => {
+    await tracker.waitForBudget();
+    try {
+      const { data } = await octokit.search.issuesAndPullRequests({
+        q: `repo:${owner}/${repo} ${qualifiers} closed:>=${since}`,
+        per_page: 1, // only total_count is needed
+      });
+      return data.total_count;
+    } finally {
+      // Always record — a failed request still consumes rate-limit budget.
+      tracker.recordCall();
+    }
+  };
+  const merged = await count("is:pr is:merged");
+  const closedUnmerged = await count("is:pr is:unmerged is:closed");
+  const denom = merged + closedUnmerged;
+  return {
+    recentMergedPRCount: merged,
+    recentMergeRate: denom > 0 ? merged / denom : null,
+  };
+}
 
 // ── Cache for contribution guidelines ──
 
@@ -70,6 +123,9 @@ export async function checkProjectHealth(
   octokit: Octokit,
   owner: string,
   repo: string,
+  // Optional injected budget tracker for the repo-wide merge-stat searches.
+  // Defaults to the shared singleton so existing callers behave identically.
+  tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<ProjectHealth> {
   const cache = getHttpCache();
   const healthCacheKey = `health:${owner}/${repo}`;
@@ -125,6 +181,13 @@ export async function checkProjectHealth(
 
         const ciStatus: "passing" | "failing" | "unknown" = "unknown";
 
+        const mergeStats = await fetchRepoMergeStats(
+          octokit,
+          owner,
+          repo,
+          tracker,
+        );
+
         return {
           repo: `${owner}/${repo}`,
           lastCommitAt,
@@ -136,6 +199,8 @@ export async function checkProjectHealth(
           stargazersCount: repoData.stargazers_count,
           forksCount: repoData.forks_count,
           language: repoData.language,
+          recentMergedPRCount: mergeStats.recentMergedPRCount,
+          recentMergeRate: mergeStats.recentMergeRate,
         };
       },
     );

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -44,6 +44,23 @@ export interface ProjectHealthData {
   stargazersCount?: number;
   forksCount?: number;
   language?: string | null;
+  /**
+   * Repo-wide merged PRs in the last 90 days. Repo-intrinsic — independent of
+   * the viewer's own contribution history — so it distinguishes a repo that
+   * merges outside work from a high-star repo that merges nobody (#248, #249,
+   * #1575). `null` when the count could not be computed (API failure) or was
+   * not fetched; callers treat `null` as inconclusive, never a hard skip.
+   */
+  recentMergedPRCount?: number | null;
+  /**
+   * Fraction of recently-closed PRs that were merged — merged / (merged +
+   * closed-unmerged) over the last 90 days. `null` when there were no closed
+   * PRs in the window or the counts could not be computed. Repo-intrinsic and
+   * part of the candidate output contract: consumed by the downstream success
+   * grade (oss-autopilot) so a healthy new repo grades on its own merits rather
+   * than the viewer's contribution relationship (#248). Not read within scout.
+   */
+  recentMergeRate?: number | null;
   /** Discriminant: a real snapshot is never `checkFailed`. */
   checkFailed?: false;
   failureReason?: undefined;

--- a/packages/core/src/eval/vet-eval.ts
+++ b/packages/core/src/eval/vet-eval.ts
@@ -125,6 +125,10 @@ export function runFixture(
       !fixture.vetTimeFacts.isClaimed &&
       fixture.vetTimeFacts.projectActive &&
       clearRequirements,
+    // Historical fixtures predate the repo-wide merge signal (#248/#249/#1575);
+    // assume acceptance so the new gate stays inert and the benchmark keeps
+    // measuring the rest of the pipeline unchanged.
+    repoAcceptsContributions: true,
   };
   const { recommendation } = deriveRecommendation(recInput);
 


### PR DESCRIPTION
## Summary

Discovery/vetting scored repos on the viewer's own contribution relationship plus a flat proxy, never on whether the repo actually merges the PRs it receives. A high-star repo that merges nobody cleared every eligibility check and was recommended `approve`; the same gap gave a healthy repo we'd never contributed to no repo-intrinsic signal to grade on.

Adds a repo-wide recent-merge signal to `checkProjectHealth`: two budget-tracked, cached Search API calls compute merged and closed-unmerged PR counts over the last 90 days, exposed as `recentMergedPRCount` and `recentMergeRate` on `ProjectHealthData`. The vetter withholds `approve` when a repo had closed PRs but merged none, and downgrades to `needs_review` when the signal is unknown or the repo has no PR activity in the window - never a hard skip.

## Why

- **Fixes #249** (aspect b): high-star, zero-merge spam repos were surfaced and `approve`d because `passedAllChecks` had no merge-acceptance term. (Aspect a - cross-round rotation - was already resolved by the persisted seen-set and language rotation.)
- **Addresses #1575 (defect 1)**: an unknown-health repo cleared the approve path. Fixed at the recommendation layer rather than the score layer, so all callers route through one gate.
- **Part of #248**: `recentMergeRate` is part of the candidate output contract, consumed by the downstream success grade in oss-autopilot so a healthy new repo grades on its own merits. That consumer ships in a paired oss-autopilot PR after this releases.

## Notes

- Merge-stat fetch errors propagate to `checkProjectHealth`'s outer catch, so a transient Search API blip fails the snapshot (uncached, self-healing) rather than pinning an inconclusive signal in the 4h health cache.
- Self-merge vs external-contribution distinction is intentionally deferred (the contributor-diversity refinement, #248 secondary); this only stops auto-approving repos that merge nothing at all.

## Test plan

- [x] `pnpm test` - 1112 core tests pass (new: gate 3-way logic, helper unit tests, transient-failure-propagates-as-checkFailed guard, repo-health merge-stat assertions)
- [x] `pnpm run lint` clean
- [x] `pnpm run format:check` clean
- [x] `tsc --noEmit` clean