### PR TITLE
fix: address all 15 findings from the round-2 audit

### DIFF
--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -1,7 +1,9 @@
 ---
 name: scout-setup
 description: Configure OSS Scout preferences for personalized issue discovery
-allowed-tools: Bash(node:*), Bash(gh:*), Bash(npm:*), Bash(cd:*), Read
+# Bash unscoped for the same reason as scout.md (#306): env-prefixed and
+# compound invocations never match Bash(prefix:*) rules.
+allowed-tools: Bash, Read
 ---
 
 # OSS Scout Setup

--- a/commands/scout.md
+++ b/commands/scout.md
@@ -1,10 +1,13 @@
 ---
 name: scout
 description: "Search for open source issues — multi-strategy search with vetting and viability scoring"
-# Scoped to what this command actually runs (defense-in-depth: it renders
-# attacker-authored issue text): the bundled CLI via node, gh auth/api, and
-# the npm build fallback. Anything else prompts the user.
-allowed-tools: Bash(node:*), Bash(gh:*), Bash(npm:*), Bash(cd:*), Read
+# Bash is deliberately unscoped: the command bodies use env-prefixed
+# invocations (GITHUB_TOKEN=$(gh auth token) node ...) and if/$() compounds
+# that prefix rules like Bash(node:*) never match, so scoping only produced
+# a permission prompt on every step (#306). The reduced surface from #299
+# stands: no Write/Edit/Task/Grep/Glob, and the untrusted-content section
+# below is the primary defense.
+allowed-tools: Bash, Read
 ---
 
 # OSS Scout — Issue Discovery

