### PR TITLE
fix: address all 27 findings from the 2026-08-07 repository audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+# CI only reads the repo; release-please.yml holds the write grants.
+permissions:
+  contents: read
+
+# Supersede in-flight runs for the same ref (but never cancel main pushes,
+# so every landed commit keeps a complete CI record).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,9 @@ packages/core/src/
 │   ├── preference-fields.ts # Shared config-set field map (CLI + MCP)
 │   ├── search-phases.ts  # Search helpers, caching, batched search
 │   ├── search-budget.ts  # Rate limit management (30 req/min sliding window)
+│   ├── issue-graphql.ts  # GraphQL broad search + batched merged-PR prefetch
 │   ├── repo-health.ts    # Project health checks, CONTRIBUTING.md parsing
+│   ├── probe-repo-file.ts # Cheap existence probes for repo files
 │   ├── category-mapping.ts # Project categories → GitHub topics
 │   ├── github.ts         # Throttled Octokit client
 │   ├── http-cache.ts     # ETag response caching, in-flight deduplication
@@ -68,30 +70,40 @@ packages/core/src/
 │   ├── logger.ts         # Debug/info/warn logger (stderr)
 │   ├── errors.ts         # Error hierarchy + strategy documentation
 │   └── pagination.ts     # Auto-pagination helper
-└── formatters/
-    └── json.ts           # JSON output formatter
+├── formatters/
+│   ├── json.ts           # JSON output formatter (--json envelope)
+│   ├── human.ts          # Human-readable terminal output
+│   └── markdown.ts       # Markdown output (results --markdown; used by action.yml)
+├── e2e/
+│   └── search-flow.test.ts # End-to-end search flow (only Octokit mocked)
+└── eval/                 # Vet eval suite (eval:vet scripts; excluded from dist)
 
 packages/mcp-server/src/
-├── index.ts              # MCP server entry point (stdio transport)
+├── index.ts              # Library entry: createServer wiring (side-effect free)
+├── bin.ts                # Stdio executable entry point
 ├── tools.ts              # 7 tools: search, scout-features, vet, skip, config, config-set, sync
-├── resources.ts          # 3 resources: scout://config, results, scores
-└── tools.test.ts         # Tool registration tests
+└── resources.ts          # 3 resources: scout://config, results, scores
 
 Plugin (repo root):
 ├── commands/scout.md, scout-setup.md
 ├── agents/issue-scout.md, repo-evaluator.md
 ├── skills/oss-search/SKILL.md
-└── .claude-plugin/plugin.json
+├── hooks/                # hooks.json + session-start, git guard, auto-format
+├── .claude-plugin/       # plugin.json, marketplace.json
+├── action.yml            # Composite GitHub Action (scheduled digest issue)
+└── examples/             # Example workflows (weekly digest)
 ```
 
 ## Development Commands
 
 ```bash
 pnpm install              # Install all workspace dependencies
-pnpm test                 # Run all tests (~900 tests across 44 files)
+pnpm -r build             # Build both packages (required before mcp-server tests)
+pnpm test                 # Run all tests (~1,100 tests across ~58 files)
 pnpm run bundle           # Rebuild CLI bundle
 pnpm run lint             # ESLint
 pnpm run format:check     # Prettier check
