### PR TITLE
ci: pin actions to commit SHAs and add Dependabot to keep them fresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  # Actions are pinned to commit SHAs (a mutable tag like @v6 can be
+  # repointed at malicious code, and the publish workflow holds NPM_TOKEN).
+  # A pin without an updater silently rots, so Dependabot owns keeping them
+  # current — it rewrites the SHA and the trailing `# vN` comment together.
+  # `directory: /` covers .github/workflows plus the composite action.yml
+  # at the repo root.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # One PR for all action bumps rather than four; these move together
+      # and each needs the same CI run to validate.
+      actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
         node-version: [20, 22, 24]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -59,11 +59,11 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
       mcp-released: ${{ steps.release.outputs['packages/mcp-server--release_created'] }}
       mcp-tag: ${{ steps.release.outputs['packages/mcp-server--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
           config-file: release-please-config.json
@@ -35,15 +35,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout tagged release
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.release-please.outputs.core-tag }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
@@ -70,15 +70,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout tagged release
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.release-please.outputs.mcp-tag }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: "20"
 


### PR DESCRIPTION
Closes the last deferred item from the round-1 audit (#281 flagged tag-pinning but deferred the fix pending an updater to maintain the SHAs).

## What

- Pin all four actions to the commit SHA their current tag resolves to, with the version kept as a trailing `# vN` comment:
  - `actions/checkout@v6` → `d23441a`
  - `actions/setup-node@v6` → `2499707`
  - `pnpm/action-setup@v5` → `fc06bc1`
  - `googleapis/release-please-action@v4` → `5c625bf`
- Applied in `ci.yml`, `release-please.yml`, **and** `action.yml` — so consumers of the published composite action get the same guarantee.
- Add `.github/dependabot.yml` (github-actions ecosystem, weekly, grouped into one PR) so the pins don't silently rot. `directory: /` covers both `.github/workflows` and the root composite action.

## Why

A tag ref is mutable: `@v6` can be repointed at new code by anyone who controls the tag. These workflows include a publish job holding `NPM_TOKEN` with `contents: write`, which makes that the highest-value target in the repo. SHA pinning removes the mutable-reference risk; Dependabot keeps the pins from going stale, which is the tradeoff that made this worth deferring until both halves could land together.

## Verification

Every pinned SHA was round-trip verified against upstream (`git ls-remote refs/tags/<v>^{}` compared to the value written in the file). This matters for `release-please.yml` in particular: it only runs on push to main, so PR CI does not exercise it and a typo'd SHA would have surfaced as a silently broken publish. All four YAML files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017G3d3BNmNYdH3RLYoAkMh7

---
_Generated by [Claude Code](https://claude.ai/code/session_017G3d3BNmNYdH3RLYoAkMh7)_