--- a/docs/audit-2026-08-07-round2.md
+++ b/docs/audit-2026-08-07-round2.md
@@ -1,0 +1,196 @@
+# Repository Audit, Round 2 — 2026-08-07
+
+Second-pass review of oss-scout at `71a7633` (post-release: core 1.5.1,
+mcp 0.10.1), after all 27 findings from the first audit
+(`docs/audit-2026-08-07.md`) were fixed via PR #301. This round had three
+angles: an adversarial review of the fix batch itself, a deep dive into
+modules the first audit did not examine closely, and a second-round
+security probe that actively tested bypasses instead of reading for them.
+
+## Baseline (verified by running everything)
+
+Build, lint, format, typecheck, 1,173 tests, bundle: all pass.
+`pnpm audit --prod --audit-level=high`: passes (3 low/moderate remain, all
+transitive via `@modelcontextprotocol/sdk`'s HTTP stack, which the
+stdio-only server never loads).
+
+## A. Regressions introduced by the round-1 fixes
+
+### A1. Local-mode checkpoint merge resurrects PRs that `sync` just removed — HIGH (verified)
+
+The #294 fix made local-mode `checkpoint()` run
+`mergeStates(this.state, loadLocalState())` (`scout.ts:1014`) before
+saving. But `mergeStates` merges `openPRs` with `unionByUrl`
+(`gist-state-store.ts:535,612-617`) and tombstones cover only
+`savedResults`/`skippedIssues` — removals from `openPRs` have no
+tombstone. `syncOpenPRs` sets `state.openPRs = remaining` then calls
+`checkpoint()` (`scout.ts:774-776`), which reloads the on-disk state that
+still lists the resolved PRs and unions them back in.
+
+**Impact:** in any `persistLocal` scout — notably the MCP server
+(`persistence: "local"`) — `openPRs` can never shrink. Every subsequent
+`sync` re-checks every resolved PR forever (one wasted API call each per
+run) and `getReposWithOpenPRs()` over-reports permanently: the exact #164
+bug, reintroduced for the MCP flow. 100% reproducible. The CLI is
+unaffected (provided mode saves without merging). The same union-based
+resurrection exists in gist `push()` but predates round 1.
+
+**Fix direction:** on `recordMergedPR`/`recordClosedPR`/sync-prune, either
+tombstone the removed open-PR URL (extend tombstones beyond
+savedResults/skips) or have `mergeStates` treat `openPRs` presence in
+`mergedPRs`/`closedPRs` as authoritative removal (a resolved PR must not
+reappear in `openPRs` — derivable without new state). The latter is
+self-healing for existing corrupted states.
+
+### A2. `results clear` hard-fails for gist-preference users without a token — MEDIUM (traced)
+
+The #276 fix routes `runResultsClear` through `withScout(...,
+{ requireToken: false, persist: true })`. In gist-preference mode,
+`buildCommandScout` constructs a gist scout with the empty token;
+`gistStore.bootstrap()` then runs unauthenticated and its 401
+**rethrows by design** (`gist-state-store.ts:124`) — `results clear`
+crashes with a raw Octokit 401 before clearing anything, where it was
+previously pure local file I/O. Even with a token, the command can now
+throw mid-run on a rate-limited push. `skip clear`/`skip remove` share
+this shape but predate round 1.
+
+**Fix direction:** for local-only mutations (`results clear`, skip ops),
+build a provided-mode scout over the local state and record tombstones
+there; let the next authenticated command push the tombstones to the
+gist. Or catch bootstrap 401 in this path and degrade to local-with-
+tombstones plus a warning.
+
+### A3. Batch auth-abort discards partial results on repo-scoped 403s — MEDIUM
+
+The #290 fix aborts `vetIssuesParallel` on any non-rate-limit 403. But
+such 403s are often **per-repo**, not token-global: SAML-SSO-enforced
+orgs, fine-grained PATs without a grant for one repo. One SSO-gated issue
+among ten candidates now throws away nine good vetted results and fails
+the whole search ("discarding partial results", `issue-vetting.ts:884`).
+The 401 case (token-global) is correctly aborted.
+
+**Fix direction:** distinguish scope: abort on 401 always; on bare 403,
+count per-repo failures and only abort if *every* attempted repo 403s (or
+after N distinct repos fail), otherwise skip the repo and keep the batch.
+
+### A4. Scoped command allowlists don't match the commands the bodies run — MEDIUM
+
+The #299 scoping set `allowed-tools: Bash(node:*), Bash(gh:*),
+Bash(npm:*), Bash(cd:*), Read`, but nearly every documented invocation is
+env-prefixed with command substitution (`GITHUB_TOKEN=$(gh auth token)
+node …`) or an `if`/`$( )` compound (the build fallback), which prefix
+rules do not match. Practical effect: `/scout` and `/scout-setup` likely
+prompt on every step instead of auto-running — safe, but the scoping is
+decorative and the UX regressed. Agent `tools` lists are fine.
+
+**Fix direction:** either restructure the command bodies so invocations
+are plain prefixes (export the token in a first approved step:
+`export GITHUB_TOKEN=$(gh auth token)` … then bare `node …` calls), or
+revert commands to unscoped `Bash` and keep the (working) agent scoping,
+documenting the tradeoff.
+
+### A5. Smaller notes on round-1 fixes — LOW
+
+- #288 residue: the preflight-failure fallback renders the fabricated
+  budget in user-facing text — "critically low API quota (4 remaining)"
+  when the preflight merely *failed*. Word the message as "quota unknown"
+  in that path (`issue-discovery.ts:657,943-946`).
+- #294 residue: preferences merge is whole-object last-stamp-wins, so the
+  fix protects list-shaped state but not interleaved preference edits
+  from two processes (no worse than before; noted for expectations). The
+  critical case — config-set clobbering its own fresh change — was traced
+  and is safe.
+- #295 note: `maxResults .max(50)` is a breaking MCP schema change vs.
+  1.5.0 clients, and the CLI has no matching upper bound — the two
+  surfaces disagree.
+- #300 residue: the host allowlist survived every bypass probe (hex/octal
+  /decimal IP forms, IPv4-mapped IPv6, userinfo tricks — tested, not just
+  read), but `fetch` follows redirects: an allowed private host can
+  307/308-redirect the issue-text POST to a public origin. Add
+  `redirect: "error"` to the triage fetch.
+- #274 watch item: overrides force `fast-uri@4.1.2` under `ajv` (declares
+  `^3`) and `ip-address@10.4.0` under `express-rate-limit` (pins 10.1.0
+  exactly). Verified working at runtime (ajv compiles/validates; server
+  imports cleanly), but keep in mind on SDK bumps. Also the
+  `@hono/node-server` pin (`>=1.19.13`) sits below its current advisory
+  (patched in 2.0.5) — unreachable (stdio-only), but the comment claims
+  coverage it no longer provides.
+
+### Verified clean (adversarially, in the fix batch)
+
+Sync double-persistence in gist mode (dirty-flag short-circuits), all six
+budget reservation call sites (recordCall in finally; no leak path),
+`canAfford` semantic change (no external callers), checkNotClaimed's
+extra-page heuristic (sound under GitHub pagination invariants), orphaned
+old-version health cache entries (GC'd by `evictStale`), null-prototype
+`repoScores` (survives stringify/spread/entries; no hasOwnProperty
+callers), `--concurrency` retype (also fixed a latent commander
+radix bug), gist invalid-remote guard, tombstone GC, hook JSON escaping,
+action.yml env passing, NaN age guard, strategies parsing, packaging.
+
+## B. New findings in previously-unaudited modules
+
+- **B1 (MEDIUM):** `scout features` ignores `excludeRepos` and
+  `aiPolicyBlocklist` on the anchor path, and `aiPolicyBlocklist` on the
+  broad path (`feature-discovery.ts:311-325`, `scout.ts:405-426`) — an
+  excluded or anti-LLM-blocklisted repo still yields feature candidates,
+  unlike the search path which filters both.
+- **B2 (MEDIUM):** markdown digest injection — `markdown.ts:9-11` escapes
+  only newlines and pipes, so an attacker-authored issue title can put a
+  live phishing link or tracking image into the digest issue that
+  `action.yml` posts. (Workflow-command injection was separately ruled
+  out: digest content goes to a file, never step stdout.) Escape inline
+  markdown (`[`, `]`, `(`, `)`, backticks, `!`, `<`) in table cells.
+- **B3 (LOW/MEDIUM):** `splitByHorizon` doesn't clamp `ratio`
+  (`feature-discovery.ts:104-106`) — library callers passing >1 can make
+  `features()` return more than `count` (CLI/zod paths validate; the
+  public API doesn't).
+- **B4 (LOW):** bootstrap reports `starredRepoCount` from the partial
+  in-memory list even when the fetch failed and nothing was saved
+  (`bootstrap.ts:71-94,222`); similarly `reposScoredCount` counts
+  pre-existing scores, masking a fully-failed run.
+- **B5 (LOW):** interactive setup accepts silently-dropped invalid
+  multi-select tokens, unbounded/negative `minStars`, and an empty
+  username that then dead-ends bootstrap (`setup.ts:87-194`).
+- **B6 (LOW):** roadmap's bare-`#N` regex matches hex colors and
+  code-fence content (`roadmap.ts:85`) — `color: #333` marks issue 333
+  as on-roadmap (bucket placement only; score unaffected).
+
+### Verified clean (new-module sweep)
+
+personalization boost/penalty arithmetic and comparator transitivity,
+diversity-slot math (clamped, exact fill), scoring NaN paths, filtering
+regexes, linked-PR thresholds, http-cache in-flight dedup (rejections
+evicted; no stuck-failure caching), local-state atomicity + corrupt-file
+backup, github throttle/retry interplay, pagination termination, command
+persist coverage, human formatter, eval exclusion from the published
+package.
+
+## C. Security round 2 — no high/critical
+
+All round-1 fixes hold under active probing. Tested (not just read):
+IP-form bypasses of the triage-host guard (hex/octal/decimal/IPv4-mapped
+IPv6 — all defeated; WHATWG URL normalization strengthens the check),
+prototype pollution through `parseScoutState` and `mergeStates` (clean),
+gist push to a non-owned gist (fails safely, no cross-user write),
+`npm pack --dry-run` contents (dist-only, no fixtures/secrets; grep for
+token patterns in eval fixtures clean), action.yml stdout paths (no
+untrusted content reaches step stdout, so no workflow-command injection).
+
+Low/informational: `@hono/node-server` pin below current advisory with a
+stale comment (unreachable — stdio only); `session-start.sh` version gate
+is prefix-anchored only (`^[0-9]+\.` without `$`) — harmless today
+because everything downstream is jq-escaped, but tighten to
+`^[0-9]+(\.[0-9]+)+$`; single-label/`.local` triage hosts remain allowed
+by design (needs local config access to abuse) — worth a comment.
+
+## Suggested fix order
+
+1. A1 — the openPRs resurrection regression (breaks MCP sync compounding).
+2. A3 — repo-scoped 403 abort (kills whole searches on one SSO repo).
+3. A2 — `results clear`/skip-ops crash for tokenless gist users.
+4. B2 — digest markdown escaping (outward-facing content).
+5. B1 — features honoring excludeRepos/aiPolicyBlocklist.
+6. A4 — command allowlist restructuring (UX).
+7. The lows: A5 batch (message wording, redirect: "error", override
+   comment), B3-B6, session-start version-gate anchor.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -67,7 +67,9 @@ if [ -n "$CURRENT" ]; then
     # the releases API is publish-date ordered, not version ordered, so
     # take the semver max of the core releases specifically (#146)
     LATEST=$(gh api repos/costajohnt/oss-scout/releases --jq '.[].tag_name' 2>/dev/null | sed -n 's/^core-v//p' | sort -V | tail -1 || echo "")
-    if [ -n "$LATEST" ] && echo "$LATEST" | grep -qE '^[0-9]+\.'; then
+    # Fully anchored: the tag text comes from the releases API, so accept
+    # only a bare semver — nothing after the last number (#316).
+    if [ -n "$LATEST" ] && echo "$LATEST" | grep -qE '^[0-9]+(\.[0-9]+)+$'; then
       touch "$LAST_CHECK"
       # Nag only when the release is strictly newer than the local version;
       # inequality alone nagged users running ahead of the latest release