+pnpm run eval:vet         # Score the vetter against historical outcomes
 pnpm start -- search 5    # Run CLI via tsx (dev mode)
 pnpm start -- search 5 --json --strategy starred  # Test specific strategy
 ```

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ oss-scout config reset                               # reset to defaults
 | `persistence` | enum | local | State storage: local or gist |
 | `preferLanguages` | string[] | [] | Soft-boost ranking for these repo languages (the `--prefer-languages` flag overrides) |
 | `preferRepos` | string[] | [] | Soft-boost ranking for these `owner/repo` slugs (the `--prefer-repos` flag overrides) |
+| `avoidRepos` | string[] | [] | Soft-penalize ranking for these `owner/repo` slugs (the `--avoid-repos` flag overrides). Milder than `excludeRepos`: pushes them down without filtering |
+| `boostIssueTypes` | string[] | [] | Soft-boost ranking for issues whose labels match these types, case-insensitive (the `--boost-issue-types` flag overrides) |
 | `diversityRatio` | number | 0 | Fraction of result slots (0-1) reserved for unboosted candidates (the `--diversity-ratio` flag overrides) |
 | `slmTriageModel` | string | (disabled) | Ollama model id for local SLM pre-triage during vetting (e.g. `gemma4:e4b`); empty disables it |
 | `slmTriageHost` | string | (127.0.0.1:11434) | Override the Ollama HTTP host when it runs on another machine |
@@ -291,7 +293,7 @@ Agents (dispatched automatically by Claude):
   "mcpServers": {
     "oss-scout": {
       "command": "npx",
-      "args": ["@oss-scout/mcp@latest"]
+      "args": ["-y", "@oss-scout/mcp@latest"]
     }
   }
 }
@@ -399,6 +401,8 @@ Search:
     --strategy <s>              Strategies: merged,starred,broad,maintained,all
     --prefer-languages <list>   Soft-boost ranking for matching repo languages
     --prefer-repos <list>       Soft-boost ranking for these owner/repo slugs
+    --avoid-repos <list>        Soft-penalize ranking for these owner/repo slugs
+    --boost-issue-types <list>  Soft-boost ranking for matching label types
     --diversity-ratio <n>       Reserve a fraction (0-1) of slots for unboosted
   features [count]              Feature opportunities in repos with 3+ merged PRs
     --anchor-threshold <n>      Override featuresAnchorThreshold (1-50)

--- a/action.yml
+++ b/action.yml
@@ -47,27 +47,36 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "20"
 
+    # Inputs are passed through env and referenced as "$VAR" rather than
+    # interpolated into the scripts, so a caller wiring event-derived data
+    # (e.g. an issue title) into an input can't inject shell.
     - name: Bootstrap and search
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.search-token }}
+        SCOUT_VERSION: ${{ inputs.version }}
+        SCOUT_USERNAME: ${{ inputs.github-username }}
+        SCOUT_MAX_RESULTS: ${{ inputs.max-results }}
+        SCOUT_STRATEGY: ${{ inputs.strategy }}
       run: |
         set -euo pipefail
-        PKG="@oss-scout/core@${{ inputs.version }}"
-        npx -y "$PKG" config set githubUsername "${{ inputs.github-username }}"
+        PKG="@oss-scout/core@${SCOUT_VERSION}"
+        npx -y "$PKG" config set githubUsername "$SCOUT_USERNAME"
         # Bootstrap is best-effort: a repo-scoped token may not see full history.
         npx -y "$PKG" bootstrap || echo "bootstrap skipped (limited token scope)"
-        npx -y "$PKG" search "${{ inputs.max-results }}" --strategy "${{ inputs.strategy }}" > /dev/null
+        npx -y "$PKG" search "$SCOUT_MAX_RESULTS" --strategy "$SCOUT_STRATEGY" > /dev/null
 
     - name: Render digest
       shell: bash
+      env:
+        SCOUT_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        PKG="@oss-scout/core@${{ inputs.version }}"
+        PKG="@oss-scout/core@${SCOUT_VERSION}"
         npx -y "$PKG" results --markdown > digest.md
         {
           echo ""
@@ -79,20 +88,29 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.issue-token }}
         GH_REPO: ${{ github.repository }}
+        SCOUT_ISSUE_TITLE: ${{ inputs.issue-title }}
+        SCOUT_ISSUE_LABEL: ${{ inputs.issue-label }}
       run: |
         set -euo pipefail
-        # Ensure the label exists (ignore "already exists").
-        gh label create "${{ inputs.issue-label }}" --color ededed \
-          --description "oss-scout scheduled digest" 2>/dev/null || true
+        # Ensure the label exists, tolerating only "already exists" — a
+        # permission failure here would otherwise surface confusingly at the
+        # gh issue step below.
+        if ! create_err=$(gh label create "$SCOUT_ISSUE_LABEL" --color ededed \
+          --description "oss-scout scheduled digest" 2>&1); then
+          if ! grep -qi "already exists" <<<"$create_err"; then
+            echo "$create_err" >&2
+            exit 1
+          fi
+        fi
 
-        existing=$(gh issue list --label "${{ inputs.issue-label }}" --state open \
+        existing=$(gh issue list --label "$SCOUT_ISSUE_LABEL" --state open \
           --json number --jq '.[0].number // empty')
 
         if [ -n "$existing" ]; then
           gh issue edit "$existing" --body-file digest.md
           echo "Updated digest issue #$existing"
         else
-          gh issue create --title "${{ inputs.issue-title }}" \
-            --label "${{ inputs.issue-label }}" --body-file digest.md
+          gh issue create --title "$SCOUT_ISSUE_TITLE" \
+            --label "$SCOUT_ISSUE_LABEL" --body-file digest.md
           echo "Created a new digest issue"
         fi

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -16,7 +16,7 @@ description: >-
   time.</commentary></example>
 model: inherit
 color: green
-tools: Bash, Read, Write
+tools: Bash, Read
 ---
 
 You are an Issue Scout helping contributors find valuable open source contribution opportunities.

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -1,28 +1,22 @@
 ---
 name: issue-scout
-description: Use this agent when searching for new issues to work on or vetting potential issues. This agent finds and evaluates good contribution opportunities.
-
-<example>
-Context: User wants to find issues to contribute to.
-user: "Find me some good issues to work on"
-assistant: "I'll use the issue-scout agent to search for issues matching your skills and preferences."
-<commentary>
-User explicitly wants to find new contribution opportunities.
-</commentary>
-</example>
-
-<example>
-Context: User found an issue and wants to evaluate it.
-user: "Is this issue worth working on? github.com/org/repo/issues/123"
-assistant: "Let me use the issue-scout agent to vet this issue thoroughly."
-<commentary>
-User wants to evaluate a specific issue before investing time.
-</commentary>
-</example>
-
+description: >-
+  Use this agent when searching for new issues to work on or vetting
+  potential issues. This agent finds and evaluates good contribution
+  opportunities.
+  <example>Context: User wants to find issues to contribute to. user: "Find
+  me some good issues to work on" assistant: "I'll use the issue-scout agent
+  to search for issues matching your skills and preferences."
+  <commentary>User explicitly wants to find new contribution
+  opportunities.</commentary></example>
+  <example>Context: User found an issue and wants to evaluate it. user: "Is
+  this issue worth working on? github.com/org/repo/issues/123" assistant:
+  "Let me use the issue-scout agent to vet this issue thoroughly."
+  <commentary>User wants to evaluate a specific issue before investing
+  time.</commentary></example>
 model: inherit
 color: green
-tools: ["Bash", "Read", "Write", "mcp__*"]
+tools: Bash, Read, Write
 ---
 
 You are an Issue Scout helping contributors find valuable open source contribution opportunities.

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -1,28 +1,22 @@
 ---
 name: repo-evaluator
-description: Use this agent when evaluating repository health before contributing, analyzing maintainer responsiveness, or deciding if a repo is worth investing time in.
-
-<example>
-Context: User found an interesting issue but wants to check the repo first.
-user: "Is this repository worth contributing to?"
-assistant: "I'll use the repo-evaluator agent to analyze the repository's health and maintainer patterns."
-<commentary>
-User wants to evaluate repo quality before investing time.
-</commentary>
-</example>
-
-<example>
-Context: User had a bad experience with a slow-responding repo.
-user: "How can I tell if a repo will actually review my PR?"
-assistant: "I'll use the repo-evaluator agent to analyze PR review patterns in the repo."
-<commentary>
-User wants to predict maintainer engagement before contributing.
-</commentary>
-</example>
-
+description: >-
+  Use this agent when evaluating repository health before contributing,
+  analyzing maintainer responsiveness, or deciding if a repo is worth
+  investing time in.
+  <example>Context: User found an interesting issue but wants to check the
+  repo first. user: "Is this repository worth contributing to?" assistant:
+  "I'll use the repo-evaluator agent to analyze the repository's health and
+  maintainer patterns." <commentary>User wants to evaluate repo quality
+  before investing time.</commentary></example>
+  <example>Context: User had a bad experience with a slow-responding repo.
+  user: "How can I tell if a repo will actually review my PR?" assistant:
+  "I'll use the repo-evaluator agent to analyze PR review patterns in the
+  repo." <commentary>User wants to predict maintainer engagement before
+  contributing.</commentary></example>
 model: inherit
 color: blue
-tools: ["Bash", "Read", "Write", "Glob", "mcp__*"]
+tools: Bash, Read, Write, Glob
 ---
 
 You are a Repository Health Analyst who evaluates open source projects to help contributors make informed decisions about where to invest their time.

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -16,7 +16,7 @@ description: >-
   contributing.</commentary></example>
 model: inherit
 color: blue
-tools: Bash, Read, Write, Glob
+tools: Bash, Read, Glob
 ---
 
 You are a Repository Health Analyst who evaluates open source projects to help contributors make informed decisions about where to invest their time.

--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -1,7 +1,7 @@
 ---
 name: scout-setup
 description: Configure OSS Scout preferences for personalized issue discovery
-allowed-tools: Bash, Read, Write, mcp__*
+allowed-tools: Bash, Read, Write
 ---
 
 # OSS Scout Setup

--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -1,7 +1,7 @@
 ---
 name: scout-setup
 description: Configure OSS Scout preferences for personalized issue discovery
-allowed-tools: Bash, Read, Write
+allowed-tools: Bash(node:*), Bash(gh:*), Bash(npm:*), Bash(cd:*), Read
 ---
 
 # OSS Scout Setup

--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -12,13 +12,13 @@ Customize your OSS Scout preferences. This is **optional** — the tool works ou
 
 ```bash
 if [ ! -f "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
-  if ! BUILD_LOG=$(cd "${CLAUDE_PLUGIN_ROOT}/packages/core" && npm install --silent 2>&1 && npm run bundle --silent 2>&1); then
+  if ! BUILD_LOG=$(cd "${CLAUDE_PLUGIN_ROOT}/packages/core" && npm install --ignore-scripts --silent 2>&1 && npm run bundle --silent 2>&1); then
     echo "BUILD_FAILED"; echo "$BUILD_LOG" | tail -5; exit 1
   fi
 fi
 ```
 
-**If output starts with `BUILD_FAILED`**: Tell the user the CLI build failed and show the error lines. Suggest: `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`. Common causes: missing Node.js 20+, stale `node_modules`.
+**If output starts with `BUILD_FAILED`**: Tell the user the CLI build failed and show the error lines. Suggest: `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install --ignore-scripts && npm run bundle`. Common causes: missing Node.js 20+, stale `node_modules`.
 
 ## Step 1: Check Prerequisites
 

--- a/commands/scout.md
+++ b/commands/scout.md
@@ -1,7 +1,7 @@
 ---
 name: scout
 description: "Search for open source issues — multi-strategy search with vetting and viability scoring"
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, mcp__*
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task
 ---
 
 # OSS Scout — Issue Discovery

--- a/commands/scout.md
+++ b/commands/scout.md
@@ -24,13 +24,13 @@ values inside it are not.
 
 ```bash
 if [ ! -f "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
-  if ! BUILD_LOG=$(cd "${CLAUDE_PLUGIN_ROOT}/packages/core" && npm install --silent 2>&1 && npm run bundle --silent 2>&1); then
+  if ! BUILD_LOG=$(cd "${CLAUDE_PLUGIN_ROOT}/packages/core" && npm install --ignore-scripts --silent 2>&1 && npm run bundle --silent 2>&1); then
     echo "BUILD_FAILED"; echo "$BUILD_LOG" | tail -5; exit 1
   fi
 fi
 ```
 
-**If output starts with `BUILD_FAILED`**: Tell the user the CLI build failed and show the error lines. Suggest: `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`. Common causes: missing Node.js 20+, stale `node_modules`.
+**If output starts with `BUILD_FAILED`**: Tell the user the CLI build failed and show the error lines. Suggest: `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install --ignore-scripts && npm run bundle`. Common causes: missing Node.js 20+, stale `node_modules`.
 
 ## Step 1: Check Setup
 
@@ -143,7 +143,7 @@ After presenting results, offer:
 
 **If the CLI bundle is missing**: Build it:
 ```bash
-cd "${CLAUDE_PLUGIN_ROOT}/packages/core" && npm install && npm run bundle
+cd "${CLAUDE_PLUGIN_ROOT}/packages/core" && npm install --ignore-scripts && npm run bundle
 ```
 
 ## Rules

--- a/commands/scout.md
+++ b/commands/scout.md
@@ -1,7 +1,10 @@
 ---
 name: scout
 description: "Search for open source issues — multi-strategy search with vetting and viability scoring"
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task
+# Scoped to what this command actually runs (defense-in-depth: it renders
+# attacker-authored issue text): the bundled CLI via node, gh auth/api, and
+# the npm build fallback. Anything else prompts the user.
+allowed-tools: Bash(node:*), Bash(gh:*), Bash(npm:*), Bash(cd:*), Read
 ---
 
 # OSS Scout — Issue Discovery

--- a/docs/audit-2026-08-07.md
+++ b/docs/audit-2026-08-07.md
@@ -1,0 +1,270 @@
+# Repository Audit — 2026-08-07
+
+Full review of oss-scout at commit `92b80af` covering build health, security,
+core correctness, tests/CI, MCP server, plugin, packaging, and docs.
+High-severity findings were independently verified by reading the code and/or
+reproducing the behavior; verification status is noted per finding.
+
+## Baseline health (verified by running everything)
+
+| Check | Result |
+| --- | --- |
+| `pnpm -r build` (tsc) | Pass |
+| `pnpm test` | **1,144 tests pass** (core: 55 files / 1,112; mcp: 2 files / 32) |
+| `pnpm run lint` | Pass |
+| `pnpm run format:check` | Pass |
+| `pnpm run typecheck` | Pass |
+| `pnpm run bundle` | Pass (CLI 1.3 MB, MCP 1.4 MB) |
+| `pnpm audit --prod --audit-level=high` | **FAIL** — see A1 |
+
+Note: `pnpm test` on a fresh clone fails in `packages/mcp-server` unless
+`pnpm -r build` runs first (mcp tests resolve `@oss-scout/core` via `dist/`).
+CI builds before testing so this only bites local fresh clones.
+
+## A. Act now
+
+### A1. CI's blocking audit gate will fail on the next run — HIGH (verified)
+
+`pnpm audit --prod --audit-level=high` exits 1 today: 13 advisories
+(2 high, 9 moderate, 2 low), all transitive via `@modelcontextprotocol/sdk`
+in `packages/mcp-server`.
+
+- `fast-uri@4.1.1` — high (GHSA-7p8r-x3mc-p8w7, patched in 4.1.2). The
+  `pnpm-workspace.yaml` override pins only `>=3.1.4`, which resolves into the
+  newly-vulnerable 4.x range.
+- `ip-address@10.1.0` — high (GHSA-mwp4-54f8-5fhr, patched in 10.3.1), via
+  `express-rate-limit`. No override exists.
+- `hono@4.12.26` — five moderate advisories want `>=4.12.34` (override pins
+  `>=4.12.25`).
+
+The last CI run on `main` (2026-07-24) passed because these advisories were
+published afterward; commit `92b80af` made the audit job blocking, so the next
+push/PR goes red. Practical exposure is low (the MCP server uses stdio, not
+the SDK's HTTP stack), but the gate is tripped.
+
+**Fix:** in `pnpm-workspace.yaml` set `fast-uri: '>=4.1.2'`,
+`hono: '>=4.12.34'`, add `ip-address: '>=10.3.1'`, then
+`pnpm install` to refresh the lockfile. (`qs`/`body-parser` moderates clear
+with an SDK bump when available.)
+
+### A2. `oss-scout sync` silently persists nothing in default local mode — HIGH (verified)
+
+`packages/core/src/commands/sync.ts:15` relies on `syncOpenPRs()`
+self-checkpointing, but `buildCommandScout`
+(`commands/command-scout.ts:29-33`) builds non-gist CLI scouts with
+`persistence: "provided"`, which leaves `persistLocal: false` and
+`gistStore: null`. `checkpoint()` (`scout.ts:996-1018`) then skips both save
+branches, clears `dirty`, and returns `true`. `runSync` never passes
+`{ persist: true }` to `withScout`, so nothing writes
+`~/.oss-scout/state.json`.
+
+**Impact:** `sync` reports "Synced N open PRs…" while discarding merged-PR
+records, repo-score updates, and open-PR pruning; every subsequent sync
+re-queries the same PRs. This is a recurrence of the #116 "honest
+persistence" class of bug and undermines #164.
+
+**Fix:** pass `{ persist: true }` in `runSync`'s `withScout` call (harmless
+double-checkpoint in gist mode).
+
+### A3. `results clear` bypasses tombstones; cleared results resurrect in gist mode — HIGH (verified)
+
+`runResultsClear` (`commands/results.ts:52-56`) writes `savedResults = []`
+directly via `saveLocalState`, skipping `OssScout.clearResults()`
+(`scout.ts:882-886`) which records deletion tombstones. `mergeSavedResults`
+(`gist-state-store.ts:581-594`) is a union by URL, so the next
+`search`/`vet-list` in gist mode merges the remote's full list back in and
+pushes it to the gist — a regression of the #117 tombstone design.
+
+**Fix:** route `results clear` through the scout (as `skip clear`/`skip
+remove` already do).
+
+### A4. Both plugin agent files have invalid YAML frontmatter — HIGH (verified)
+
+`agents/issue-scout.md` and `agents/repo-evaluator.md` embed multi-line
+`<example>` blocks at column 0 inside the unquoted `description:` scalar;
+`yaml.safe_load` fails on both ("while scanning a simple key"). A strict
+frontmatter parser throws, risking the agents failing to register or losing
+their `model`/`color`/`tools` fields. `commands/*.md` and the skill file
+parse fine.
+
+**Fix:** fold the examples into the description with a block scalar
+(`description: >-` or a quoted string), or move examples into the body.
+
+## B. Security
+
+Overall posture: **clean at the high-risk surfaces.** Verified clean:
+
+- Token handling: env `GITHUB_TOKEN` then `gh auth token` via `execFileSync`
+  (array args, no shell); cached in memory only; deliberately logs only
+  `err.message` to avoid token-bearing exec buffers; no token field in any
+  persisted schema, state file, gist, MCP resource, or `--json` output.
+- No `exec`/`execSync` anywhere in TS code — every child-process call is
+  `execFile*` with fixed binary + array args.
+- Gist store: created `public: false`, never toggled; 401 propagates so a
+  stale gist-id can't fork state; tombstone-aware union merge; unparseable
+  remote on bootstrap falls back to cache rather than clobbering.
+- File permissions: data/cache dirs 0700; state, gist-id, and HTTP-cache
+  files 0600; atomic tmp-write + rename in `local-state.ts`.
+- HTTP cache keys are `sha256(url)` — no path traversal.
+- ReDoS: CONTRIBUTING parsing uses bounded quantifiers (documented fix);
+  `roadmap.ts` escapes regex metachars; GraphQL queries validate
+  owner/repo/username patterns and use variables.
+- CI/release: no `pull_request_target`; publish jobs use npm `--provenance`,
+  `id-token: write`, scoped `NPM_TOKEN`, least-privilege permission
+  downgrades; tag-checkout + frozen lockfile.
+
+Findings:
+
+- **B1 (MEDIUM):** `action.yml:58-96` interpolates `${{ inputs.* }}` directly
+  into `run:` scripts (`version`, `github-username`, `strategy`,
+  `max-results`, `issue-title`, `issue-label`). Defaults are safe, but a
+  consuming workflow wiring event-derived data into any input gets shell
+  execution with the tokens in env — and `inputs.version` flows into
+  `npx -y`. Route inputs through `env:` and reference `"$VAR"`.
+- **B2 (LOW):** `hooks/auto-format-before-push.sh:14-23,132` splices `${msg}`
+  (including up to 200 chars of formatter stderr — repo-controlled output)
+  into the hook's JSON decision without escaping. `session-start.sh:85`
+  already does this correctly with `jq -Rrs '@json'`; reuse that.
+- **B3 (LOW):** Plugin commands/agents that ingest attacker-authored GitHub
+  text run with unrestricted `Bash`, `Write`, and an `mcp__*` wildcard. The
+  untrusted-content warnings in all four surfaces are well written, but
+  scoping Bash to the specific CLI/`gh` invocations would be
+  defense-in-depth.
+- **B4 (LOW):** `slmTriageHost` accepts arbitrary URLs (no scheme/host
+  validation); vetting POSTs issue text to `${host}/api/chat`. Content is
+  public and responses are schema-validated, so this is a beaconing footnote;
+  a localhost/private-range allowlist would close it.
+- **B5 (INFO):** `guard-git-operations.sh` force-push guard is bypassable
+  (`command git push -f`, `git -c … push --force`) — fine as an accident
+  guard, not a boundary. `mergeRepoScores` assigns parsed keys via bracket
+  notation (`__proto__` hygiene; use `Object.create(null)`). Workflow actions
+  are tag-pinned, not SHA-pinned, including in the publish pipeline.
+
+## C. Core correctness (beyond A2/A3)
+
+- **C1 (MEDIUM):** `issue-discovery.ts:686-690` — exhausted REST *Search*
+  quota aborts the entire search, but Phase 0/1 use the Core API and
+  broad/maintained now run on GraphQL. The gate outlived the GraphQL
+  migration; it should skip/limit the search-bucket consumers, not return
+  `{ candidates: [] }`.
+- **C2 (MEDIUM):** `repo-health.ts:131` — `health:` cache key is not
+  schema-versioned, violating the codebase's own #158 rule
+  (`versionedCacheKey`). After a `ProjectHealth` shape change (as in
+  #248/#249), stale 4h entries make `repoAcceptsContributionsFromHealth`
+  return `null`, downgrading every approve to `needs_review` and disabling
+  vet-result caching until entries expire.
+- **C3 (MEDIUM):** `gist-state-store.ts:133-187` — `push()` is
+  read-merge-write with no ETag/If-Match; concurrent pushes from two machines
+  can drop additions (tombstones only protect deletions). Also, a remote that
+  fails validation returns `null` from `fetchGistState` and `push()`
+  overwrites it — the bootstrap path guards against exactly this, `push()`
+  doesn't.
+- **C4 (MEDIUM):** `search-budget.ts:133-170` — `waitForBudget()` doesn't
+  reserve; with `MAX_CONCURRENT_VETTING = 3`, three vetters can pass the gate
+  on an external budget of 1 and overshoot into real 429s (the sliding window
+  has a safety margin; the external-quota path has none).
+- **C5 (MEDIUM):** `issue-discovery.ts:649,673-684` — when the rate-limit
+  pre-flight fails, `searchBudget` stays at the fabricated 19, so no phase is
+  actually skipped despite the log saying "skipping heavy phases", and the
+  tracker is seeded with a made-up reset time.
+- **C6 (LOW):** invalid/empty `updated_at` (mapped to `""` by both REST
+  adapters) makes `daysBetween` return NaN, which bypasses the
+  `maxAgeDays` filter (`NaN > 90` is false). One `Number.isNaN` guard fixes
+  it.
+- **C7 (LOW):** `issue-vetting.ts:857-859` — batch abort-on-auth is 401-only;
+  non-rate-limit 403s (SAML, fine-grained token) are treated as per-item
+  noise while `resolveErrorCode` classifies them as `AUTH_REQUIRED`. The
+  batch should abort consistently with the error taxonomy.
+- **C8 (LOW):** CLI numeric args use bare `parseInt` — `search 50O` runs as
+  50 instead of a `VALIDATION` error; `--anchor-threshold 5.9` truncates.
+- **C9 (LOW):** a tombstone with unparseable `removedAt` never ages out and
+  lexically suppresses that URL forever (`gist-state-store.ts:423-426`).
+- **C10 (LOW):** `checkNotClaimed` derives the last comment page from a
+  possibly-stale prefetched count; a claim landing after prefetch on a
+  page boundary is missed — biased toward the busiest issues.
+
+## D. Tests & CI
+
+Assessment: **strong.** No snapshots, no `.only`/`.skip`, no network in
+tests, mocked clocks (no real sleeps), regression tests annotated with issue
+numbers, and a genuine e2e test (`e2e/search-flow.test.ts`) that mocks only
+the Octokit boundary. Release pipeline: npm provenance, least-privilege
+publish jobs, version coupling verified consistent (core 1.5.0 ↔
+plugin.json; mcp 0.10.0 ↔ `index.ts` annotation ↔ manifest).
+
+- **D1 (MEDIUM):** `ci.yml` has no `permissions:` block — jobs run with
+  default token permissions. Add `permissions: contents: read` at workflow
+  level. (`release-please.yml` already does least-privilege correctly.)
+- **D2 (LOW):** `packages/mcp-server/src/resources.ts` has no behavioral
+  tests (only a `typeof` check) — the largest genuine coverage gap.
+  `index.test.ts` is mostly shape checks, the pattern `cli.test.ts` was
+  rewritten to eliminate.
+- **D3 (LOW):** actions are tag-pinned (`@v4`–`@v6`), not SHA-pinned;
+  `action.yml` uses `setup-node@v4` while CI uses v6. No `concurrency` group
+  in ci.yml. Publish jobs don't re-run tests (trust CI-on-main for the same
+  commit).
+- **D4 (INFO):** `action.yml`'s `gh label create … 2>/dev/null || true`
+  swallows permission failures, not just "already exists".
+
+## E. MCP server, plugin, packaging, docs
+
+MCP server verified sound: all 7 tools + 3 resources exist and match the
+docs; stdio hygiene is clean (logger → stderr, no stdout writes in the server
+import graph); tool errors return `isError` rather than crashing; version
+annotations consistent.
+
+- **E1 (MEDIUM):** long-lived MCP server checkpoints are last-writer-wins on
+  `~/.oss-scout/state.json` — no reload/merge in local mode, so a
+  days-running server clobbers interleaved CLI changes. Gist mode merges;
+  local mode should reload-and-merge before write.
+- **E2 (MEDIUM):** skill name `OSS Issue Search Best Practices`
+  (`skills/oss-search/SKILL.md:2`) violates the lowercase-hyphen skill-name
+  format and doesn't match its directory; may be rejected or renamed on load.
+- **E3 (MEDIUM):** README MCP snippet (`README.md:293-296`) lacks `-y` in
+  `npx` args — under a stdio MCP client there's no TTY, so first run hangs on
+  the npx prompt. Use `["-y", "@oss-scout/mcp@latest"]`.
+- **E4 (MEDIUM):** `types` is not first in the conditional exports of either
+  package (`import` precedes `types`); TS resolves correctly today only by
+  adjacent-file fallback. Reorder in core `"."`, core `"./types"`, mcp `"."`.
+- **E5 (LOW):** `mcp__*` in plugin `allowed-tools`/`tools` lists likely
+  matches nothing (MCP permission rules don't support `*`; use
+  `mcp__servername`). Agents also use a JSON array where a comma-separated
+  string is specified — moot until A4 is fixed.
+- **E6 (LOW):** `commands/scout.md` / `scout-setup.md` fallback runs
+  `npm install` without `--ignore-scripts`, reopening the supply-chain hole
+  `session-start.sh` deliberately closed (#146).
+- **E7 (LOW):** MCP schema gaps: `maxResults` unbounded (CLI enforces 1–50
+  for features); `strategies` is CSV while other list params are arrays;
+  `skip remove` skips URL validation that `skip add` performs. `withTimeout`
+  abandons but doesn't cancel timed-out work (state keeps mutating after the
+  error returns).
+- **E8 (LOW):** packaging nits: shipped CLI bundle references an excluded
+  sourcemap (`--sourcemap` + `!dist/**/*.map`); dead `files` rule
+  `!dist/core/test-utils.*`.
+- **E9 (LOW):** README's config table and search flags omit `avoidRepos` /
+  `boostIssueTypes` (both shipped in 1.5.0; the MCP tools document them).
+
+## F. Documentation drift (CLAUDE.md)
+
+- Test count is stale: says "~900 tests across 44 files"; actual is 1,144
+  across 57.
+- File listing omits real modules: `core/issue-graphql.ts`,
+  `core/probe-repo-file.ts`, `formatters/human.ts`, `formatters/markdown.ts`,
+  all of `src/eval/` and `src/e2e/`; MCP `bin.ts` (the actual stdio entry
+  since #148 — `index.ts` is now the library entry). Plugin section omits
+  `hooks/`, `action.yml`, `examples/`, `.claude-plugin/marketplace.json`.
+- Everything else spot-checked accurate: 10 CLI commands, 7 tools/3
+  resources, version-coupling description, error-strategy and no-singleton
+  claims.
+
+## Suggested fix order
+
+1. A1 — refresh security overrides (unblocks CI).
+2. A2/A3 — the two silent data-loss bugs in `sync` and `results clear`.
+3. A4 + E2 — plugin agent YAML and skill name (plugin may be partly broken
+   for users today).
+4. E3 — README `npx -y` (first-run MCP hang for new users).
+5. D1, B1 — CI `permissions:` block; `action.yml` env-var input passing.
+6. The mediums in C (discovery gating, health cache versioning, gist push
+   safety, budget reservation) as a follow-up batch.
+7. Docs refresh (F, E9) — cheap, and CLAUDE.md guides future agent work.

--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -11,14 +11,20 @@ set -uo pipefail
 
 warn_and_exit() {
   local msg="$1"
+  # The message can carry formatter stderr and repo paths — repo-influenced
+  # text — so JSON-escape it (same jq pattern as session-start.sh) instead of
+  # splicing it into the decision JSON raw. jq is guaranteed here: every call
+  # site is after the jq availability check below.
+  local escaped
+  escaped=$(printf '%s' "Auto-format hook: ${msg}" | jq -Rrs '@json | .[1:-1]')
   cat <<WARN_EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "allow",
-    "permissionDecisionReason": "Auto-format hook: ${msg}"
+    "permissionDecisionReason": "${escaped}"
   },
-  "systemMessage": "Auto-format hook: ${msg}"
+  "systemMessage": "${escaped}"
 }
 WARN_EOF
   exit 0

--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -23,6 +23,8 @@ fi
 
 # Block `git push --force` (without --force-with-lease)
 # Match --force or -f but NOT --force-with-lease
+# This is a guardrail against accidental agent behavior, not a security
+# boundary: wrappers like `command git push -f` or `sh -c '...'` bypass it.
 if echo "$command" | grep -qE 'git\s+push\b' && echo "$command" | grep -qE '(\s--force\b|\s-f\b)' && ! echo "$command" | grep -qE '\s--force-with-lease'; then
   cat <<'EOF'
 {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,23 +8,22 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./types": {
-      "import": "./dist/core/types.js",
-      "types": "./dist/core/types.d.ts"
+      "types": "./dist/core/types.d.ts",
+      "import": "./dist/core/types.js"
     }
   },
   "files": [
     "dist/",
     "!dist/**/*.map",
-    "!dist/core/test-utils.*",
     "!dist/eval/**"
   ],
   "scripts": {
     "build": "tsc",
-    "bundle": "esbuild src/cli.ts --bundle --platform=node --target=node20 --format=cjs --minify --sourcemap --outfile=dist/cli.bundle.cjs",
+    "bundle": "esbuild src/cli.ts --bundle --platform=node --target=node20 --format=cjs --minify --outfile=dist/cli.bundle.cjs",
     "start": "tsx src/cli.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -28,6 +28,7 @@ import {
   saveLocalState,
 } from "./core/local-state.js";
 import { CONCRETE_STRATEGIES, SearchStrategySchema } from "./core/schemas.js";
+import { parseStrictInt } from "./commands/validation.js";
 import type { SearchStrategy } from "./core/schemas.js";
 
 function handleCommandError(err: unknown, options: { json?: boolean }): never {
@@ -193,8 +194,8 @@ program
           );
         }
         const { runSearch } = await import("./commands/search.js");
-        const maxResults = count ? parseInt(count, 10) : 10;
-        if (isNaN(maxResults) || maxResults < 1) {
+        const maxResults = count ? parseStrictInt(count, "count") : 10;
+        if (maxResults < 1) {
           throw new ValidationError("count must be a positive integer");
         }
         const state = loadLocalState();
@@ -296,16 +297,19 @@ program
     ) =>
       runAction(options, async () => {
         const { runFeatures } = await import("./commands/features.js");
-        const maxResults = count ? parseInt(count, 10) : 10;
-        if (isNaN(maxResults) || maxResults < 1 || maxResults > 50) {
+        const maxResults = count ? parseStrictInt(count, "count") : 10;
+        if (maxResults < 1 || maxResults > 50) {
           throw new ValidationError(
             "count must be an integer between 1 and 50",
           );
         }
         let anchorThreshold: number | undefined;
         if (options.anchorThreshold !== undefined) {
-          const parsed = parseInt(options.anchorThreshold, 10);
-          if (isNaN(parsed) || parsed < 1 || parsed > 50) {
+          const parsed = parseStrictInt(
+            options.anchorThreshold,
+            "--anchor-threshold",
+          );
+          if (parsed < 1 || parsed > 50) {
             throw new ValidationError(
               "--anchor-threshold must be an integer between 1 and 50",
             );
@@ -314,7 +318,8 @@ program
         }
         let splitRatio: number | undefined;
         if (options.splitRatio !== undefined) {
-          const parsed = Number.parseFloat(options.splitRatio);
+          // Number() rejects trailing garbage ("0.6abc"), unlike parseFloat.
+          const parsed = Number(options.splitRatio);
           if (isNaN(parsed) || parsed < 0 || parsed > 1) {
             throw new ValidationError(
               "--split-ratio must be a number between 0 and 1",
@@ -456,31 +461,32 @@ program
     "Re-vet all saved search results and classify their current status",
   )
   .option("--prune", "Remove unavailable issues from saved results")
-  .option(
-    "--concurrency <n>",
-    "Max concurrent API requests (default: 5)",
-    parseInt,
-  )
+  .option("--concurrency <n>", "Max concurrent API requests (default: 5)")
   .option("--json", "Output as JSON")
   .action(
     async (options: {
       prune?: boolean;
-      concurrency?: number;
+      concurrency?: string;
       json?: boolean;
     }) =>
       runAction(options, async () => {
-        if (
-          options.concurrency !== undefined &&
-          (isNaN(options.concurrency) || options.concurrency < 1)
-        ) {
-          throw new ValidationError("--concurrency must be a positive integer");
+        let concurrency: number | undefined;
+        if (options.concurrency !== undefined) {
+          // Parsed in the action (not a commander argParser) so a bad value
+          // honors the --json error contract instead of a raw parse error.
+          concurrency = parseStrictInt(options.concurrency, "--concurrency");
+          if (concurrency < 1) {
+            throw new ValidationError(
+              "--concurrency must be a positive integer",
+            );
+          }
         }
         const { runVetList } = await import("./commands/vet-list.js");
         const state = loadLocalState();
         const result = await runVetList({
           state,
           prune: options.prune,
-          concurrency: options.concurrency,
+          concurrency,
         });
         if (options.json) {
           console.log(formatJsonSuccess(result));

--- a/packages/core/src/commands/results.test.ts
+++ b/packages/core/src/commands/results.test.ts
@@ -18,6 +18,17 @@ vi.mock("../core/local-state.js", () => {
   };
 });
 
+// runResultsClear goes through withScout (tombstones, #276); keep token
+// discovery out of the tests so they never shell out to `gh auth token`.
+vi.mock("../core/utils.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    requireGitHubToken: () => "fake-token",
+    getGitHubToken: () => "fake-token",
+  };
+});
+
 // Import after mock setup
 const { runResults, runResultsClear } = await import("./results.js");
 
@@ -168,6 +179,22 @@ describe("results command", () => {
 
       const updated = await getMockState();
       expect(updated.savedResults).toEqual([]);
+    });
+
+    it("records deletion tombstones so a gist merge cannot resurrect cleared results (#276)", async () => {
+      const state = ScoutStateSchema.parse({ version: 1 });
+      state.savedResults = [
+        makeSavedCandidate({ issueUrl: "https://github.com/a/b/issues/1" }),
+        makeSavedCandidate({ issueUrl: "https://github.com/c/d/issues/2" }),
+      ];
+      await setMockState(state);
+
+      await runResultsClear();
+
+      const updated = await getMockState();
+      const tombstoned = (updated.tombstones ?? []).map((t: any) => t.url);
+      expect(tombstoned).toContain("https://github.com/a/b/issues/1");
+      expect(tombstoned).toContain("https://github.com/c/d/issues/2");
     });
 
     it("is a no-op when already empty", async () => {

--- a/packages/core/src/commands/results.ts
+++ b/packages/core/src/commands/results.ts
@@ -2,9 +2,10 @@
  * Results command — display and manage saved search results.
  */
 
-import { loadLocalState, saveLocalState } from "../core/local-state.js";
+import { loadLocalState } from "../core/local-state.js";
 import type { SavedCandidate } from "../core/schemas.js";
 import { ValidationError } from "../core/errors.js";
+import { withScout } from "./with-scout.js";
 
 export interface ResultsOptions {
   json?: boolean;
@@ -49,8 +50,18 @@ export async function runResults(
   });
 }
 
+/**
+ * Clear all saved results via the scout so deletion tombstones are recorded
+ * (#117). Writing an empty list straight to the local file skipped the
+ * tombstones, and the next gist merge (union by URL) resurrected every
+ * "cleared" result from the remote copy (#276). Mirrors runSkipClear.
+ */
 export async function runResultsClear(): Promise<void> {
-  const state = loadLocalState();
-  state.savedResults = [];
-  saveLocalState(state);
+  await withScout(
+    undefined,
+    (scout) => {
+      scout.clearResults();
+    },
+    { requireToken: false, persist: true },
+  );
 }

--- a/packages/core/src/commands/sync.test.ts
+++ b/packages/core/src/commands/sync.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ScoutStateSchema } from "../core/schemas.js";
+import type { ScoutState } from "../core/schemas.js";
+import type { SyncResult } from "../core/types.js";
+
+// Mock local-state module — factory must not reference top-level imports
+vi.mock("../core/local-state.js", () => {
+  let mockState: any = { version: 1 };
+  return {
+    loadLocalState: () => mockState,
+    saveLocalState: (state: any) => {
+      mockState = state;
+    },
+    hasLocalState: () => true,
+    _setMockState: (state: any) => {
+      mockState = state;
+    },
+    _getMockState: () => mockState,
+  };
+});
+
+vi.mock("../core/utils.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    requireGitHubToken: () => "fake-token",
+    getGitHubToken: () => "fake-token",
+  };
+});
+
+// Fake scout standing in for the CLI's provided-mode scout: checkpoint() is a
+// no-op that reports success, exactly like the real thing (#275).
+const syncResult: SyncResult = {
+  checked: 2,
+  merged: 1,
+  closed: 0,
+  stillOpen: 1,
+  errors: 0,
+};
+let scoutState: ScoutState;
+const fakeScout = {
+  syncOpenPRs: vi.fn(async () => {
+    scoutState.lastSearchAt = "2026-08-07T00:00:00.000Z";
+    return syncResult;
+  }),
+  getState: () => scoutState,
+  checkpoint: vi.fn(async () => true),
+};
+
+vi.mock("./command-scout.js", () => ({
+  buildCommandScout: async () => fakeScout,
+}));
+
+const { runSync } = await import("./sync.js");
+
+async function getMockState(): Promise<any> {
+  const mod = (await import("../core/local-state.js")) as any;
+  return mod._getMockState();
+}
+
+async function setMockState(state: any) {
+  const mod = (await import("../core/local-state.js")) as any;
+  mod._setMockState(state);
+}
+
+describe("runSync", () => {
+  beforeEach(async () => {
+    scoutState = ScoutStateSchema.parse({ version: 1 });
+    await setMockState(ScoutStateSchema.parse({ version: 1 }));
+    vi.clearAllMocks();
+  });
+
+  it("returns the sync result", async () => {
+    const result = await runSync();
+    expect(result).toEqual(syncResult);
+    expect(fakeScout.syncOpenPRs).toHaveBeenCalledOnce();
+  });
+
+  it("persists the scout's updated state to the local file (#275)", async () => {
+    // Regression: in the CLI's non-gist mode the scout is provided-mode, whose
+    // checkpoint() is a no-op returning true. Unless runSync asks withScout to
+    // persist, sync reports success while ~/.oss-scout/state.json is unchanged.
+    await runSync();
+    const persisted = await getMockState();
+    expect(persisted.lastSearchAt).toBe("2026-08-07T00:00:00.000Z");
+  });
+
+  it("still checkpoints for gist-mode scouts", async () => {
+    await runSync();
+    expect(fakeScout.checkpoint).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/commands/sync.ts
+++ b/packages/core/src/commands/sync.ts
@@ -11,6 +11,11 @@ import type { SyncResult } from "../core/types.js";
 export async function runSync(options?: {
   state?: ScoutState;
 }): Promise<SyncResult> {
-  // syncOpenPRs checkpoints itself, so withScout doesn't need to persist.
-  return withScout(options?.state, (scout) => scout.syncOpenPRs());
+  // syncOpenPRs checkpoints itself, but in the CLI's non-gist mode the scout
+  // is built with `persistence: "provided"`, where checkpoint() is a no-op —
+  // only withScout's persist epilogue writes ~/.oss-scout/state.json. Without
+  // it, sync reported success while discarding every update (#275).
+  return withScout(options?.state, (scout) => scout.syncOpenPRs(), {
+    persist: true,
+  });
 }

--- a/packages/core/src/commands/validation.test.ts
+++ b/packages/core/src/commands/validation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   validateUrl,
   validateGitHubUrl,
+  parseStrictInt,
   ISSUE_URL_PATTERN,
 } from "./validation.js";
 import { ValidationError } from "../core/errors.js";
@@ -132,5 +133,30 @@ describe("validation", () => {
         ),
       ).toBe(false);
     });
+  });
+});
+
+describe("parseStrictInt (#291)", () => {
+  it("parses a plain decimal integer", () => {
+    expect(parseStrictInt("50", "count")).toBe(50);
+    expect(parseStrictInt(" 7 ", "count")).toBe(7);
+  });
+
+  it("rejects trailing garbage that parseInt would accept", () => {
+    expect(() => parseStrictInt("50O", "count")).toThrow(ValidationError);
+    expect(() => parseStrictInt("5x", "count")).toThrow(
+      'count must be an integer (got "5x")',
+    );
+    expect(() => parseStrictInt("3abc", "--concurrency")).toThrow(
+      ValidationError,
+    );
+  });
+
+  it("rejects floats, negatives, and empty strings", () => {
+    expect(() => parseStrictInt("5.9", "--anchor-threshold")).toThrow(
+      ValidationError,
+    );
+    expect(() => parseStrictInt("-3", "count")).toThrow(ValidationError);
+    expect(() => parseStrictInt("", "count")).toThrow(ValidationError);
   });
 });

--- a/packages/core/src/commands/validation.ts
+++ b/packages/core/src/commands/validation.ts
@@ -20,6 +20,19 @@ export function validateGitHubUrl(
   );
 }
 
+/**
+ * Parse a strictly-decimal integer CLI argument. Bare parseInt accepts
+ * trailing garbage ("50O" → 50), silently running with a different value
+ * than the user typed (#291).
+ */
+export function parseStrictInt(value: string, label: string): number {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new ValidationError(`${label} must be an integer (got "${value}")`);
+  }
+  return parseInt(trimmed, 10);
+}
+
 export function validateUrl(url: string): string {
   if (url.length > MAX_URL_LENGTH) {
     throw new ValidationError(

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -57,6 +57,18 @@ export function getHttpStatusCode(error: unknown): number | undefined {
   return undefined;
 }
 
+/**
+ * True for errors resolveErrorCode classifies as AUTH_REQUIRED: a 401, or a
+ * 403 that is not a rate-limit/abuse condition (fine-grained-token "Resource
+ * not accessible", SAML enforcement, ...). Retrying other work with the same
+ * token cannot succeed, so batch loops should abort on these (#290).
+ */
+export function isAuthError(error: unknown): boolean {
+  const status = getHttpStatusCode(error);
+  if (status === 401) return true;
+  return status === 403 && !isRateLimitError(error);
+}
+
 export function isRateLimitError(error: unknown): boolean {
   const status = getHttpStatusCode(error);
   if (status === 429) return true;

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -784,6 +784,35 @@ describe("mergeStates", () => {
     expect(merged.skippedIssues.find((s) => s.url === url)).toBeDefined();
   });
 
+  it("drops tombstones with an unparseable removedAt instead of keeping them forever (#292)", () => {
+    // A corrupt removedAt never ages past the 90-day TTL and, compared
+    // lexically in applyTombstones, would suppress its URL on every merge.
+    const url = "https://github.com/a/b/issues/9";
+    const local = makeState({
+      tombstones: [{ url, removedAt: "zzz-not-a-date" }],
+    });
+    const remote = makeState({
+      savedResults: [
+        {
+          issueUrl: url,
+          repo: "a/b",
+          number: 9,
+          title: "t",
+          labels: [],
+          recommendation: "approve" as const,
+          viabilityScore: 80,
+          searchPriority: "normal",
+          firstSeenAt: "2026-06-01T00:00:00Z",
+          lastSeenAt: "2026-06-01T00:00:00Z",
+          lastScore: 80,
+        },
+      ],
+    });
+
+    const merged = mergeStates(local, remote);
+    expect(merged.tombstones.find((t) => t.url === url)).toBeUndefined();
+  });
+
   it("does not resurrect a skipped URL into saved results from remote (#117)", () => {
     // Local skipped an issue (which removes it from savedResults). Remote
     // still has it saved. The merge must not let the remote saved copy

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -503,6 +503,66 @@ describe("GistStateStore", () => {
       expect(update).not.toHaveBeenCalled();
     });
 
+    it("does not overwrite a remote whose content fails validation (#286)", async () => {
+      // The remote may hold a newer state version or recoverable corruption;
+      // push must fail (keeping the local cache) rather than clobber it.
+      const goodState = makeState();
+      const update = vi.fn().mockResolvedValue({ data: { id: "gist-1" } });
+      const get = vi
+        .fn()
+        // Bootstrap sees valid content so the store binds to gist-1...
+        .mockResolvedValueOnce(gistResponse(goodState, "gist-1"))
+        // ...but by push time the remote no longer parses.
+        .mockResolvedValue({
+          data: {
+            id: "gist-1",
+            files: { "state.json": { content: "{ not valid json" } },
+          },
+        });
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({
+          data: [{ id: "gist-1", description: "oss-scout-state" }],
+        }),
+        get,
+        update,
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      const localState = makeState({
+        preferences: { githubUsername: "local-only" },
+      });
+      const ok = await store.push(localState);
+
+      expect(ok).toBe(false);
+      expect(update).not.toHaveBeenCalled();
+      // Local cache still captured the change.
+      const cached = JSON.parse(
+        fs.readFileSync(path.join(tempDir, "state-cache.json"), "utf-8"),
+      );
+      expect(cached.preferences.githubUsername).toBe("local-only");
+    });
+
+    it("still pushes when the remote gist has no state file yet (missing ≠ invalid, #286)", async () => {
+      const update = vi.fn().mockResolvedValue({ data: { id: "gist-1" } });
+      const octokit = makeOctokit({
+        list: vi.fn().mockResolvedValue({ data: [] }),
+        create: vi.fn().mockResolvedValue({ data: { id: "gist-1" } }),
+        get: vi.fn().mockResolvedValue({
+          data: { id: "gist-1", files: {} },
+        }),
+        update,
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+
+      const ok = await store.push(makeState());
+      expect(ok).toBe(true);
+      expect(update).toHaveBeenCalled();
+    });
+
     it("merges the concurrent remote state before writing, not last-writer-wins (#117)", async () => {
       // A second machine pushed a merged PR the local copy never saw
       const remoteState = makeState({

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -451,8 +451,11 @@ function mergeTombstones(local: Tombstone[], remote: Tombstone[]): Tombstone[] {
     if (!existing || t.removedAt > existing.removedAt) byUrl.set(t.url, t);
   }
   return [...byUrl.values()].filter((t) => {
+    // An unparseable removedAt is dropped: keeping it (the old behavior)
+    // made it immortal — it never aged past the TTL and, compared lexically
+    // in applyTombstones, suppressed its URL on every merge forever (#292).
     const ts = new Date(t.removedAt).getTime();
-    return !Number.isFinite(ts) || ts >= cutoff;
+    return Number.isFinite(ts) && ts >= cutoff;
   });
 }
 

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -142,11 +142,28 @@ export class GistStateStore {
     // tombstones in mergeStates keep removals from resurfacing. A fetch
     // failure (not auth/rate-limit, which propagate) degrades to writing the
     // local snapshot, the prior best-effort behavior.
+    //
+    // Known limitation: the Gists API has no conditional update, so this
+    // read-merge-write has a small race window — two machines pushing
+    // near-simultaneously can drop additions made between the loser's fetch
+    // and write (tombstones protect only deletions). Union-merge keeps the
+    // window's blast radius to the most recent additions.
     let toWrite = state;
     try {
       const remote = await this.fetchGistState(this.gistId);
-      if (remote) {
-        toWrite = mergeStates(state, remote);
+      if (remote.kind === "ok") {
+        toWrite = mergeStates(state, remote.state);
+      } else if (remote.kind === "invalid") {
+        // The remote holds content this binary can't validate — possibly a
+        // newer state version or recoverable corruption. Overwriting would
+        // destroy it; mirror the bootstrap guard ("using local cache to
+        // avoid data loss") and report sync failure instead (#286).
+        this.writeCache(state);
+        warn(
+          MODULE,
+          "Remote gist content failed validation — not overwriting it. Changes saved locally; gist sync skipped.",
+        );
+        return false;
       }
     } catch (err) {
       rethrowIfFatal(err);
@@ -200,9 +217,9 @@ export class GistStateStore {
       debug(MODULE, `Trying cached gist ID: ${cachedId}`);
       try {
         const fetched = await this.fetchGistState(cachedId);
-        if (fetched) {
+        if (fetched.kind === "ok") {
           this.gistId = cachedId;
-          const state = this.mergeCacheInto(fetched);
+          const state = this.mergeCacheInto(fetched.state);
           this.writeCache(state);
           return { gistId: cachedId, state, created: false };
         }
@@ -225,8 +242,8 @@ export class GistStateStore {
       this.saveGistId(search.id);
       this.gistId = search.id;
       const fetched = await this.fetchGistState(search.id);
-      if (fetched) {
-        const state = this.mergeCacheInto(fetched);
+      if (fetched.kind === "ok") {
+        const state = this.mergeCacheInto(fetched.state);
         this.writeCache(state);
         return { gistId: search.id, state, created: false };
       }
@@ -286,17 +303,28 @@ export class GistStateStore {
 
   // ── Gist API operations ──────────────────────────────────────────────
 
-  private async fetchGistState(gistId: string): Promise<ScoutState | null> {
+  /**
+   * "missing" (no file/content) and "invalid" (content that fails parse or
+   * schema validation) are distinct outcomes: an invalid remote may be a
+   * corrupted-but-recoverable state or a newer state version written by a
+   * newer binary, so callers must not treat it as "nothing there" and
+   * overwrite it (#286).
+   */
+  private async fetchGistState(
+    gistId: string,
+  ): Promise<
+    { kind: "ok"; state: ScoutState } | { kind: "missing" } | { kind: "invalid" }
+  > {
     const { data } = await this.octokit.gists.get({ gist_id: gistId });
     const file = data.files?.[GIST_FILENAME];
-    if (!file?.content) return null;
+    if (!file?.content) return { kind: "missing" };
 
     try {
       const parsed = JSON.parse(file.content);
-      return parseScoutState(parsed);
+      return { kind: "ok", state: parseScoutState(parsed) };
     } catch (err) {
       warn(MODULE, `Gist content failed validation: ${errorMessage(err)}`);
-      return null;
+      return { kind: "invalid" };
     }
   }
 
@@ -543,7 +571,12 @@ function mergeRepoScores(
   local: Record<string, RepoScore>,
   remote: Record<string, RepoScore>,
 ): Record<string, RepoScore> {
-  const merged: Record<string, RepoScore> = { ...local };
+  // Null prototype: repo names are parsed record keys, so a "__proto__" key
+  // must land as an own property, not a prototype assignment.
+  const merged: Record<string, RepoScore> = Object.assign(
+    Object.create(null),
+    local,
+  );
   for (const [repo, remoteScore] of Object.entries(remote)) {
     const localScore = merged[repo];
     if (!localScore) {

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -313,7 +313,9 @@ export class GistStateStore {
   private async fetchGistState(
     gistId: string,
   ): Promise<
-    { kind: "ok"; state: ScoutState } | { kind: "missing" } | { kind: "invalid" }
+    | { kind: "ok"; state: ScoutState }
+    | { kind: "missing" }
+    | { kind: "invalid" }
   > {
     const { data } = await this.octokit.gists.get({ gist_id: gistId });
     const file = data.files?.[GIST_FILENAME];

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -794,6 +794,45 @@ describe("IssueDiscovery", () => {
       expect(strategiesUsed).toContain("maintained");
     });
 
+    it("still runs the non-Search phases when the REST Search quota is fully exhausted (#284)", async () => {
+      // remaining: 0 used to abort the entire search with zero candidates,
+      // even though Phase 0/1 bill the Core bucket and broad/maintained run
+      // on GraphQL. Only the starred phase should be skipped.
+      vi.mocked(checkRateLimit).mockResolvedValue({
+        remaining: 0,
+        limit: 30,
+        resetAt: new Date(Date.now() + 60000).toISOString(),
+      });
+
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [makeCandidate("org/merged", "merged_pr")],
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged"]),
+        getStarredRepos: vi.fn(() => ["org/starred"]),
+      });
+
+      const { candidates, strategiesUsed } = await discovery.searchIssues({
+        maxResults: 10,
+        interPhaseDelayMs: 0,
+        broadPhaseDelayMs: 0,
+      });
+
+      expect(candidates.length).toBeGreaterThan(0);
+      expect(strategiesUsed).toContain("merged");
+      expect(strategiesUsed).not.toContain("starred");
+      expect(strategiesUsed).toContain("broad");
+      expect(strategiesUsed).toContain("maintained");
+      // The end-of-run summary replaces the initial exhaustion warning with
+      // the fuller explanation of what was skipped.
+      expect(discovery.rateLimitWarning).toMatch(
+        /starred-repo phase was skipped/i,
+      );
+    });
+
     it("still runs Phases 2 and 3 when REST budget is low (<20) since they use GraphQL", async () => {
       // Broad/maintained now bill the GraphQL points bucket, not the REST
       // Search bucket, so a low REST budget must NOT gate them off anymore.

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -1030,6 +1030,25 @@ describe("IssueDiscovery", () => {
   });
 
   describe("searchIssues — filtering", () => {
+    it("filterIssues excludes issues with an unparseable updated_at (#289)", async () => {
+      // The REST adapters map a missing timestamp to "", whose NaN age used
+      // to bypass the maxAgeDays comparison (NaN > n is false).
+      const items: GitHubSearchItem[] = [
+        {
+          html_url: "https://github.com/some/repo/issues/1",
+          repository_url: "https://api.github.com/repos/some/repo",
+          updated_at: "",
+        },
+      ];
+      mockSearchAcrossLanguagesAndLabels.mockResolvedValue(items);
+
+      const discovery = makeDiscovery();
+
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(
+        "No issue candidates found",
+      );
+    });
+
     it("filterIssues excludes repos in excludeRepos", async () => {
       const items: GitHubSearchItem[] = [
         {

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -794,6 +794,36 @@ describe("IssueDiscovery", () => {
       expect(strategiesUsed).toContain("maintained");
     });
 
+    it("skips the starred phase when the rate-limit preflight fails (#288)", async () => {
+      // The fallback previously left searchBudget at 19 (>= critical), so no
+      // phase was skipped despite the "conservative budget" warning.
+      vi.mocked(checkRateLimit).mockRejectedValue(
+        Object.assign(new Error("boom"), { status: 500 }),
+      );
+
+      mockFetchIssuesFromKnownRepos.mockResolvedValue({
+        candidates: [makeCandidate("org/merged", "merged_pr")],
+        allReposFailed: false,
+        rateLimitHit: false,
+      });
+
+      const discovery = makeDiscovery({
+        getReposWithMergedPRs: vi.fn(() => ["org/merged"]),
+        getStarredRepos: vi.fn(() => ["org/starred"]),
+      });
+
+      const { strategiesUsed } = await discovery.searchIssues({
+        maxResults: 10,
+        interPhaseDelayMs: 0,
+        broadPhaseDelayMs: 0,
+      });
+
+      expect(strategiesUsed).toContain("merged");
+      expect(strategiesUsed).not.toContain("starred");
+      expect(strategiesUsed).toContain("broad");
+      expect(strategiesUsed).toContain("maintained");
+    });
+
     it("still runs the non-Search phases when the REST Search quota is fully exhausted (#284)", async () => {
       // remaining: 0 used to abort the entire search with zero candidates,
       // even though Phase 0/1 bill the Core bucket and broad/maintained run

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -684,9 +684,14 @@ export class IssueDiscovery {
     }
 
     if (searchBudget <= 0) {
+      // An exhausted REST Search bucket is no reason to abort the run:
+      // Phase 0/1 read the much larger Core API bucket and broad/maintained
+      // run on GraphQL (#284). The starred-phase gate below already skips the
+      // one budget-gated phase, and the tracker paces the remaining
+      // merge-stat search calls until the quota resets.
       this.rateLimitWarning =
-        "GitHub search API quota exhausted. Try again after the rate limit resets.";
-      return { candidates: [], strategiesUsed: [] };
+        "GitHub search API quota exhausted — skipping the starred phase; other phases don't use it.";
+      warn(MODULE, this.rateLimitWarning);
     }
 
     // Derive search context

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -136,7 +136,12 @@ function buildIssueFilter(
       if (config.aiBlocklisted.has(repoLower)) return false;
       if (config.lowScoringRepos.has(repoLower)) return false;
       if (config.skippedUrls.has(item.html_url)) return false;
+      // An unparseable updated_at (the adapters map a missing timestamp to
+      // "") makes daysBetween return NaN, and NaN > maxAgeDays is false — so
+      // undated issues sailed through the staleness filter (#289). Treat an
+      // unknown age as failing it.
       const updatedAt = new Date(item.updated_at);
+      if (Number.isNaN(updatedAt.getTime())) return false;
       const ageDays = daysBetween(updatedAt, config.now);
       if (ageDays > config.maxAgeDays) return false;
       if (!config.includeDocIssues && isDocOnlyIssue(item)) return false;

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -676,9 +676,13 @@ export class IssueDiscovery {
         CRITICAL_BUDGET_THRESHOLD,
         new Date(Date.now() + 60000).toISOString(),
       );
+      // Below the critical threshold so the starred-phase gate actually
+      // skips it — the fallback previously left searchBudget at 19, which
+      // passed the gate and made this log line a lie (#288).
+      searchBudget = CRITICAL_BUDGET_THRESHOLD - 1;
       warn(
         MODULE,
-        "Could not check rate limit — using conservative budget, skipping heavy phases:",
+        "Could not check rate limit — using conservative budget, skipping the starred phase:",
         errorMessage(error),
       );
     }

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -651,7 +651,10 @@ export class IssueDiscovery {
     // only this search's GraphQL query spend.
     resetGraphQLSearchQueryCount();
     const tracker = this.budgetTracker;
-    let searchBudget = LOW_BUDGET_THRESHOLD - 1;
+    // Fallback below the critical threshold so a failed preflight actually
+    // skips the starred phase — the old fallback of 19 passed the gate and
+    // made the "conservative budget" warning a lie (#288).
+    let searchBudget = CRITICAL_BUDGET_THRESHOLD - 1;
     try {
       const rateLimit = await checkRateLimit(this.githubToken);
       searchBudget = rateLimit.remaining;
@@ -681,10 +684,6 @@ export class IssueDiscovery {
         CRITICAL_BUDGET_THRESHOLD,
         new Date(Date.now() + 60000).toISOString(),
       );
-      // Below the critical threshold so the starred-phase gate actually
-      // skips it — the fallback previously left searchBudget at 19, which
-      // passed the gate and made this log line a lie (#288).
-      searchBudget = CRITICAL_BUDGET_THRESHOLD - 1;
       warn(
         MODULE,
         "Could not check rate limit — using conservative budget, skipping the starred phase:",

--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -470,6 +470,36 @@ describe("checkNotClaimed", () => {
     expect(result.passed).toBe(false);
   });
 
+  it("fetches one page past a full last page so fresh claims aren't missed (#293)", async () => {
+    // commentCount says 100 (1 page), but a claim landed as comment 101
+    // after the prefetch. The full page-1 response signals a possible
+    // page boundary crossing; the tail page must be fetched.
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      body: `comment ${i}`,
+    }));
+    const listComments = vi
+      .fn()
+      .mockResolvedValueOnce({ data: fullPage })
+      .mockResolvedValueOnce({ data: [{ body: "I'll take this issue" }] });
+    const octokit = makeCommentsOctokit(listComments);
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 100);
+    expect(listComments).toHaveBeenCalledTimes(2);
+    expect(listComments).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 2 }),
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it("does not fetch an extra page when the last page is short", async () => {
+    const listComments = vi
+      .fn()
+      .mockResolvedValue({ data: [{ body: "normal discussion" }] });
+    const octokit = makeCommentsOctokit(listComments);
+    const result = await checkNotClaimed(octokit, "owner", "repo", 1, 50);
+    expect(listComments).toHaveBeenCalledTimes(1);
+    expect(result.passed).toBe(true);
+  });
+
   it("returns passed:true and inconclusive:true on API error", async () => {
     const octokit = makeCommentsOctokit(
       vi.fn().mockRejectedValue(new Error("Network error")),

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -330,6 +330,22 @@ export async function checkNotClaimed(
       recentComments.push(...response.data);
     }
 
+    // commentCount comes from a prefetch that may be minutes old. If the
+    // computed last page came back full, comments may have crossed a page
+    // boundary since — exactly the busy issues where fresh claims land — so
+    // fetch one more page for the true tail (#293).
+    const lastFetched = recentComments.length % PER_PAGE;
+    if (recentComments.length > 0 && lastFetched === 0) {
+      const response = await octokit.issues.listComments({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        per_page: PER_PAGE,
+        page: lastPage + 1,
+      });
+      recentComments.push(...response.data);
+    }
+
     for (const comment of recentComments) {
       if (commentClaimsIssue(comment.body || "")) {
         return { passed: false };

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -4,6 +4,12 @@ import { calculateViabilityScore } from "./issue-scoring.js";
 
 // ── Mocks ──────────────────────────────────────────────────────────
 
+// Hoisted so both the errors-module mock's isRateLimitError and isAuthError
+// share one fn, keeping their classifications consistent when tests flip it.
+const mockIsRateLimitError = vi.hoisted(() =>
+  vi.fn((_e?: unknown) => false),
+);
+
 vi.mock("./logger.js", () => ({
   debug: vi.fn(),
   warn: vi.fn(),
@@ -43,7 +49,16 @@ vi.mock("./errors.js", () => ({
     }
     return undefined;
   }),
-  isRateLimitError: vi.fn(() => false),
+  isRateLimitError: mockIsRateLimitError,
+  // Mirrors the real classification, deferring to the mocked
+  // isRateLimitError so tests that flip it stay consistent (#290).
+  isAuthError: vi.fn((e: unknown) => {
+    const s =
+      e && typeof e === "object" && "status" in e
+        ? (e as { status: unknown }).status
+        : undefined;
+    return s === 401 || (s === 403 && !mockIsRateLimitError(e));
+  }),
   // No-op by default: the prefetch path (#169) calls this on a GraphQL error;
   // these tests exercise the REST fallback, so nothing here is fatal.
   rethrowIfFatal: vi.fn(),
@@ -960,6 +975,48 @@ describe("IssueVetter", () => {
           10,
         ),
       ).rejects.toThrow("Bad credentials");
+    });
+
+    it("propagates non-rate-limit 403s (SAML, token scope) like 401s (#290)", async () => {
+      // Previously only 401 aborted the batch; a SAML-enforcement 403 was
+      // counted as N per-item transient failures that burned the budget.
+      const samlErr = Object.assign(
+        new Error("Resource protected by organization SAML enforcement"),
+        { status: 403 },
+      );
+      const octokit = {
+        issues: { get: vi.fn().mockRejectedValue(samlErr) },
+      } as unknown as Octokit;
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      await expect(
+        vetter.vetIssuesParallel(
+          [
+            "https://github.com/owner/repo/issues/1",
+            "https://github.com/owner/repo/issues/2",
+          ],
+          10,
+        ),
+      ).rejects.toThrow("SAML enforcement");
+    });
+
+    it("does NOT abort the batch on a rate-limit 403", async () => {
+      mockIsRateLimitError.mockReturnValue(true);
+      const rlErr = Object.assign(new Error("API rate limit exceeded"), {
+        status: 403,
+      });
+      const octokit = {
+        issues: { get: vi.fn().mockRejectedValue(rlErr) },
+      } as unknown as Octokit;
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      const result = await vetter.vetIssuesParallel(
+        ["https://github.com/owner/repo/issues/1"],
+        10,
+      );
+      expect(result.rateLimitHit).toBe(true);
     });
   });
 

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -6,9 +6,7 @@ import { calculateViabilityScore } from "./issue-scoring.js";
 
 // Hoisted so both the errors-module mock's isRateLimitError and isAuthError
 // share one fn, keeping their classifications consistent when tests flip it.
-const mockIsRateLimitError = vi.hoisted(() =>
-  vi.fn((_e?: unknown) => false),
-);
+const mockIsRateLimitError = vi.hoisted(() => vi.fn((_e?: unknown) => false));
 
 vi.mock("./logger.js", () => ({
   debug: vi.fn(),

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -25,7 +25,7 @@ import {
 import {
   ValidationError,
   errorMessage,
-  getHttpStatusCode,
+  isAuthError,
   isRateLimitError,
 } from "./errors.js";
 import { debug, warn } from "./logger.js";
@@ -854,7 +854,10 @@ export class IssueVetter {
           }
         })
         .catch((error) => {
-          if (getHttpStatusCode(error) === 401) {
+          // Abort on anything resolveErrorCode calls AUTH_REQUIRED — 401 or a
+          // non-rate-limit 403 (SAML, token scope). Retrying the rest of the
+          // batch with the same token can only burn budget (#290).
+          if (isAuthError(error)) {
             firstAuthError ??= error;
             return;
           }

--- a/packages/core/src/core/preference-fields.ts
+++ b/packages/core/src/core/preference-fields.ts
@@ -17,6 +17,7 @@ import {
 } from "./schemas.js";
 import type { ScoutPreferences } from "./schemas.js";
 import { ValidationError } from "./errors.js";
+import { assertValidTriageHost } from "./slm-triage.js";
 
 export type FieldConfig =
   | { type: "array" | "number" | "float" | "boolean" | "string" }
@@ -171,6 +172,10 @@ export function applyPreferenceField(
 
   switch (field.type) {
     case "string":
+      // Issue text is POSTed to slmTriageHost during vetting, so it must
+      // stay a local/private address (#300). Validated here (not in the
+      // schema) so states persisted before this rule still parse.
+      if (key === "slmTriageHost") assertValidTriageHost(value);
       prefs[key] = value;
       break;
 

--- a/packages/core/src/core/repo-health.ts
+++ b/packages/core/src/core/repo-health.ts
@@ -15,7 +15,12 @@ import {
   rethrowIfFatal,
 } from "./errors.js";
 import { warn } from "./logger.js";
-import { getHttpCache, cachedRequest, cachedTimeBased } from "./http-cache.js";
+import {
+  getHttpCache,
+  cachedRequest,
+  cachedTimeBased,
+  versionedCacheKey,
+} from "./http-cache.js";
 import { probeRepoFile } from "./probe-repo-file.js";
 import {
   type SearchBudgetTracker,
@@ -128,7 +133,11 @@ export async function checkProjectHealth(
   tracker: SearchBudgetTracker = getSearchBudgetTracker(),
 ): Promise<ProjectHealth> {
   const cache = getHttpCache();
-  const healthCacheKey = `health:${owner}/${repo}`;
+  // Versioned (#158): the cached ProjectHealth is read back with an unchecked
+  // cast, and its shape has changed before (#248 added recentMergedPRCount) —
+  // a stale-shaped entry degraded every approve to needs_review for the
+  // cache TTL (#285).
+  const healthCacheKey = versionedCacheKey(`health:${owner}/${repo}`);
 
   try {
     return await cachedTimeBased(

--- a/packages/core/src/core/search-budget.test.ts
+++ b/packages/core/src/core/search-budget.test.ts
@@ -132,6 +132,51 @@ describe("SearchBudgetTracker", () => {
     await tracker.waitForBudget(); // must not hang
   });
 
+  describe("reservation (#287)", () => {
+    it("waitForBudget reserves the slot it grants until recordCall lands", async () => {
+      tracker.init(2, new Date(Date.now() + 60_000).toISOString());
+
+      await tracker.waitForBudget();
+      // One of the two external slots is now reserved by the in-flight call.
+      expect(tracker.canAfford(2)).toBe(false);
+      expect(tracker.canAfford(1)).toBe(true);
+
+      tracker.recordCall(); // converts the reservation into a recorded call
+      expect(tracker.canAfford(1)).toBe(true); // 2 - 1 recorded = 1 left
+      expect(tracker.canAfford(2)).toBe(false);
+    });
+
+    it("a second concurrent waiter blocks until the reserved call is recorded", async () => {
+      const { sleep } = await import("./utils.js");
+      vi.mocked(sleep).mockReset();
+      const realNow = Date.now();
+      // External quota of exactly 1: pre-fix, both waiters passed and the
+      // second call overshot into a real 429.
+      tracker.init(1, new Date(realNow + 30_000).toISOString());
+
+      await tracker.waitForBudget(); // first caller claims the only slot
+
+      let sleepCount = 0;
+      vi.mocked(sleep).mockImplementation(async () => {
+        sleepCount++;
+        if (sleepCount === 1) {
+          // First poll: the in-flight call lands, releasing the reservation
+          // but consuming the external quota.
+          tracker.recordCall();
+        } else {
+          // Later waits: advance the clock past the quota reset.
+          vi.spyOn(Date, "now").mockReturnValue(realNow + 31_000);
+        }
+      });
+
+      await tracker.waitForBudget();
+      // The second waiter had to wait (for the in-flight call, then for the
+      // quota reset) instead of sharing the first caller's slot.
+      expect(sleepCount).toBeGreaterThanOrEqual(2);
+      vi.restoreAllMocks();
+    });
+  });
+
   describe("external budget replenishment (#119)", () => {
     it("replenishes once resetAt passes and keeps the diagnostics counter", () => {
       const realNow = Date.now();

--- a/packages/core/src/core/search-budget.ts
+++ b/packages/core/src/core/search-budget.ts
@@ -44,6 +44,14 @@ export class SearchBudgetTracker {
   private callsSinceReset: number = 0;
 
   /**
+   * Slots handed out by waitForBudget() but not yet recorded. Without this,
+   * concurrent callers (vetting runs 3 tasks) could all pass waitForBudget()
+   * on an effective budget of 1 before any recordCall() landed, overshooting
+   * the external quota into real 429s (#287).
+   */
+  private reservedCalls: number = 0;
+
+  /**
    * Initialize with pre-flight rate limit data from GitHub.
    */
   init(remaining: number, resetAt: string): void {
@@ -52,6 +60,7 @@ export class SearchBudgetTracker {
     this.callTimestamps = [];
     this.totalCalls = 0;
     this.callsSinceReset = 0;
+    this.reservedCalls = 0;
     debug(
       MODULE,
       `Initialized: ${remaining} remaining, resets at ${new Date(this.resetAt).toLocaleTimeString()}`,
@@ -59,9 +68,12 @@ export class SearchBudgetTracker {
   }
 
   /**
-   * Record that a Search API call was just made.
+   * Record that a Search API call was just made. Releases the reservation
+   * taken by the preceding waitForBudget() (every call site pairs them, with
+   * recordCall in a finally).
    */
   recordCall(): void {
+    if (this.reservedCalls > 0) this.reservedCalls--;
     this.callTimestamps.push(Date.now());
     this.totalCalls++;
     this.callsSinceReset++;
@@ -111,9 +123,12 @@ export class SearchBudgetTracker {
   private getEffectiveBudget(): number {
     this.refreshExternalBudget();
     // Use the stricter of: local window limit vs. known remaining quota
-    // minus calls made since the last reset
-    const localBudget = EFFECTIVE_BUDGET - this.callTimestamps.length;
-    const externalBudget = this.knownRemaining - this.callsSinceReset;
+    // minus calls made since the last reset. Outstanding reservations count
+    // against both so concurrent waiters can't share one remaining slot.
+    const localBudget =
+      EFFECTIVE_BUDGET - this.callTimestamps.length - this.reservedCalls;
+    const externalBudget =
+      this.knownRemaining - this.callsSinceReset - this.reservedCalls;
     return Math.max(0, Math.min(localBudget, externalBudget));
   }
 
@@ -126,7 +141,9 @@ export class SearchBudgetTracker {
   }
 
   /**
-   * Wait if necessary to stay within the Search API rate limit.
+   * Wait if necessary to stay within the Search API rate limit, then reserve
+   * one call slot. The reservation is released by the paired recordCall(), so
+   * concurrent callers cannot all claim the same last remaining slot (#287).
    * If the sliding window is at capacity, sleeps until the oldest
    * call ages out of the window.
    */
@@ -137,12 +154,19 @@ export class SearchBudgetTracker {
       this.pruneOldTimestamps();
 
       if (this.getEffectiveBudget() > 0) {
+        this.reservedCalls++;
         return; // Budget available, no wait needed
       }
 
       // Wait until the oldest call in the window ages out
       const oldestInWindow = this.callTimestamps[0];
       if (!oldestInWindow) {
+        if (this.reservedCalls > 0) {
+          // Budget is consumed only by outstanding reservations; their calls
+          // will land shortly. Poll rather than waiting for the quota reset.
+          await sleep(250);
+          continue;
+        }
         // No calls in window — the external quota is exhausted. Wait for
         // GitHub's reset when we know it, otherwise proceed (#119).
         const untilReset = this.resetAt - Date.now();
@@ -154,6 +178,7 @@ export class SearchBudgetTracker {
           await sleep(untilReset + 100);
           continue;
         }
+        this.reservedCalls++;
         return;
       }
       const waitUntil = oldestInWindow + SEARCH_WINDOW_MS;

--- a/packages/core/src/core/slm-triage.test.ts
+++ b/packages/core/src/core/slm-triage.test.ts
@@ -178,11 +178,11 @@ describe("triageWithSLM", () => {
 
     await triageWithSLM(
       { issue: ISSUE, linkedPRExists: false },
-      { model: "gemma4:e4b", host: "http://example.test:99999", fetchImpl },
+      { model: "gemma4:e4b", host: "http://192.168.1.20:11434", fetchImpl },
     );
 
     expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
-      "http://example.test:99999/api/chat",
+      "http://192.168.1.20:11434/api/chat",
     );
   });
 
@@ -245,5 +245,59 @@ describe("buildTriageInput", () => {
       linkedPR: null,
     });
     expect(result.linkedPRExists).toBe(false);
+  });
+});
+
+describe("isAllowedTriageHost (#300)", () => {
+  it("allows localhost, loopback, and private-range hosts", async () => {
+    const { isAllowedTriageHost } = await import("./slm-triage.js");
+    for (const host of [
+      "http://localhost:11434",
+      "http://127.0.0.1:11434",
+      "https://10.0.0.5:11434",
+      "http://192.168.1.20:11434",
+      "http://172.16.0.1:11434",
+      "http://[::1]:11434",
+      "http://ollama-box:11434",
+      "http://my-server.local:11434",
+    ]) {
+      expect(isAllowedTriageHost(host), host).toBe(true);
+    }
+  });
+
+  it("rejects public hosts, bad schemes, and junk", async () => {
+    const { isAllowedTriageHost } = await import("./slm-triage.js");
+    for (const host of [
+      "http://evil.example.com:11434",
+      "https://attacker.io/api",
+      "http://8.8.8.8:11434",
+      "http://172.32.0.1:11434",
+      "ftp://127.0.0.1:11434",
+      "file:///etc/passwd",
+      "not a url",
+      "",
+    ]) {
+      expect(isAllowedTriageHost(host), host).toBe(false);
+    }
+  });
+
+  it("triageWithSLM fails open (null) on a disallowed host without fetching", async () => {
+    const { triageWithSLM } = await import("./slm-triage.js");
+    const fetchImpl = vi.fn();
+    const result = await triageWithSLM(
+      {
+        title: "t",
+        body: "b",
+        labels: [],
+        linkedPRExists: false,
+      },
+      {
+        model: "gemma",
+        host: "http://evil.example.com",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      },
+    );
+    expect(result).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/core/slm-triage.ts
+++ b/packages/core/src/core/slm-triage.ts
@@ -22,6 +22,10 @@
  *   Slower models simply produce `null` and don't block vetting.
  */
 import type { TrackedIssue, LinkedPR } from "./schemas.js";
+import { ValidationError } from "./errors.js";
+import { warn } from "./logger.js";
+
+const MODULE = "slm-triage";
 
 /** Default Ollama HTTP endpoint when not overridden. */
 const DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434";
@@ -103,6 +107,52 @@ function buildPrompt(input: SLMTriageInput): string {
 }
 
 /**
+ * Guard for user-configured Ollama hosts (#300): http(s) scheme and a
+ * local/private address only. Issue titles/bodies are POSTed to this host
+ * during vetting, so an arbitrary public URL would let a config change
+ * beacon fetched content off-machine.
+ */
+export function isAllowedTriageHost(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  const host = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "localhost" || host === "::1") return true;
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const a = Number(v4[1]);
+    const b = Number(v4[2]);
+    if (a === 127 || a === 10) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    return false;
+  }
+  if (host.includes(":")) {
+    // IPv6 literals: unique-local (fc00::/7) and link-local (fe80::/10).
+    return (
+      host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80")
+    );
+  }
+  // Single-label LAN hostnames ("ollama-box") and mDNS .local names.
+  return !host.includes(".") || host.endsWith(".local");
+}
+
+/**
+ * Throw a ValidationError unless the value is empty (use the default) or an
+ * allowed local/private Ollama host. Called by config-set (CLI + MCP).
+ */
+export function assertValidTriageHost(value: string): void {
+  if (value === "" || isAllowedTriageHost(value)) return;
+  throw new ValidationError(
+    `slmTriageHost must be an http(s) URL pointing at localhost or a private/LAN address (got "${value}"). Example: http://192.168.1.20:11434`,
+  );
+}
+
+/**
  * Run an SLM triage classification. Returns `null` on any failure path
  * — caller treats `null` as "no SLM signal available".
  */