--- a/packages/core/src/commands/command-scout.test.ts
+++ b/packages/core/src/commands/command-scout.test.ts
@@ -26,6 +26,21 @@ describe("buildCommandScout (#115)", () => {
     });
   });
 
+  it("degrades gist mode to provided when no token is available (#304)", async () => {
+    // Unauthenticated gist bootstrap 401s by design, which crashed
+    // local-only commands (results clear, skip ops) for gist users.
+    const state = ScoutStateSchema.parse({
+      version: 1,
+      preferences: { persistence: "gist" },
+    });
+    await buildCommandScout(state, "");
+    expect(createScoutMock).toHaveBeenCalledWith({
+      githubToken: "",
+      persistence: "provided",
+      initialState: state,
+    });
+  });
+
   it("uses provided mode (local file) when the preference is local", async () => {
     const state = ScoutStateSchema.parse({
       version: 1,

--- a/packages/core/src/commands/command-scout.ts
+++ b/packages/core/src/commands/command-scout.ts
@@ -8,6 +8,7 @@
  */
 import type { ScoutState } from "../core/schemas.js";
 import { createScout, type OssScout } from "../scout.js";
+import { warn } from "../core/logger.js";
 
 /**
  * Build a scout for a CLI command from already-loaded local state and a token.
@@ -18,13 +19,26 @@ import { createScout, type OssScout } from "../scout.js";
  *   file fresh as an offline cache.
  * - otherwise → provided-state scout backed by the local file. The command's
  *   `saveLocalState` + `checkpoint()` persist locally.
+ *
+ * Gist mode requires a token: unauthenticated gist bootstrap 401s and that
+ * error propagates by design, which crashed local-only commands (results
+ * clear, skip ops) for gist-preference users running without a token (#304).
+ * With no token, degrade to provided mode — changes land in the local file
+ * and the bootstrap-time merge syncs them to the gist on the next
+ * authenticated command (tombstones included, so deletions propagate too).
  */
 export async function buildCommandScout(
   state: ScoutState,
   token: string,
 ): Promise<OssScout> {
   if (state.preferences.persistence === "gist") {
-    return createScout({ githubToken: token, persistence: "gist" });
+    if (token) {
+      return createScout({ githubToken: token, persistence: "gist" });
+    }
+    warn(
+      "command-scout",
+      "No GitHub token available — changes will be saved locally and synced to the gist on the next authenticated command.",
+    );
   }
   return createScout({
     githubToken: token,

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -90,6 +90,17 @@ function parseMultiSelect<T extends string>(
 ): T[] {
   if (!input) return [];
   const selected = parseCSV(input);
+  // Say which tokens were dropped instead of silently ignoring a typo —
+  // "smal" quietly meaning "all scopes" was indistinguishable from
+  // success (#314).
+  const unrecognized = selected.filter(
+    (s) => !(options as readonly string[]).includes(s),
+  );
+  if (unrecognized.length > 0) {
+    console.error(
+      `  (ignoring unrecognized value(s): ${unrecognized.join(", ")} — valid: ${options.join(", ")})`,
+    );
+  }
   return selected.filter((s): s is T =>
     (options as readonly string[]).includes(s),
   );
@@ -130,6 +141,13 @@ export async function runSetup(
       : "GitHub username: ";
     const usernameInput = await ask(rl, usernamePrompt);
     const githubUsername = usernameInput || usernameDefault;
+    if (!githubUsername) {
+      // Saving an empty username used to dead-end the very next bootstrap
+      // with "Run `oss-scout setup` first" — a confusing loop (#314).
+      console.error(
+        "  ⚠ No GitHub username set — `oss-scout bootstrap` and personalized search won't work until you run `oss-scout config set githubUsername <login>`.",
+      );
+    }
 
     // Languages
     const defaultLangs = "any (all languages)";
@@ -159,9 +177,12 @@ export async function runSetup(
       ? parseMultiSelect(scopeInput, ALL_SCOPES)
       : [...ALL_SCOPES];
 
-    // Minimum stars
+    // Minimum stars — floor at 0 so a typo like "-5" can't persist (#314).
     const minStarsInput = await ask(rl, "Minimum repo stars [50]: ");
-    const minStars = minStarsInput ? parseInt(minStarsInput, 10) : 50;
+    const minStarsParsed = minStarsInput ? parseInt(minStarsInput, 10) : 50;
+    const minStars = Number.isNaN(minStarsParsed)
+      ? 50
+      : Math.max(0, minStarsParsed);
 
     // Project categories
     const categoryOptions = ALL_CATEGORIES.join(", ");
@@ -191,7 +212,7 @@ export async function runSetup(
       scope: scope.length > 0 ? scope : undefined,
       excludeRepos,
       projectCategories,
-      minStars: isNaN(minStars) ? 50 : minStars,
+      minStars,
       slmTriageModel,
     });
 

--- a/packages/core/src/core/bootstrap.ts
+++ b/packages/core/src/core/bootstrap.ts
@@ -69,6 +69,12 @@ export async function bootstrapScout(
 
   // 1. Fetch starred repos (up to 500)
   const starredRepos: string[] = [];
+  // Only counts what was actually saved: a mid-pagination failure used to
+  // report the partial in-memory length even though nothing persisted (#313).
+  let starredRepoSavedCount = 0;
+  // Repos whose score this run touched — the returned reposScoredCount used
+  // to be the whole pre-existing map, masking fully-failed runs (#313).
+  const reposScoredThisRun = new Set<string>();
   try {
     let starredPage = 0;
     for await (const response of octokit.paginate.iterator(
@@ -87,6 +93,7 @@ export async function bootstrapScout(
     }
     debug(MODULE, `Fetched ${starredRepos.length} starred repos`);
     scout.setStarredRepos(starredRepos);
+    starredRepoSavedCount = starredRepos.length;
   } catch (err) {
     rethrowIfFatal(err);
     warn(MODULE, `Failed to fetch starred repos: ${errorMessage(err)}`);
@@ -122,6 +129,7 @@ export async function bootstrapScout(
           mergedAt: item.closed_at ?? new Date().toISOString(),
           repo,
         });
+        reposScoredThisRun.add(repo);
         mergedPRCount++;
       }
 
@@ -163,6 +171,7 @@ export async function bootstrapScout(
           closedAt: item.closed_at ?? new Date().toISOString(),
           repo,
         });
+        reposScoredThisRun.add(repo);
         closedPRCount++;
       }
 
@@ -216,15 +225,12 @@ export async function bootstrapScout(
     errors.push("open PR fetch failed");
   }
 
-  const state = scout.getState();
-  const reposScoredCount = Object.keys(state.repoScores).length;
-
   return {
-    starredRepoCount: starredRepos.length,
+    starredRepoCount: starredRepoSavedCount,
     mergedPRCount,
     closedPRCount,
     openPRCount,
-    reposScoredCount,
+    reposScoredCount: reposScoredThisRun.size,
     skippedDueToRateLimit: false,
     errors,
   };

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -340,6 +340,36 @@ describe("discoverFeatures orchestrator", () => {
     expect(octokit.issues.listForRepo).not.toHaveBeenCalled();
   });
 
+  it("filters anchors against excludeRepos/excludeOrgs/aiPolicyBlocklist (#307)", async () => {
+    const octokit = {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    } as never;
+    const vetter = { vetIssue: vi.fn() } as never;
+    const result = await discoverFeatures({
+      octokit,
+      vetter,
+      repoScores: mkScores(
+        ["Excluded/Repo", 5],
+        ["blocked/llm", 5],
+        ["badorg/thing", 5],
+        ["good/repo", 5],
+      ),
+      count: 10,
+      excludeRepos: ["excluded/repo"],
+      excludeOrgs: ["badorg"],
+      aiPolicyBlocklist: ["blocked/llm"],
+    });
+    expect(result.anchorRepos).toEqual(["good/repo"]);
+    // Only the surviving anchor was queried.
+    const calls = (
+      octokit.issues.listForRepo as ReturnType<typeof vi.fn>
+    ).mock.calls.map((c: [{ owner: string; repo: string }]) => c[0]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ owner: "good", repo: "repo" });
+  });
+
   it("returns no-results message when anchors exist but no feature issues found", async () => {
     const octokit = {
       issues: {
@@ -944,6 +974,39 @@ describe("discoverFeaturesBroad", () => {
     expect(result.biggerBets).toHaveLength(1);
     expect(result.anchorRepos).toEqual([]);
     expect(result.message).toBeNull();
+  });
+
+  it("filters aiPolicyBlocklist repos out of broad results (#307)", async () => {
+    const item = (repo: string, n: number) => ({
+      html_url: `https://github.com/${repo}/issues/${n}`,
+      title: `feature ${n}`,
+      labels: [{ name: "enhancement" }],
+      comments: 1,
+      reactions: { total_count: 1 },
+      milestone: null,
+      pull_request: undefined,
+      assignee: null,
+      created_at: "2026-04-01",
+      number: n,
+    });
+    const search = vi.fn().mockResolvedValue({
+      data: { items: [item("Blocked/LLM", 1), item("good/repo", 2)] },
+    });
+    const octokit = { search: { issuesAndPullRequests: search } } as never;
+    const vetter = makeVetter();
+
+    await discoverFeaturesBroad({
+      octokit,
+      vetter,
+      count: 10,
+      aiPolicyBlocklist: ["blocked/llm"],
+    });
+
+    const vettedUrls = (
+      (vetter as { vetIssue: ReturnType<typeof vi.fn> }).vetIssue
+    ).mock.calls.map((c: [string]) => c[0]);
+    expect(vettedUrls).toHaveLength(1);
+    expect(vettedUrls[0]).toContain("good/repo");
   });
 
   it("fans out per language and dedups across queries (#121)", async () => {

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -269,6 +269,21 @@ describe("splitByHorizon 60/40 split", () => {
     mkCand("b5", 80, "bigger-bet"),
   ];
 
+  it("clamps out-of-range ratios so the result never exceeds count (#312)", () => {
+    const over = splitByHorizon([...quickWinPool, ...biggerBetPool], 10, 1.5);
+    expect(over.quickWins.length + over.biggerBets.length).toBeLessThanOrEqual(
+      10,
+    );
+    // ratio 1.5 clamps to 1: all-quick allocation.
+    expect(over.quickWins).toHaveLength(8);
+    expect(over.biggerBets).toHaveLength(2);
+
+    const under = splitByHorizon([...quickWinPool, ...biggerBetPool], 10, -1);
+    expect(
+      under.quickWins.length + under.biggerBets.length,
+    ).toBeLessThanOrEqual(10);
+  });
+
   it("returns 6 quick + 4 bigger when count=10 and both abundant", () => {
     const out = splitByHorizon([...quickWinPool, ...biggerBetPool], 10);
     expect(out.quickWins).toHaveLength(6);

--- a/packages/core/src/core/feature-discovery.test.ts
+++ b/packages/core/src/core/feature-discovery.test.ts
@@ -1018,8 +1018,8 @@ describe("discoverFeaturesBroad", () => {
     });
 
     const vettedUrls = (
-      (vetter as { vetIssue: ReturnType<typeof vi.fn> }).vetIssue
-    ).mock.calls.map((c: [string]) => c[0]);
+      vetter as { vetIssue: ReturnType<typeof vi.fn> }
+    ).vetIssue.mock.calls.map((c: [string]) => c[0]);
     expect(vettedUrls).toHaveLength(1);
     expect(vettedUrls[0]).toContain("good/repo");
   });

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -101,7 +101,11 @@ export function splitByHorizon(
     .filter((c) => c.horizon === "bigger-bet")
     .sort((a, b) => b.viabilityScore - a.viabilityScore);
 
-  const targetQuick = Math.round(count * ratio);
+  // Clamp: the public library API validates nothing, and an out-of-range
+  // ratio made targetBigger negative and the result exceed count (#312).
+  // Same pattern as applyDiversityRatio.
+  const clampedRatio = Math.max(0, Math.min(1, ratio));
+  const targetQuick = Math.round(count * clampedRatio);
   const targetBigger = count - targetQuick;
 
   const quickTaken = Math.min(allQuick.length, targetQuick);

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -18,7 +18,7 @@ import type { IssueCandidate } from "./types.js";
 import type { IssueVetter } from "./issue-vetting.js";
 import { errorMessage, rethrowIfFatal } from "./errors.js";
 import { warn } from "./logger.js";
-import { sleep } from "./utils.js";
+import { sleep, extractRepoFromUrl } from "./utils.js";
 import { fetchRoadmapIssueRefs } from "./roadmap.js";
 import { cachedSearchIssues } from "./search-phases.js";
 
@@ -211,6 +211,39 @@ export interface DiscoverFeaturesOptions {
   anchorThreshold?: number;
   /** Override default split ratio (0.6 = 60% quick wins, 40% bigger bets). */
   splitRatio?: number;
+  /** Repos the user excluded — anchors must honor them like search does (#307). */
+  excludeRepos?: string[];
+  /** Orgs the user excluded (#307). */
+  excludeOrgs?: string[];
+  /** Repos with anti-AI contribution policies (#307). */
+  aiPolicyBlocklist?: string[];
+}
+
+/**
+ * Case-insensitive repo/org exclusion shared by both feature paths (#307).
+ * The search pipeline has always honored excludeRepos/excludeOrgs/
+ * aiPolicyBlocklist; feature discovery previously bypassed all three on the
+ * anchor path and the blocklist on the broad path.
+ */
+function buildRepoExclusionFilter(opts: {
+  excludeRepos?: string[];
+  excludeOrgs?: string[];
+  aiPolicyBlocklist?: string[];
+}): (repoFullName: string) => boolean {
+  const excluded = new Set(
+    [...(opts.excludeRepos ?? []), ...(opts.aiPolicyBlocklist ?? [])].map(
+      (r) => r.toLowerCase(),
+    ),
+  );
+  const excludedOrgs = new Set(
+    (opts.excludeOrgs ?? []).map((o) => o.toLowerCase()),
+  );
+  return (repoFullName: string): boolean => {
+    const lower = repoFullName.toLowerCase();
+    if (excluded.has(lower)) return false;
+    const org = lower.split("/")[0];
+    return !(org && excludedOrgs.has(org));
+  };
 }
 
 interface RawIssueItem {
@@ -308,7 +341,11 @@ async function vetAndClassify(
 export async function discoverFeatures(
   opts: DiscoverFeaturesOptions,
 ): Promise<FeatureSearchResult> {
-  const anchorRepos = resolveAnchorRepos(opts.repoScores, opts.anchorThreshold);
+  const includeRepo = buildRepoExclusionFilter(opts);
+  const anchorRepos = resolveAnchorRepos(
+    opts.repoScores,
+    opts.anchorThreshold,
+  ).filter(includeRepo);
   if (anchorRepos.length === 0) {
     return {
       quickWins: [],
@@ -388,6 +425,8 @@ export interface DiscoverFeaturesBroadOptions {
   languages?: string[];
   excludeRepos?: string[];
   excludeOrgs?: string[];
+  /** Repos with anti-AI contribution policies, filtered post-search (#307). */
+  aiPolicyBlocklist?: string[];
   /** Override default split ratio. */
   splitRatio?: number;
   /** Maximum search results to vet (default 30). */
@@ -505,8 +544,16 @@ export async function discoverFeaturesBroad(
         merged.push(raw);
       }
     }
+    // The queries already carry -repo:/-org: exclusions; the blocklist is
+    // filtered here instead so it can't blow GitHub's query-length/operator
+    // limits, and the post-filter also backstops the query path (#307).
+    const includeRepo = buildRepoExclusionFilter(opts);
     items = merged
       .filter((it) => !it.pull_request && !it.assignee && isFeatureIssue(it))
+      .filter((it) => {
+        const repo = extractRepoFromUrl(it.html_url);
+        return repo === null || includeRepo(repo);
+      })
       .slice(0, maxToVet);
   } catch (err: unknown) {
     rethrowIfFatal(err);

--- a/packages/core/src/core/feature-discovery.ts
+++ b/packages/core/src/core/feature-discovery.ts
@@ -235,8 +235,8 @@ function buildRepoExclusionFilter(opts: {
   aiPolicyBlocklist?: string[];
 }): (repoFullName: string) => boolean {
   const excluded = new Set(
-    [...(opts.excludeRepos ?? []), ...(opts.aiPolicyBlocklist ?? [])].map(
-      (r) => r.toLowerCase(),
+    [...(opts.excludeRepos ?? []), ...(opts.aiPolicyBlocklist ?? [])].map((r) =>
+      r.toLowerCase(),
     ),
   );
   const excludedOrgs = new Set(

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -784,6 +784,35 @@ describe("mergeStates", () => {
     expect(merged.skippedIssues.find((s) => s.url === url)).toBeDefined();
   });
 
+  it("does not resurrect a resolved PR into openPRs (#303)", () => {
+    // Sync recorded PR A as merged and pruned it from openPRs; the other
+    // side (on-disk copy in local mode, or another machine's gist) still
+    // lists A as open. The union must not bring it back.
+    const url = "https://github.com/a/b/pull/5";
+    const local = makeState({
+      openPRs: [],
+      mergedPRs: [{ url, title: "t", mergedAt: "2026-06-02T00:00:00Z" }],
+    });
+    const remote = makeState({
+      openPRs: [{ url, title: "t", openedAt: "2026-06-01T00:00:00Z" }],
+    });
+
+    const merged = mergeStates(local, remote);
+    expect(merged.openPRs.find((p) => p.url === url)).toBeUndefined();
+    expect(merged.mergedPRs.find((p) => p.url === url)).toBeDefined();
+
+    // Same for closed-without-merge, and symmetric (remote resolved).
+    const local2 = makeState({
+      openPRs: [{ url, title: "t", openedAt: "2026-06-01T00:00:00Z" }],
+    });
+    const remote2 = makeState({
+      openPRs: [],
+      closedPRs: [{ url, title: "t", closedAt: "2026-06-02T00:00:00Z" }],
+    });
+    const merged2 = mergeStates(local2, remote2);
+    expect(merged2.openPRs.find((p) => p.url === url)).toBeUndefined();
+  });
+
   it("drops tombstones with an unparseable removedAt instead of keeping them forever (#292)", () => {
     // A corrupt removedAt never ages past the 90-day TTL and, compared
     // lexically in applyTombstones, would suppress its URL on every merge.

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -517,6 +517,23 @@ export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
     remotePrefsTs,
   );
 
+  // A resolved PR must never reappear as open. openPRs removals carry no
+  // tombstone, so the plain union resurrected PRs that sync had just
+  // recorded as merged/closed — in local mode this meant openPRs could
+  // never shrink and every sync re-checked every resolved PR forever
+  // (#303). Presence in the merged mergedPRs/closedPRs is authoritative
+  // removal; this also self-heals states corrupted before the fix.
+  const mergedPRsFinal = unionByUrl(local.mergedPRs, remote.mergedPRs);
+  const closedPRsFinal = unionByUrl(local.closedPRs, remote.closedPRs);
+  const resolvedUrls = new Set([
+    ...mergedPRsFinal.map((p) => p.url),
+    ...closedPRsFinal.map((p) => p.url),
+  ]);
+  const openPRsFinal = unionByUrl(
+    local.openPRs ?? [],
+    remote.openPRs ?? [],
+  ).filter((p) => !resolvedUrls.has(p.url));
+
   return {
     ...local,
     ...remote,
@@ -530,9 +547,9 @@ export function mergeStates(local: ScoutState, remote: ScoutState): ScoutState {
       local.starredReposLastFetched,
       remote.starredReposLastFetched,
     ),
-    mergedPRs: unionByUrl(local.mergedPRs, remote.mergedPRs),
-    closedPRs: unionByUrl(local.closedPRs, remote.closedPRs),
-    openPRs: unionByUrl(local.openPRs ?? [], remote.openPRs ?? []),
+    mergedPRs: mergedPRsFinal,
+    closedPRs: closedPRsFinal,
+    openPRs: openPRsFinal,
     savedResults: savedResultsFinal,
     skippedIssues,
     lastSearchAt: pickFresherTimestamp(local.lastSearchAt, remote.lastSearchAt),

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -655,6 +655,9 @@ export class IssueDiscovery {
     // skips the starred phase — the old fallback of 19 passed the gate and
     // made the "conservative budget" warning a lie (#288).
     let searchBudget = CRITICAL_BUDGET_THRESHOLD - 1;
+    // Tracked so the summary says "quota unknown" instead of presenting the
+    // fabricated fallback number as a real reading (#309).
+    let preflightFailed = false;
     try {
       const rateLimit = await checkRateLimit(this.githubToken);
       searchBudget = rateLimit.remaining;
@@ -680,6 +683,7 @@ export class IssueDiscovery {
       }
     } catch (error) {
       if (getHttpStatusCode(error) === 401) throw error;
+      preflightFailed = true;
       tracker.init(
         CRITICAL_BUDGET_THRESHOLD,
         new Date(Date.now() + 60000).toISOString(),
@@ -942,7 +946,9 @@ export class IssueDiscovery {
     // means the starred phase was dropped, not the heavy broad/maintained ones.
     const phasesSkippedForBudget = searchBudget < CRITICAL_BUDGET_THRESHOLD;
     const budgetNote = phasesSkippedForBudget
-      ? ` The starred-repo phase was skipped due to critically low API quota (${searchBudget} remaining); broad and maintained phases still ran on GraphQL.`
+      ? preflightFailed
+        ? " The starred-repo phase was skipped as a precaution because the rate-limit check failed (quota unknown); broad and maintained phases still ran on GraphQL."
+        : ` The starred-repo phase was skipped due to critically low API quota (${searchBudget} remaining); broad and maintained phases still ran on GraphQL.`
       : "";
 
     if (allCandidates.length === 0) {

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -975,9 +975,7 @@ describe("IssueVetter", () => {
       ).rejects.toThrow("Bad credentials");
     });
 
-    it("propagates non-rate-limit 403s (SAML, token scope) like 401s (#290)", async () => {
-      // Previously only 401 aborted the batch; a SAML-enforcement 403 was
-      // counted as N per-item transient failures that burned the budget.
+    it("surfaces an auth error when every attempted vet is forbidden (#290/#305)", async () => {
       const samlErr = Object.assign(
         new Error("Resource protected by organization SAML enforcement"),
         { status: 403 },
@@ -993,10 +991,62 @@ describe("IssueVetter", () => {
           [
             "https://github.com/owner/repo/issues/1",
             "https://github.com/owner/repo/issues/2",
+            "https://github.com/owner/repo/issues/3",
+            "https://github.com/owner/repo/issues/4",
+            "https://github.com/owner/repo/issues/5",
           ],
           10,
         ),
       ).rejects.toThrow("SAML enforcement");
+      // Once the first 403 settles, the repo is skipped — at most the first
+      // concurrent wave (MAX_CONCURRENT_VETTING = 3) is attempted, not all 5.
+      expect(
+        (octokit.issues.get as ReturnType<typeof vi.fn>).mock.calls.length,
+      ).toBeLessThanOrEqual(3);
+    });
+
+    it("keeps partial results when a bare 403 is repo-scoped (#305)", async () => {
+      // owner1's org enforces SAML; owner2 vets fine. The batch must return
+      // owner2's candidate instead of discarding everything.
+      const samlErr = Object.assign(
+        new Error("Resource protected by organization SAML enforcement"),
+        { status: 403 },
+      );
+      const goodIssue = {
+        data: {
+          id: 123,
+          html_url: "https://github.com/owner2/repo/issues/9",
+          title: "Fix the bug",
+          body: "1. Steps\n2. Expected\n```js\ncode\n```",
+          comments: 0,
+          labels: [{ name: "bug" }],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-03-01T00:00:00Z",
+        },
+      };
+      const octokit = {
+        issues: {
+          get: vi.fn().mockImplementation(({ owner }: { owner: string }) =>
+            owner === "owner1"
+              ? Promise.reject(samlErr)
+              : Promise.resolve(goodIssue),
+          ),
+        },
+        graphql: vi.fn().mockResolvedValue({}),
+      } as unknown as Octokit;
+
+      const stateReader = makeStubStateReader();
+      const vetter = new IssueVetter(octokit, stateReader);
+      const result = await vetter.vetIssuesParallel(
+        [
+          "https://github.com/owner1/repo/issues/1",
+          "https://github.com/owner2/repo/issues/9",
+        ],
+        10,
+      );
+      expect(result.candidates).toHaveLength(1);
+      expect(result.candidates[0].issue.repo).toBe("owner2/repo");
+      expect(result.allFailed).toBe(false);
     });
 
     it("does NOT abort the batch on a rate-limit 403", async () => {

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -1026,11 +1026,13 @@ describe("IssueVetter", () => {
       };
       const octokit = {
         issues: {
-          get: vi.fn().mockImplementation(({ owner }: { owner: string }) =>
-            owner === "owner1"
-              ? Promise.reject(samlErr)
-              : Promise.resolve(goodIssue),
-          ),
+          get: vi
+            .fn()
+            .mockImplementation(({ owner }: { owner: string }) =>
+              owner === "owner1"
+                ? Promise.reject(samlErr)
+                : Promise.resolve(goodIssue),
+            ),
         },
         graphql: vi.fn().mockResolvedValue({}),
       } as unknown as Octokit;

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -25,6 +25,7 @@ import {
 import {
   ValidationError,
   errorMessage,
+  getHttpStatusCode,
   isAuthError,
   isRateLimitError,
 } from "./errors.js";
@@ -802,6 +803,14 @@ export class IssueVetter {
     // the token is invalid and no other issue will succeed either —
     // continuing to log per-issue warnings buries the actual problem.
     let firstAuthError: unknown = null;
+    // Bare (non-rate-limit) 403s are frequently repo-scoped — SAML-enforced
+    // orgs, fine-grained PATs without a grant for one repo — so they must
+    // not abort the batch and discard good results (#305). Skip further
+    // issues from the forbidden repo; only if every attempted vet was
+    // forbidden do we surface it as an auth failure (dead token).
+    let firstForbiddenError: unknown = null;
+    let forbiddenCount = 0;
+    const forbiddenRepos = new Set<string>();
 
     // Dedup defensively: the pending map is keyed by URL, so a duplicate
     // input would overwrite the in-flight entry and its finally-cleanup
@@ -840,6 +849,12 @@ export class IssueVetter {
     for (const url of uniqueUrls) {
       if (candidates.length >= maxResults) break;
       if (firstAuthError) break; // stop scheduling once auth has failed
+      const parsedUrl = parseGitHubUrl(url);
+      const repoKey = parsedUrl ? `${parsedUrl.owner}/${parsedUrl.repo}` : null;
+      if (repoKey && forbiddenRepos.has(repoKey)) {
+        debug(MODULE, `Skipping ${url}: repo already returned 403`);
+        continue;
+      }
       attemptedCount++;
 
       const core = prefetchFor(url);
@@ -854,11 +869,24 @@ export class IssueVetter {
           }
         })
         .catch((error) => {
-          // Abort on anything resolveErrorCode calls AUTH_REQUIRED — 401 or a
-          // non-rate-limit 403 (SAML, token scope). Retrying the rest of the
-          // batch with the same token can only burn budget (#290).
-          if (isAuthError(error)) {
+          // A 401 is token-global: no other issue can succeed, so stop the
+          // batch (#290).
+          if (getHttpStatusCode(error) === 401) {
             firstAuthError ??= error;
+            return;
+          }
+          // A bare 403 is treated as repo-scoped (#305): skip this repo's
+          // remaining issues but keep vetting the rest of the batch.
+          if (isAuthError(error)) {
+            firstForbiddenError ??= error;
+            forbiddenCount++;
+            failedVettingCount++;
+            if (repoKey) forbiddenRepos.add(repoKey);
+            warn(
+              MODULE,
+              `Access forbidden for ${url} (SAML/token scope?) — skipping this repo:`,
+              errorMessage(error),
+            );
             return;
           }
           failedVettingCount++;
@@ -888,6 +916,17 @@ export class IssueVetter {
         );
       }
       throw firstAuthError;
+    }
+
+    // Every attempted vet was forbidden — that's not repo-scoped, the token
+    // is effectively dead for this search. Surface it as the auth error it
+    // is instead of an empty result (#305).
+    if (
+      firstForbiddenError &&
+      attemptedCount > 0 &&
+      forbiddenCount === attemptedCount
+    ) {
+      throw firstForbiddenError;
     }
 
     const allFailed =

--- a/packages/core/src/core/roadmap.test.ts
+++ b/packages/core/src/core/roadmap.test.ts
@@ -33,6 +33,23 @@ describe("parseRoadmapIssueRefs", () => {
     expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([99]));
   });
 
+  it("ignores #N inside fenced code blocks and inline code (#315)", () => {
+    const md = [
+      "Theme:",
+      "```css",
+      ".header { color: #333; }",
+      "```",
+      "Also `border: #666` inline.",
+      "- but do fix #77",
+    ].join("\n");
+    expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([77]));
+  });
+
+  it("resumes scanning after a code fence closes", () => {
+    const md = "```\n#111\n```\n- track #22\n";
+    expect(parseRoadmapIssueRefs(md, "a", "b")).toEqual(new Set([22]));
+  });
+
   it("extracts in-repo GitHub issue URLs", () => {
     const md =
       "See https://github.com/foo/bar/issues/1 and https://github.com/Foo/BAR/issues/2 for context.";

--- a/packages/core/src/core/roadmap.ts
+++ b/packages/core/src/core/roadmap.ts
@@ -79,9 +79,20 @@ export function parseRoadmapIssueRefs(
   // strip out `owner/repo#N` matches first so `#N` in a cross-repo ref to
   // a different repo doesn't leak in as a bare match.
   const fullRefStripPattern = /\b[\w.-]+\/[\w.-]+#\d+\b/gi;
+  // Skip fenced code blocks and inline code spans: `color: #333` in a code
+  // sample is a hex color, not issue 333 (#315). A prose-level 3-digit
+  // color outside code remains indistinguishable — accepted residual.
+  let inFence = false;
   for (const line of content.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
     if (/^\s*#+\s/.test(line)) continue;
-    const stripped = line.replace(fullRefStripPattern, "");
+    const stripped = line
+      .replace(fullRefStripPattern, "")
+      .replace(/`[^`]*`/g, "");
     for (const m of stripped.matchAll(/(?:^|[^&\w])#(\d+)\b/g)) {
       const n = Number.parseInt(m[1], 10);
       if (n > 0) refs.add(n);

--- a/packages/core/src/core/slm-triage.ts
+++ b/packages/core/src/core/slm-triage.ts
@@ -138,6 +138,10 @@ export function isAllowedTriageHost(raw: string): boolean {
     );
   }
   // Single-label LAN hostnames ("ollama-box") and mDNS .local names.
+  // Known residual (#310): a single-label name can resolve off-host through
+  // a DNS search domain, and .local via a hostile mDNS responder — both
+  // require an attacker who can already write this config (local access),
+  // so they are accepted by design.
   return !host.includes(".") || host.endsWith(".local");
 }
 
@@ -189,6 +193,10 @@ export async function triageWithSLM(
         options: { temperature: 0.1 },
       }),
       signal: AbortSignal.timeout(timeoutMs),
+      // No redirect following: an allowed private host could otherwise
+      // 307/308-redirect the issue-text POST body to a public origin (#310).
+      // Ollama never redirects, so this costs nothing.
+      redirect: "error",
     });
   } catch {
     // Connection refused, timeout, DNS error, etc.

--- a/packages/core/src/formatters/markdown.test.ts
+++ b/packages/core/src/formatters/markdown.test.ts
@@ -48,4 +48,33 @@ describe("formatResultsMarkdown (#170)", () => {
     // Exactly the 5 column separators (no extra unescaped pipe from the title).
     expect(row.match(/(?<!\\)\|/g)).toHaveLength(6);
   });
+
+  it("neutralizes markdown injection in attacker-authored titles (#308)", () => {
+    const md = formatResultsMarkdown([
+      candidate({
+        title:
+          "Fix [update your token](https://phish.example) ![](https://evil/p.png) <details>",
+      }),
+    ]);
+    const row = md.split("\n").find((l) => l.includes("[#1]"))!;
+    // Brackets/parens/bang/angle-brackets are escaped, so no injected link,
+    // image, or HTML can render.
+    expect(row).toContain("\\[update your token\\]\\(https://phish.example\\)");
+    expect(row).toContain("\\!\\[\\]");
+    expect(row).toContain("\\<details\\>");
+    expect(row).not.toMatch(/(?<!\\)\[update your token\](?!\\)/);
+  });
+
+  it("renders the title as a link to the real issue (suppresses autolinks)", () => {
+    const md = formatResultsMarkdown([
+      candidate({ title: "See https://evil.example now" }),
+    ]);
+    const row = md.split("\n").find((l) => l.includes("[#1]"))!;
+    // Title text sits inside a link to the real issue URL; GFM does not
+    // autolink inside link text, so the pasted URL stays inert.
+    expect(row).toContain("](https://github.com/owner/repo/issues/1) |");
+    expect(row).toMatch(
+      /\[See https:\/\/evil\.example now\]\(https:\/\/github\.com\/owner\/repo\/issues\/1\)/,
+    );
+  });
 });

--- a/packages/core/src/formatters/markdown.ts
+++ b/packages/core/src/formatters/markdown.ts
@@ -5,9 +5,17 @@
 
 import type { SavedCandidate } from "../core/schemas.js";
 
-/** Escape pipe and newline so a title can't break the markdown table. */
+/**
+ * Escape markdown so an attacker-authored issue title renders as inert text
+ * (#308). The digest is posted as a GitHub issue body by action.yml, so an
+ * unescaped title could plant live links, images, or HTML in the user's
+ * trusted digest. Newlines and pipes also keep the table intact.
+ */
 function cell(value: string): string {
-  return value.replace(/\r?\n/g, " ").replace(/\|/g, "\\|").trim();
+  return value
+    .replace(/\r?\n/g, " ")
+    .replace(/[\\`*_[\]()!<>~|]/g, "\\$&")
+    .trim();
 }
 
 /**
@@ -27,7 +35,11 @@ export function formatResultsMarkdown(results: SavedCandidate[]): string {
   const divider = "| ----- | ---- | ----- | -------------- | ----- |";
   const rows = sorted.map((r) => {
     const issueLink = `[#${r.number}](${r.issueUrl})`;
-    return `| ${r.viabilityScore} | ${cell(r.repo)} | ${issueLink} | ${cell(r.recommendation)} | ${cell(r.title)} |`;
+    // Title rendered as a link to the real issue: GFM does not process
+    // autolinks inside link text, so a bare URL pasted into a title can't
+    // become a clickable phishing link either (#308).
+    const titleLink = `[${cell(r.title)}](${r.issueUrl})`;
+    return `| ${r.viabilityScore} | ${cell(r.repo)} | ${issueLink} | ${cell(r.recommendation)} | ${titleLink} |`;
   });
 
   return [

--- a/packages/core/src/scout.test.ts
+++ b/packages/core/src/scout.test.ts
@@ -126,6 +126,28 @@ describe("createScout", () => {
     expect(urls).toContain("https://github.com/o/r/pull/2");
   });
 
+  it("local-mode checkpoint does not resurrect a PR that was just resolved (#303)", async () => {
+    // The on-disk state still lists the PR as open (written before this
+    // process resolved it); the checkpoint merge must not union it back.
+    const url = "https://github.com/o/r/pull/7";
+    localStateStore.current = ScoutStateSchema.parse({
+      version: 1,
+      openPRs: [{ url, title: "t", openedAt: "2026-06-01T00:00:00Z" }],
+    });
+    const scout = await createScout({ githubToken: "test-token" });
+    scout.recordMergedPR({
+      url,
+      title: "t",
+      mergedAt: "2026-06-02T00:00:00Z",
+      repo: "o/r",
+    });
+
+    expect(await scout.checkpoint()).toBe(true);
+    const saved = localStateStore.current as ScoutState;
+    expect(saved.openPRs.find((p) => p.url === url)).toBeUndefined();
+    expect(saved.mergedPRs.find((p) => p.url === url)).toBeDefined();
+  });
+
   it("creates instance with provided state", async () => {
     const state = makeState({
       preferences: {

--- a/packages/core/src/scout.ts
+++ b/packages/core/src/scout.ts
@@ -410,6 +410,7 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
           languages: this.state.preferences.languages,
           excludeRepos: this.state.preferences.excludeRepos,
           excludeOrgs: this.state.preferences.excludeOrgs,
+          aiPolicyBlocklist: this.state.preferences.aiPolicyBlocklist,
           splitRatio:
             options?.splitRatio ?? this.state.preferences.featuresSplitRatio,
         })
@@ -418,6 +419,9 @@ export class OssScout implements ScoutStateReader, ScoutStateWriter {
           vetter,
           repoScores: this.state.repoScores ?? {},
           count,
+          excludeRepos: this.state.preferences.excludeRepos,
+          excludeOrgs: this.state.preferences.excludeOrgs,
+          aiPolicyBlocklist: this.state.preferences.aiPolicyBlocklist,
           anchorThreshold:
             options?.anchorThreshold ??
             this.state.preferences.featuresAnchorThreshold,

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -59,9 +59,12 @@ export function registerTools(server: McpServer, scout: OssScout): void {
         .number()
         .int()
         .min(1)
-        .max(50)
+        // 100, not 50: the CLI's search count is unbounded, so a tight MCP
+        // cap made the two surfaces disagree for 1.5.0 clients while still
+        // needing SOME ceiling against absurd values (#317).
+        .max(100)
         .optional()
-        .describe("Maximum number of results to return (1-50, default 10)"),
+        .describe("Maximum number of results to return (1-100, default 10)"),
       strategies: z
         .string()
         .optional()

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,11 @@ overrides:
   # CORS wildcard-with-credentials reflection (4.12.25) plus five later
   # advisories, all patched by 4.12.34.
   hono: '>=4.12.34'
-  # Transitive via @modelcontextprotocol/sdk. Pinned alongside hono.
+  # Transitive via @modelcontextprotocol/sdk. Knowingly pinned BELOW the
+  # current path-traversal advisory (patched only in 2.0.5): forcing 2.x
+  # under an SDK that expects 1.x risks breaking its HTTP transports, and
+  # the vulnerable code is unreachable here — the MCP server is stdio-only
+  # and never loads the hono HTTP adapter (#311). Revisit on SDK bumps.
   '@hono/node-server': '>=1.19.13'
   # Transitive via @modelcontextprotocol/sdk -> ajv. Path traversal, two
   # host-confusion advisories (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6,


### PR DESCRIPTION
Remediates every finding from the round-2 audit (report included as `docs/audit-2026-08-07-round2.md`): an adversarial review of the round-1 fix batch, a deep dive into previously unaudited modules, and a security re-probe with active bypass testing. One commit per issue; merging closes #303 through #317.

## Highlights

**High severity — regression from round 1**
- #303 — `mergeStates` union resurrected open PRs that sync had just resolved; in local mode (the MCP server) `openPRs` could never shrink and every sync re-checked every resolved PR forever. Presence in `mergedPRs`/`closedPRs` is now authoritative removal — self-healing for already-corrupted states, and it also fixes the pre-existing gist-push variant.

**Medium**
- #305 — bare 403s (SAML orgs, fine-grained PATs) are treated as repo-scoped: the repo is skipped, the batch keeps its good results; only all-forbidden batches surface an auth error. 401 still aborts.
- #304 — gist-preference users without a token no longer crash on local-only commands; `buildCommandScout` degrades to local persistence with a warning.
- #308 — digest markdown escapes metacharacters and links titles to the real issue, killing the phishing-link/tracking-image vector in Action-posted digests.
- #307 — `scout features` now honors `excludeRepos`/`excludeOrgs`/`aiPolicyBlocklist` on both anchor and broad paths.
- #306 — command `Bash` scoping reverted (prefix rules never matched the env-prefixed/compound invocations, causing prompts on every step); the reduced tool surface and working agent scoping stand.

**Low**
- #309 quota-unknown wording instead of a fabricated number; #310 `redirect: "error"` on the triage POST; #311 honest `@hono/node-server` pin comment; #312 `splitRatio` clamp; #313 honest bootstrap counts; #314 setup input feedback; #315 roadmap code-fence skip; #316 anchored version gate; #317 MCP `maxResults` cap raised to 100.

## Verification

Full pipeline green locally: build, lint, format, typecheck, **1,184 tests** (up from 1,173 with new regression coverage), bundle, `pnpm audit --prod --audit-level=high`.

Merge note: a **merge commit** (not squash) preserves the per-issue conventional commits for release-please and the `Fixes #N` trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017G3d3BNmNYdH3RLYoAkMh7

---
_Generated by [Claude Code](https://claude.ai/code/session_017G3d3BNmNYdH3RLYoAkMh7)_