@@ -113,6 +163,16 @@ export async function triageWithSLM(
   if (!options.model) return null;
 
   const host = options.host ?? DEFAULT_OLLAMA_HOST;
+  // Enforced at use time too, covering hosts written straight into
+  // state.json without going through config-set (#300). Fail open like
+  // every other triage failure path.
+  if (!isAllowedTriageHost(host)) {
+    warn(
+      MODULE,
+      `slmTriageHost "${host}" is not a local/private address; skipping SLM triage`,
+    );
+    return null;
+  }
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const fetchFn = options.fetchImpl ?? fetch;
 

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -94,6 +94,38 @@ describe("createScout", () => {
     expect(saved.mergedPRs).toHaveLength(1);
   });
 
+  it("local-mode checkpoint merges concurrent on-disk changes instead of clobbering them (#294)", async () => {
+    // A long-lived scout (the MCP server) checkpoints days after boot; any
+    // state.json change the CLI made in between must survive the write.
+    const scout = await createScout({ githubToken: "test-token" });
+    scout.recordMergedPR({
+      url: "https://github.com/o/r/pull/1",
+      title: "from scout",
+      mergedAt: "2026-01-01T00:00:00Z",
+      repo: "o/r",
+    });
+
+    // Simulate the CLI writing a different merged PR to disk after the
+    // scout booted.
+    localStateStore.current = ScoutStateSchema.parse({
+      version: 1,
+      mergedPRs: [
+        {
+          url: "https://github.com/o/r/pull/2",
+          title: "from CLI",
+          mergedAt: "2026-01-02T00:00:00Z",
+          repo: "o/r",
+        },
+      ],
+    });
+
+    expect(await scout.checkpoint()).toBe(true);
+    const saved = localStateStore.current as ScoutState;
+    const urls = saved.mergedPRs.map((p) => p.url);
+    expect(urls).toContain("https://github.com/o/r/pull/1");
+    expect(urls).toContain("https://github.com/o/r/pull/2");
+  });
+
   it("creates instance with provided state", async () => {
     const state = makeState({
       preferences: {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -1007,6 +1007,11 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
       // claimed success while saving nothing (#116). A failed write keeps
       // the dirty flag and reports failure.
       try {
+        // Reload-and-merge before writing: a long-lived scout (the MCP
+        // server runs for days) would otherwise last-writer-wins clobber
+        // state.json changes made by the CLI since boot (#294). The
+        // tombstone-aware merge preserves both sides, mirroring gist mode.
+        this.state = mergeStates(this.state, loadLocalState());
         saveLocalState(this.state);
       } catch {
         return false;

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,8 +8,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OssScout } from "@oss-scout/core";
+import { registerResources } from "./resources.js";
+
+function createMockScout(overrides: Partial<OssScout> = {}): OssScout {
+  return {
+    getPreferences: vi.fn().mockReturnValue({
+      languages: ["typescript"],
+      minStars: 50,
+    }),
+    getSavedResults: vi.fn().mockReturnValue([
+      {
+        issueUrl: "https://github.com/o/r/issues/1",
+        repo: "o/r",
+        viabilityScore: 80,
+      },
+    ]),
+    getState: vi.fn().mockReturnValue({
+      version: 1,
+      repoScores: {
+        "o/r": { mergedPRCount: 3, closedWithoutMergeCount: 0, score: 8 },
+      },
+    }),
+    ...overrides,
+  } as unknown as OssScout;
+}
+
+/**
+ * Extract the read callback for a given resource name from the McpServer spy.
+ * Registration signature: server.resource(name, uri, metadata, readCallback)
+ * — the callback is always the last argument.
+ */
+function getResourceHandler(
+  server: McpServer,
+  name: string,
+): (...args: unknown[]) => Promise<{
+  contents: Array<{ uri: string; mimeType: string; text: string }>;
+}> {
+  const calls = vi.mocked(server.resource).mock.calls;
+  const call = calls.find((c) => c[0] === name);
+  if (!call) throw new Error(`Resource "${name}" not registered`);
+  return call[call.length - 1] as (...args: unknown[]) => Promise<{
+    contents: Array<{ uri: string; mimeType: string; text: string }>;
+  }>;
+}
+
+describe("registerResources", () => {
+  let server: McpServer;
+  let scout: OssScout;
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    scout = createMockScout();
+    vi.spyOn(server, "resource");
+    registerResources(server, scout);
+  });
+
+  it("registers all three resources with their scout:// URIs", () => {
+    expect(server.resource).toHaveBeenCalledTimes(3);
+    const calls = vi.mocked(server.resource).mock.calls;
+    const byName = new Map(calls.map((c) => [c[0], c[1]]));
+    expect(byName.get("config")).toBe("scout://config");
+    expect(byName.get("results")).toBe("scout://results");
+    expect(byName.get("scores")).toBe("scout://scores");
+  });
+
+  it("scout://config returns the current preferences as JSON", async () => {
+    const read = getResourceHandler(server, "config");
+    const { contents } = await read();
+
+    expect(contents).toHaveLength(1);
+    expect(contents[0].uri).toBe("scout://config");
+    expect(contents[0].mimeType).toBe("application/json");
+    expect(JSON.parse(contents[0].text)).toEqual({
+      languages: ["typescript"],
+      minStars: 50,
+    });
+  });
+
+  it("scout://results returns the saved results as JSON", async () => {
+    const read = getResourceHandler(server, "results");
+    const { contents } = await read();
+
+    expect(contents[0].uri).toBe("scout://results");
+    const parsed = JSON.parse(contents[0].text);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].issueUrl).toBe("https://github.com/o/r/issues/1");
+  });
+
+  it("scout://scores returns the state's repoScores as JSON", async () => {
+    const read = getResourceHandler(server, "scores");
+    const { contents } = await read();
+
+    expect(contents[0].uri).toBe("scout://scores");
+    const parsed = JSON.parse(contents[0].text);
+    expect(parsed["o/r"].score).toBe(8);
+  });
+
+  it("reads reflect live scout state, not a boot-time snapshot", async () => {
+    // Resources must call through on every read; a captured snapshot would
+    // go stale as tools mutate the scout between reads.
+    const read = getResourceHandler(server, "results");
+    await read();
+    vi.mocked(scout.getSavedResults).mockReturnValue([]);
+    const { contents } = await read();
+    expect(JSON.parse(contents[0].text)).toEqual([]);
+    expect(scout.getSavedResults).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -250,6 +250,16 @@ describe("registerTools", () => {
       expect(scout.checkpoint).toHaveBeenCalled();
     });
 
+    it("returns a readable error for an invalid strategy, not a raw ZodError (#295)", async () => {
+      const handler = getToolHandler(server, "search");
+      const result = await handler({ strategies: "broad,bogus" }, {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid strategy "bogus"');
+      expect(result.content[0].text).toContain("merged");
+      expect(scout.search).not.toHaveBeenCalled();
+    });
+
     it("returns isError on failure", async () => {
       const errorScout = createMockScout({
         search: vi.fn().mockRejectedValue(new Error("API rate limited")),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -30,6 +30,12 @@ function withPersistWarning<T extends object>(payload: T, persisted: boolean) {
   return persisted ? payload : { ...payload, persistWarning: PERSIST_WARNING };
 }
 
+/**
+ * Rejects when `ms` elapses, but does NOT cancel the underlying work — the
+ * scout call keeps running (consuming API budget and mutating scout state)
+ * after the tool has returned its timeout error. Acceptable for a local
+ * stdio server; revisit with AbortSignal threading if it ever matters (#295).
+ */
 function withTimeout<T>(
   promise: Promise<T>,
   ms: number = TOOL_TIMEOUT_MS,
@@ -51,8 +57,11 @@ export function registerTools(server: McpServer, scout: OssScout): void {
     {
       maxResults: z
         .number()
+        .int()
+        .min(1)
+        .max(50)
         .optional()
-        .describe("Maximum number of results to return (default 10)"),
+        .describe("Maximum number of results to return (1-50, default 10)"),
       strategies: z
         .string()
         .optional()
@@ -102,10 +111,19 @@ export function registerTools(server: McpServer, scout: OssScout): void {
       diversityRatio,
     }) => {
       try {
+        // Validate each CSV entry with a readable error instead of letting a
+        // raw ZodError string reach the model (#295).
         const parsedStrategies = strategies
-          ? strategies
-              .split(",")
-              .map((s) => SearchStrategySchema.parse(s.trim()))
+          ? strategies.split(",").map((s) => {
+              const trimmed = s.trim();
+              const parsed = SearchStrategySchema.safeParse(trimmed);
+              if (!parsed.success) {
+                throw new Error(
+                  `Invalid strategy "${trimmed}". Valid strategies: ${SearchStrategySchema.options.join(", ")}`,
+                );
+              }
+              return parsed.data;
+            })
           : undefined;
 
         const result = await withTimeout(
@@ -155,8 +173,11 @@ export function registerTools(server: McpServer, scout: OssScout): void {
     {
       maxResults: z
         .number()
+        .int()
+        .min(1)
+        .max(50)
         .optional()
-        .describe("Maximum number of results to return (default 10)"),
+        .describe("Maximum number of results to return (1-50, default 10)"),
       anchorThreshold: z
         .number()
         .int()
@@ -315,6 +336,9 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         }
 
         if (action === "remove") {
+          // Deliberately no URL validation, matching the CLI's runSkipRemove:
+          // entries stored before skip-add validation existed may be junk,
+          // and exact-match removal is the only way to clean them up.
           const wasPresent = scout
             .getSkippedIssues()
             .some((s) => s.url === issueUrl);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,10 @@ settings:
 
 overrides:
   vite: '>=8.0.16'
-  hono: '>=4.12.25'
+  hono: '>=4.12.34'
   '@hono/node-server': '>=1.19.13'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
+  ip-address: '>=10.3.1'
 
 importers:
 
@@ -335,7 +336,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.25'
+      hono: '>=4.12.34'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -906,8 +907,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -984,8 +985,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+  hono@4.13.1:
+    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -1014,8 +1015,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1710,9 +1711,9 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.26)':
+  '@hono/node-server@1.19.14(hono@4.13.1)':
     dependencies:
-      hono: 4.12.26
+      hono: 4.13.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -1736,7 +1737,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.26)
+      '@hono/node-server': 1.19.14(hono@4.13.1)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -1746,7 +1747,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.26
+      hono: 4.13.1
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2087,7 +2088,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2308,7 +2309,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -2351,7 +2352,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2429,7 +2430,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.26: {}
+  hono@4.13.1: {}
 
   html-escaper@2.0.2: {}
 
@@ -2453,7 +2454,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,12 +13,17 @@ overrides:
   # Windows alternate paths (high). Patched in 8.0.16.
   vite: '>=8.0.16'
   # Transitive via packages/mcp-server -> @modelcontextprotocol/sdk -> hono.
-  # CORS middleware wildcard-with-credentials reflection (high). Patched in
-  # 4.12.25.
-  hono: '>=4.12.25'
+  # CORS wildcard-with-credentials reflection (4.12.25) plus five later
+  # advisories, all patched by 4.12.34.
+  hono: '>=4.12.34'
   # Transitive via @modelcontextprotocol/sdk. Pinned alongside hono.
   '@hono/node-server': '>=1.19.13'
-  # Transitive via @modelcontextprotocol/sdk -> ajv. Path traversal plus two
-  # host-confusion advisories (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6),
-  # all patched by 3.1.4.
-  fast-uri: '>=3.1.4'
+  # Transitive via @modelcontextprotocol/sdk -> ajv. Path traversal, two
+  # host-confusion advisories (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6,
+  # patched by 3.1.4), and the 4.x backslash-authority host confusion
+  # (GHSA-7p8r-x3mc-p8w7, patched by 4.1.2).
+  fast-uri: '>=4.1.2'
+  # Transitive via @modelcontextprotocol/sdk -> express-rate-limit. Leading-zero
+  # octet decode mismatch enabling SSRF/trust-boundary bypass
+  # (GHSA-mwp4-54f8-5fhr). Patched in 10.3.1.
+  ip-address: '>=10.3.1'

--- a/skills/oss-search/SKILL.md
+++ b/skills/oss-search/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: OSS Issue Search Best Practices
+name: oss-search
 description: This skill should be used when searching for open source issues, vetting contributions, interpreting viability scores, or planning a search strategy. Covers multi-strategy search, vetting workflow, and score interpretation.
 version: 1.1.0
 ---


### PR DESCRIPTION
Remediates every finding from the full repository audit (report included as `docs/audit-2026-08-07.md`). One commit per issue; merging closes #274 through #300.

## Highlights

**High severity**
- #274 — refresh security overrides (`fast-uri >=4.1.2`, `hono >=4.12.34`, add `ip-address >=10.3.1`); the blocking `pnpm audit --prod --audit-level=high` CI gate passes again
- #275 — `oss-scout sync` silently persisted nothing in the default local mode; now persists via `withScout({ persist: true })`
- #276 — `results clear` bypassed deletion tombstones, so cleared results resurrected from the gist on the next merge
- #277 — both plugin agent files had invalid YAML frontmatter (agents could fail to register)

**Core correctness**
- #284/#288 — discovery no longer aborts (or mis-reports) when the REST Search quota is exhausted or the rate-limit preflight fails; only the starred phase is gated
- #285 — `health:` cache key is schema-versioned per the #158 rule (stale entries degraded every vet for the 4h TTL after a shape change)
- #286/#292 — gist `push()` refuses to overwrite an unparseable remote; corrupt tombstones now age out
- #287 — `waitForBudget()` reserves the slot it grants, so 3 concurrent vetters can't overshoot an external budget of 1 into 429s
- #289 — invalid `updated_at` no longer bypasses the `maxAgeDays` filter via NaN
- #290 — vetting batches abort on non-rate-limit 403s (SAML/token scope), consistent with `resolveErrorCode`
- #291 — CLI numeric args reject trailing garbage (`search 50O` no longer runs as 50)
- #293 — `checkNotClaimed` fetches past a full last comment page so fresh claims aren't missed

**MCP / plugin / packaging**
- #294 — local-mode checkpoint reload-and-merges so a long-lived MCP server can't clobber interleaved CLI state changes
- #295/#296 — tighter tool schemas (bounded `maxResults`, readable strategy errors) and behavioral tests for the `scout://` resources
- #278/#297/#299 — skill name conforms to the lowercase-hyphen format, command fallbacks use `npm install --ignore-scripts`, tool allowlists scoped to what each surface runs
- #280 — `types` first in conditional exports; dangling sourcemap reference removed

**Hardening & docs**
- #281/#282 — `ci.yml` least-privilege permissions + concurrency; `action.yml` inputs passed via `env:` (no inline `${{ }}` in scripts), setup-node aligned, label-create failures surfaced
- #283 — auto-format hook JSON-escapes interpolated messages
- #300 — `slmTriageHost` restricted to local/private addresses at config-set and use time
- #279/#298 — README `npx -y` + missing config options; CLAUDE.md refreshed

## Verification

Full pipeline green locally: build, lint, format, typecheck, **1,173 tests** (1,135 core + 38 mcp, up from 1,144 with new regression coverage), bundle, and `pnpm audit --prod --audit-level=high`.

Note for merging: a **merge commit** (not squash) preserves the 27 conventional commits so release-please picks up each fix in the changelog and every `Fixes #N` trailer closes its issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017G3d3BNmNYdH3RLYoAkMh7

---
_Generated by [Claude Code](https://claude.ai/code/session_017G3d3BNmNYdH3RLYoAkMh7)_